### PR TITLE
fix(embed,modernbert): 入力ガードと設定バリデーションの追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/thkt/rurico"
 [features]
 default = ["mlx"]
 mlx = ["dep:mlx-rs"]
+test-mlx = []
 test-support = []
 
 [dependencies]

--- a/src/embed/pooling.rs
+++ b/src/embed/pooling.rs
@@ -49,6 +49,12 @@ pub fn postprocess_embedding(
             actual: 0,
         });
     }
+    if flat.len() % seq_len != 0 {
+        return Err(EmbedError::DimensionMismatch {
+            expected: EMBEDDING_DIMS as usize,
+            actual: flat.len(),
+        });
+    }
     let hidden_size = flat.len() / seq_len;
     if hidden_size != EMBEDDING_DIMS as usize {
         return Err(EmbedError::DimensionMismatch {

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -215,6 +215,19 @@ fn reorder_by_indices_round_trip() {
 }
 
 #[test]
+fn postprocess_embedding_rejects_indivisible_length() {
+    let hidden_size = EMBEDDING_DIMS as usize;
+    let seq_len = 2;
+    let data = vec![0.0f32; seq_len * hidden_size + 1];
+    let mask = vec![1u32; seq_len];
+    let err = postprocess_embedding(&data, seq_len, &mask).unwrap_err();
+    assert!(
+        matches!(err, EmbedError::DimensionMismatch { .. }),
+        "expected DimensionMismatch for indivisible length, got: {err}"
+    );
+}
+
+#[test]
 fn postprocess_embedding_happy_path() {
     let hidden_size = EMBEDDING_DIMS as usize;
     let seq_len = 2;

--- a/src/modernbert/config.rs
+++ b/src/modernbert/config.rs
@@ -8,7 +8,6 @@ pub struct Config {
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
     pub intermediate_size: usize,
-    #[allow(dead_code)]
     pub max_position_embeddings: usize,
     pub layer_norm_eps: f64,
     #[allow(dead_code)]
@@ -35,6 +34,9 @@ impl Config {
         }
         if self.vocab_size == 0 {
             return Err("vocab_size must be > 0".into());
+        }
+        if self.max_position_embeddings == 0 {
+            return Err("max_position_embeddings must be > 0".into());
         }
         Ok(())
     }
@@ -97,6 +99,17 @@ pub mod tests {
         let mut c = test_config();
         c.vocab_size = 0;
         assert!(c.validate().unwrap_err().contains("vocab_size"));
+    }
+
+    #[test]
+    fn config_validate_zero_max_position_embeddings() {
+        let mut c = test_config();
+        c.max_position_embeddings = 0;
+        assert!(
+            c.validate()
+                .unwrap_err()
+                .contains("max_position_embeddings")
+        );
     }
 
     #[test]

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -214,6 +214,7 @@ pub struct ModernBert {
     #[param]
     final_norm: nn::LayerNorm,
     local_attention_half: usize,
+    max_seq_len: usize,
     local_mask_cache: Option<(i32, Array)>,
 }
 
@@ -243,11 +244,19 @@ impl ModernBert {
             layers,
             final_norm,
             local_attention_half: config.local_attention / 2,
+            max_seq_len: config.max_position_embeddings,
             local_mask_cache: None,
         })
     }
 
     pub fn load(path: impl AsRef<Path>, config: &Config) -> Result<Self, Exception> {
+        let path = path.as_ref();
+        if !path.exists() {
+            return Err(Exception::custom(format!(
+                "model file not found: {}",
+                path.display()
+            )));
+        }
         let mut model = Self::new(config)?;
         model
             .load_safetensors(path)
@@ -262,6 +271,15 @@ impl ModernBert {
         batch_size: i32,
         seq_len: i32,
     ) -> Result<Array, Exception> {
+        if seq_len < 0 {
+            return Err(Exception::custom("seq_len must be non-negative"));
+        }
+        let max_seq = self.max_seq_len as i32;
+        if seq_len > max_seq {
+            return Err(Exception::custom(format!(
+                "seq_len ({seq_len}) exceeds maximum ({max_seq})"
+            )));
+        }
         let expected_len = batch_size
             .checked_mul(seq_len)
             .ok_or_else(|| Exception::custom("batch_size * seq_len overflows i32"))?
@@ -343,7 +361,17 @@ mod tests {
     use crate::modernbert::config::tests::test_config;
 
     #[cfg(feature = "mlx")]
-    mod mlx_tests {
+    #[test]
+    fn load_nonexistent_path_errors() {
+        let config = test_config();
+        let result = ModernBert::load("/nonexistent/model.safetensors", &config);
+        assert!(result.is_err());
+    }
+
+    /// MLX runtime tests — may abort due to foreign exceptions from mlx-rs FFI.
+    /// Run with `cargo test --features test-mlx`.
+    #[cfg(all(feature = "mlx", feature = "test-mlx"))]
+    mod mlx_runtime_tests {
         use serial_test::serial;
 
         use super::*;
@@ -459,14 +487,6 @@ mod tests {
                     }
                 }
             }
-        }
-
-        #[test]
-        #[serial]
-        fn load_nonexistent_path_errors() {
-            let config = test_config();
-            let result = ModernBert::load("/nonexistent/model.safetensors", &config);
-            assert!(result.is_err());
         }
     }
 }


### PR DESCRIPTION
## 概要

- `postprocess_embedding`: `flat.len()` が `seq_len` で割り切れない場合を reject（silent data corruption 防止）
- `ModernBert::load`: MLX 初期化前にファイル存在チェック（abort 防止）
- `ModernBert::forward`: `seq_len <= max_position_embeddings` を強制（二次メモリ OOM ガード）
- `Config::validate`: `max_position_embeddings > 0` を必須化
- MLX ランタイムテストを `test-mlx` feature flag で隔離（`cargo test` の abort 解消）

## 背景

embedding パイプラインと ModernBERT モデルのコード監査で検出された指摘への対応。
Finding 1（MLX foreign exception abort）はテスト隔離で軽減。根本原因は upstream の mlx-rs 側。

## テスト計画

- [x] `cargo test` 通過（71 passed, 0 failed）
- [x] `load_nonexistent_path_errors` が MLX 初期化なしで通常テストとして実行
- [x] `postprocess_embedding_rejects_indivisible_length` で新ガードをカバー
- [x] `config_validate_zero_max_position_embeddings` で新バリデーションをカバー
- [ ] `cargo test --features test-mlx` を専用 CI ジョブで実行