### PR TITLE
embed・storage の audit 指摘対応

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rurico"
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.91"
 description = "Shared embedding and storage utilities for semantic search CLIs"
 license = "MIT"
 repository = "https://github.com/thkt/rurico"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Apple Silicon (MLX) 上で日本語テキストのembeddingと類似検索を行
 ## 要件
 
 - macOS (Apple Silicon) — MLX backend必須
-- Rust 1.85+ (edition 2024)
+- Rust 1.91+ (edition 2024)
 
 ## 使い方
 


### PR DESCRIPTION
## 概要

- MLX 推論パスから `unpack_batch_output` を抽出し、flat output tensor サイズが `batch_size * max_seq_len` で割り切れない場合に `DimensionMismatch` を返す shape guard を追加（silent truncation 防止）
- `EmbedError::Config` variant を導入し、config 読み込み/パースエラーを推論エラーと区別可能にした
- CI actions バージョン更新（`actions/checkout` v6.0.2, `dtolnay/rust-toolchain` latest）、`Cargo.toml` に `rust-version` 追加、README で git 依存を tag 固定 + storage 初期化例を追加

## テスト計画

- [ ] `cargo test` — 新規 `unpack_batch_output_*` テスト3件 + 更新済み `read_config_*` / `probe_rejects_invalid_config` が全パス
- [ ] `cargo clippy -- -D warnings` — 警告なし
- [ ] CI が更新後の action versions で green