### PR TITLE
missing_docs lint を有効化し全公開APIを文書化

### DIFF
--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -18,29 +18,56 @@ pub(crate) use pooling::postprocess_embedding;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+/// Output vector dimensionality (768-d for ruri-v3-310m).
 pub const EMBEDDING_DIMS: u32 = 768;
+/// Prefix prepended to query text before tokenization.
 pub const QUERY_PREFIX: &str = "検索クエリ: ";
+/// Prefix prepended to document text before tokenization.
 pub const DOCUMENT_PREFIX: &str = "検索文書: ";
 
 const MODEL_REPO: &str = "cl-nagoya/ruri-v3-310m";
 const MODEL_REVISION: &str = "18b60fb8c2b9df296fb4212bb7d23ef94e579cd3";
 
+/// Errors from embedding operations.
 #[derive(Debug, thiserror::Error)]
 pub enum EmbedError {
+    /// Model weights file not found.
     #[error("model not found at {path}")]
-    ModelNotFound { path: PathBuf },
+    ModelNotFound {
+        /// Path that was looked up.
+        path: PathBuf,
+    },
+    /// Output tensor shape does not match expected dimensions.
     #[error("dimension mismatch: expected {expected}, got {actual}")]
-    DimensionMismatch { expected: usize, actual: usize },
+    DimensionMismatch {
+        /// Expected dimension count.
+        expected: usize,
+        /// Actual dimension count.
+        actual: usize,
+    },
+    /// Config file missing or unparseable.
     #[error("config error at {path}: {reason}")]
-    Config { path: PathBuf, reason: String },
+    Config {
+        /// Config file path.
+        path: PathBuf,
+        /// Parse or IO failure detail.
+        reason: String,
+    },
+    /// MLX inference failure.
     #[error("inference error: {0}")]
     Inference(String),
+    /// Tokenizer load or encode failure.
     #[error("tokenizer error: {0}")]
     Tokenizer(String),
+    /// Model download failure.
     #[error("download failed: {0}")]
     Download(String),
+    /// Weights loaded but model is corrupt or incompatible.
     #[error("model load failed: {reason}")]
-    ModelCorrupt { reason: String },
+    ModelCorrupt {
+        /// Failure detail from the backend.
+        reason: String,
+    },
 }
 
 impl EmbedError {
@@ -64,9 +91,12 @@ impl EmbedError {
     }
 }
 
+/// Result of [`Embedder::probe`] — whether the MLX backend can load the model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProbeStatus {
+    /// Model loaded successfully.
     Available,
+    /// MLX backend crashed or is unsupported on this hardware.
     BackendUnavailable,
 }
 
@@ -78,21 +108,29 @@ pub enum ProbeStatus {
 /// # Contract
 /// Implementations MUST return vectors of exactly [`EMBEDDING_DIMS`] elements.
 pub trait Embed: Send + Sync {
+    /// Embed a search query (prepends [`QUERY_PREFIX`]).
     fn embed_query(&self, text: &str) -> Result<Vec<f32>, EmbedError>;
+    /// Embed a document for indexing (prepends [`DOCUMENT_PREFIX`]).
     fn embed_document(&self, text: &str) -> Result<Vec<f32>, EmbedError>;
+    /// Batch-embed documents. Default calls [`embed_document`](Self::embed_document) per item.
     fn embed_documents_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
         texts.iter().map(|t| self.embed_document(t)).collect()
     }
 }
 
+/// Paths to the three model artifacts (weights, config, tokenizer).
 #[derive(Debug, Clone)]
 pub struct ModelPaths {
+    /// SafeTensors weights file.
     pub model: PathBuf,
+    /// `config.json` (ModernBERT hyperparameters).
     pub config: PathBuf,
+    /// `tokenizer.json` (HuggingFace tokenizer).
     pub tokenizer: PathBuf,
 }
 
 impl ModelPaths {
+    /// Build paths assuming standard filenames under `dir`.
     #[cfg(any(test, feature = "test-support"))]
     pub fn from_dir(dir: &std::path::Path) -> Self {
         Self {
@@ -102,6 +140,7 @@ impl ModelPaths {
         }
     }
 
+    /// Check that all three files exist, returning [`EmbedError::ModelNotFound`] on the first miss.
     pub fn validate(&self) -> Result<(), EmbedError> {
         for path in [&self.model, &self.config, &self.tokenizer] {
             if !path.exists() {
@@ -168,6 +207,9 @@ fn model_paths_from_cache(cache: &hf_hub::Cache) -> Result<Option<ModelPaths>, E
     }))
 }
 
+/// Deserialize a JSON config file into `T`.
+///
+/// Returns [`EmbedError::Config`] on IO failure or JSON parse error.
 pub fn read_config<T: serde::de::DeserializeOwned>(
     path: &std::path::Path,
 ) -> Result<T, EmbedError> {
@@ -175,16 +217,22 @@ pub fn read_config<T: serde::de::DeserializeOwned>(
     serde_json::from_str(&text).map_err(|e| EmbedError::config(path, format!("parse error: {e}")))
 }
 
+/// Load a HuggingFace tokenizer from a JSON file.
 pub fn load_tokenizer(path: &std::path::Path) -> Result<tokenizers::Tokenizer, EmbedError> {
     tokenizers::Tokenizer::from_file(path).map_err(EmbedError::tokenizer)
 }
 
+/// Output of [`tokenize_with_prefix`]: token IDs, attention mask, and sequence length.
 pub struct TokenizedInput {
+    /// Token IDs produced by the tokenizer.
     pub input_ids: Vec<u32>,
+    /// 1 for real tokens, 0 for padding.
     pub attention_mask: Vec<u32>,
+    /// Number of tokens (including special tokens).
     pub seq_len: usize,
 }
 
+/// Tokenize `text` with a prefix prepended (e.g. query/document prefix).
 pub fn tokenize_with_prefix(
     tokenizer: &tokenizers::Tokenizer,
     text: &str,
@@ -204,7 +252,9 @@ pub fn tokenize_with_prefix(
     })
 }
 
-/// Shorter texts first reduces wasted padding in batched tokenization.
+/// Return indices into `texts` sorted by ascending byte length.
+///
+/// Shorter-first ordering minimizes padding waste in batched tokenization.
 pub(crate) fn sort_indices_by_len(texts: &[&str]) -> Vec<usize> {
     let mut indices: Vec<usize> = (0..texts.len()).collect();
     indices.sort_unstable_by_key(|&i| texts[i].len());
@@ -237,8 +287,9 @@ fn probe_env_to_paths(
 
 /// Call at the start of `main()` in binaries that use [`Embedder::probe`].
 ///
-/// When the process was re-invoked as a probe subprocess, this function loads
-/// the model, reports the result, and exits. Otherwise it returns immediately.
+/// When the process was re-invoked as a probe subprocess, this function writes
+/// a handshake token to stdout, attempts to load the model, and exits with
+/// code 0 (success) or non-zero (failure). Otherwise it returns immediately.
 pub fn handle_probe_if_needed() {
     let Some(result) = probe_env_to_paths(
         std::env::var(PROBE_ENV_MODEL).ok(),
@@ -269,9 +320,9 @@ pub fn handle_probe_if_needed() {
 /// Uses `Command` (fork+exec internally) so the child gets a clean process
 /// state, avoiding the async-signal-safety issues of bare fork().
 ///
-/// - Exit 0 → model loads successfully
-/// - Exit non-zero → model load failed (reason captured from stderr)
-/// - Killed by signal → MLX framework crashed (e.g. SIGABRT)
+/// - Exit 0 → [`ProbeStatus::Available`]
+/// - Exit non-zero → [`EmbedError::ModelCorrupt`] (reason from stderr)
+/// - Killed by signal / no exit code → [`ProbeStatus::BackendUnavailable`]
 fn probe_via_subprocess(paths: &ModelPaths) -> Result<ProbeStatus, EmbedError> {
     let exe = std::env::current_exe()
         .map_err(|e| EmbedError::inference(format!("cannot locate executable: {e}")))?;
@@ -354,6 +405,7 @@ fn probe_via_fork(paths: &ModelPaths) -> Result<ProbeStatus, EmbedError> {
     }
 }
 
+/// Thread-safe embedding model backed by MLX. Wraps the backend in a [`Mutex`].
 pub struct Embedder {
     inner: Mutex<EmbedderInner>,
 }
@@ -365,6 +417,7 @@ impl std::fmt::Debug for Embedder {
 }
 
 impl Embedder {
+    /// Load model weights, config, and tokenizer from `paths`.
     pub fn new(paths: &ModelPaths) -> Result<Self, EmbedError> {
         let inner = EmbedderInner::new(paths)?;
         Ok(Self {

--- a/src/embed/test_support.rs
+++ b/src/embed/test_support.rs
@@ -8,6 +8,7 @@ fn one_hot(index: usize) -> Vec<f32> {
     v
 }
 
+/// Returns deterministic one-hot vectors for all inputs.
 pub struct MockEmbedder;
 
 impl Embed for MockEmbedder {
@@ -24,12 +25,14 @@ impl Embed for MockEmbedder {
     }
 }
 
+/// Embedder that returns errors (configurable per method).
 pub struct FailingEmbedder {
     message: &'static str,
     docs_fail: bool,
 }
 
 impl FailingEmbedder {
+    /// Both `embed_query` and `embed_document` return errors.
     pub fn all_fail(message: &'static str) -> Self {
         Self {
             message,
@@ -37,6 +40,7 @@ impl FailingEmbedder {
         }
     }
 
+    /// Only `embed_query` returns errors; documents succeed.
     pub fn query_only(message: &'static str) -> Self {
         Self {
             message,
@@ -59,6 +63,7 @@ impl Embed for FailingEmbedder {
     }
 }
 
+/// Batch returns fewer vectors than inputs (triggers mismatch errors).
 pub struct MismatchEmbedder;
 
 impl Embed for MismatchEmbedder {
@@ -75,11 +80,13 @@ impl Embed for MismatchEmbedder {
     }
 }
 
+/// Alternates between success and failure on `embed_document`.
 pub struct AlternatingEmbedder {
     call_count: AtomicU32,
 }
 
 impl AlternatingEmbedder {
+    /// Create with call counter at zero (first `embed_document` fails).
     pub fn new() -> Self {
         Self {
             call_count: AtomicU32::new(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
+//! Local semantic search over text — embedding, indexing, and retrieval.
+#![warn(missing_docs)]
+
+/// Embedding models and the [`Embed`](embed::Embed) trait.
 pub mod embed;
+/// ModernBERT transformer implementation on MLX.
 pub mod modernbert;
+/// SQLite-backed vector + FTS5 hybrid storage.
 pub mod storage;
+/// Text chunking utilities.
 pub mod text;

--- a/src/modernbert/config.rs
+++ b/src/modernbert/config.rs
@@ -3,22 +3,35 @@ use serde::Deserialize;
 /// ModernBERT config (config.json).
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
+    /// Vocabulary size (number of token embeddings).
     pub vocab_size: usize,
+    /// Hidden dimension of each transformer layer.
     pub hidden_size: usize,
+    /// Number of transformer layers.
     pub num_hidden_layers: usize,
+    /// Number of attention heads per layer.
     pub num_attention_heads: usize,
+    /// FFN intermediate dimension (before GLU split).
     pub intermediate_size: usize,
+    /// Maximum input sequence length.
     pub max_position_embeddings: usize,
+    /// Epsilon for layer normalization.
     pub layer_norm_eps: f64,
+    /// Padding token ID.
     #[allow(dead_code)]
     pub pad_token_id: u32,
+    /// Apply global (full-sequence) attention every N layers.
     pub global_attn_every_n_layers: usize,
+    /// RoPE theta for global attention layers.
     pub global_rope_theta: f64,
+    /// Sliding window size for local attention layers.
     pub local_attention: usize,
+    /// RoPE theta for local attention layers.
     pub local_rope_theta: f64,
 }
 
 impl Config {
+    /// Validate invariants (non-zero sizes, divisibility).
     pub fn validate(&self) -> Result<(), String> {
         if self.num_attention_heads == 0 {
             return Err("num_attention_heads must be > 0".into());

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -205,10 +205,14 @@ pub struct ModernBert {
     final_norm: nn::LayerNorm,
     local_attention_half: usize,
     max_seq_len: usize,
+    /// Single-entry cache keyed on `seq_len`. Rebuilds when `seq_len` changes.
     local_mask_cache: Option<(i32, Array)>,
 }
 
 impl ModernBert {
+    /// Construct a model with randomly initialized weights from `config`.
+    ///
+    /// Use [`ModernBert::load`] to load pre-trained weights from a SafeTensors file.
     pub fn new(config: &Config) -> Result<Self, Exception> {
         config
             .validate()
@@ -238,6 +242,7 @@ impl ModernBert {
         })
     }
 
+    /// Load a pre-trained model from a SafeTensors file.
     pub fn load(path: impl AsRef<Path>, config: &Config) -> Result<Self, Exception> {
         let path = path.as_ref();
         if !path.exists() {
@@ -253,6 +258,7 @@ impl ModernBert {
         Ok(model)
     }
 
+    /// Run a forward pass, returning final hidden states `[batch_size, seq_len, hidden_size]`.
     pub fn forward(
         &mut self,
         input_ids: &[u32],

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,11 +10,15 @@ use sqlite_vec::sqlite3_vec_init;
 #[cfg(not(target_endian = "little"))]
 compile_error!("rurico requires a little-endian target for f32↔u8 embedding storage");
 
+/// Reinterpret `&[f32]` as `&[u8]` (zero-copy, little-endian).
 pub fn f32_as_bytes(slice: &[f32]) -> &[u8] {
     bytemuck::cast_slice(slice)
 }
 
-/// Register sqlite-vec as an auto-extension.
+/// Register sqlite-vec as a process-global auto-extension.
+///
+/// Idempotent — subsequent calls are no-ops. All SQLite connections opened
+/// after this call will have the vec extension available.
 pub fn ensure_sqlite_vec() -> Result<(), String> {
     static INIT: std::sync::OnceLock<Result<(), i32>> = std::sync::OnceLock::new();
     let init_result = INIT.get_or_init(|| {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -78,31 +78,28 @@ impl SanitizedFtsQuery {
 pub struct MatchFtsQuery(String);
 
 impl MatchFtsQuery {
+    /// Borrow the inner query string.
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+
+    /// Consume and return the inner `String`.
+    pub fn into_string(self) -> String {
+        self.0
     }
 }
 
 /// Reasons why [`prepare_match_query`] cannot produce a usable query.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SanitizeError {
     /// The input string was empty or contained only whitespace.
+    #[error("search query is empty")]
     EmptyInput,
     /// The input contained tokens, but none survived sanitization
     /// (e.g. only `NEAR()` groups or prefix characters).
+    #[error("search query contains no searchable terms")]
     NoSearchableTerms,
 }
-
-impl std::fmt::Display for SanitizeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyInput => f.write_str("search query is empty"),
-            Self::NoSearchableTerms => f.write_str("search query contains no searchable terms"),
-        }
-    }
-}
-
-impl std::error::Error for SanitizeError {}
 
 /// Neutralize FTS5 special syntax in user queries: `NEAR()` grouping,
 /// start-of-column `^`, required `+` / excluded `-` prefixes, column-filter
@@ -161,7 +158,7 @@ pub fn rrf_merge<K: Clone + Eq + Hash + Ord>(
     results
 }
 
-/// Quote a term for FTS5 MATCH syntax.
+/// Wrap `s` in double quotes for FTS5 MATCH syntax, escaping internal `"` as `""`.
 pub fn fts_quote(s: &str) -> String {
     format!("\"{}\"", s.replace('"', "\"\""))
 }


### PR DESCRIPTION
Closes #11

## 概要

- `lib.rs` に `#![warn(missing_docs)]` を追加し、60件の既存警告をモジュール分割せず一括で解消
- `embed`, `modernbert`, `storage` の全公開アイテムに doc comment を追加。probe プロトコル・冪等性・`DimensionMismatch` 条件など正確性を重視した behavior-first 記述
- `SanitizeError` を `thiserror` derive に移行し、`MatchFtsQuery::into_string()` を追加（crate 内の一貫性）

## テスト計画

- [ ] `cargo build` が `missing_docs` 警告なしで通る
- [ ] `cargo test` がリグレッションなしで通る
- [ ] `cargo doc` が全公開アイテムのドキュメントを生成し、壊れた intra-doc link がない