### PR TITLE
TOKEN_BUDGET sub-batch分割によるMetal OOM防止

### DIFF
--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -88,34 +88,44 @@ impl EmbedderInner {
             max_content_tokens,
         )?;
 
-        let (input_ids, attention_mask, batch_size, max_len) =
-            crate::model_io::pad_sequences(&all_chunk_tokens, None);
+        // Split into sub-batches bounded by TOKEN_BUDGET total positions to avoid
+        // Metal OOM when long sequences produce large padded tensors.
+        // TOKEN_BUDGET = 256K positions ≈ 128 chunks × 2048 tokens, which matches
+        // the empirically confirmed safe range for ruri-v3-310m on Apple Silicon.
+        const TOKEN_BUDGET: usize = 256_000;
+        let max_len_overall = all_chunk_tokens.iter().map(|c| c.len()).max().unwrap_or(1);
+        let sub_batch_size = (TOKEN_BUDGET / max_len_overall).max(1);
 
-        let output = self
-            .model
-            .forward(
-                &input_ids,
-                &attention_mask,
-                batch_size as i32,
-                max_len as i32,
-            )
-            .map_err(EmbedError::inference)?;
+        let mut all_embeddings = Vec::with_capacity(all_chunk_tokens.len());
+        for sub_batch in all_chunk_tokens.chunks(sub_batch_size) {
+            let (input_ids, attention_mask, batch_size, max_len) =
+                crate::model_io::pad_sequences(sub_batch, None);
 
-        let result = (|| {
-            output.eval().map_err(EmbedError::inference)?;
-            let flat: &[f32] = output.as_slice();
-            unpack_batch_output(flat, batch_size, max_len, &attention_mask)
-        })();
-        crate::mlx_cache::release_inference_output(output);
-        let all_embeddings = result?;
+            let output = self
+                .model
+                .forward(
+                    &input_ids,
+                    &attention_mask,
+                    batch_size as i32,
+                    max_len as i32,
+                )
+                .map_err(EmbedError::inference)?;
+
+            let sub_result = (|| {
+                output.eval().map_err(EmbedError::inference)?;
+                let flat: &[f32] = output.as_slice();
+                unpack_batch_output(flat, batch_size, max_len, &attention_mask)
+            })();
+            crate::mlx_cache::release_inference_output(output);
+            all_embeddings.extend(sub_result?);
+        }
 
         // Regroup by document, preserving input order
         let mut results = Vec::with_capacity(texts.len());
-        let mut offset = 0;
+        let mut iter = all_embeddings.into_iter();
         for &count in &chunks_per_doc {
-            let chunks = all_embeddings[offset..offset + count].to_vec();
+            let chunks: Vec<_> = iter.by_ref().take(count).collect();
             results.push(ChunkedEmbedding { chunks });
-            offset += count;
         }
 
         Ok(results)

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -1,10 +1,11 @@
 //! Process-global MLX cache lock shared by embed and reranker modules.
 //!
-//! `mlx_clear_cache()` is a global FFI call that is not thread-safe.
-//! Both embed and reranker call it after inference to free GPU memory.
-//! A single `Mutex` ensures these calls are serialized.
+//! `mlx_clear_cache()` and `mlx_detail_compile_clear_cache()` are global FFI
+//! calls that are not thread-safe. Both embed and reranker call them after
+//! inference to free GPU memory. A single `Mutex` ensures these calls are
+//! serialized.
 
-/// Process-global lock for [`mlx_sys::mlx_clear_cache`] calls.
+/// Process-global lock for [`mlx_sys::mlx_clear_cache`] and [`mlx_sys::mlx_detail_compile_clear_cache`] calls.
 ///
 /// Recover from poison: cache-clear is stateless (guards `()`), safe to
 /// proceed after a panic in another thread.
@@ -13,7 +14,12 @@ pub(crate) static MLX_CACHE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new((
 /// Consume an MLX output array and attempt to clear the GPU cache.
 ///
 /// Takes `output` by value to enforce drop-before-clear ordering at compile
-/// time. Cache-clear failure is non-fatal: logged as a warning.
+/// time. Cache-clear failures are non-fatal: logged as warnings.
+///
+/// Clears both the buffer pool (`mlx_clear_cache`) and the compiled Metal
+/// kernel cache (`mlx_detail_compile_clear_cache`). The compile cache grows
+/// with each unique `(batch_size, seq_len)` pair; clearing it after every
+/// batch prevents Metal OOM across long embedding runs.
 ///
 /// # Safety (caller invariants)
 /// 1. `output` is taken by value — no borrows remain after this call.
@@ -29,6 +35,10 @@ pub(crate) fn release_inference_output(output: mlx_rs::Array) {
     let code = unsafe { mlx_sys::mlx_clear_cache() };
     if code != 0 {
         log::warn!("mlx_clear_cache failed (code: {code})");
+    }
+    let code = unsafe { mlx_sys::mlx_detail_compile_clear_cache() };
+    if code != 0 {
+        log::warn!("mlx_detail_compile_clear_cache failed (code: {code})");
     }
 }
 


### PR DESCRIPTION
## 問題

大量の長文ドキュメントを一括エンベディングする際、`embed_texts`は全チャンクを1つのテンソルにパディングしてからMLXモデルに転送していた。Apple Siliconでは、大きな`(batch_size × seq_len)`テンソルがMetalバッファプールとコンパイル済みカーネルキャッシュを枯渇させ、実行中にOOMが発生する。

成長の原因は2つ:

1. パディング済み入出力テンソルがバッチ内の総トークン数に比例して増大
2. 各`(batch_size, seq_len)`ペアが固有のコンパイル済みMetalカーネルを生成し、長時間実行でキャッシュが無制限に成長

## 変更内容

**`src/embed/mlx.rs`**
- `sub_batch_size = TOKEN_BUDGET / max_chunk_len`（TOKEN_BUDGET = 256,000 positions）でsub-batch分割
- `all_chunk_tokens.chunks(sub_batch_size)`でループし、sub-batchごとにpad → forward → evaluate → unpackを実行、`extend`で結果を蓄積
- ドキュメント単位の再グループ化を`offset`ポインタから`iter.by_ref().take(count)`に変更

**`src/mlx_cache.rs`**
- `release_inference_output`内で`mlx_clear_cache()`直後に`mlx_detail_compile_clear_cache()`を呼び出し
- モジュールdocと関数docを更新し、両キャッシュタイプとcompile cacheクリアの必要性を記載

## 備考

- 公開API・出力値の変更なし
- TOKEN_BUDGET未満のバッチは単一のforward passで処理（既存性能への影響なし）
- TOKEN_BUDGETは名前付き定数として定義、チューニング容易
