### PR TITLE
SIGINT中断時のhf-hubダウンロード安全性をドキュメント化

### DIFF
--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -114,6 +114,16 @@ fn model_repo_for<Id: ModelArtifact>(model: Id) -> hf_hub::Repo {
 ///
 /// Returns [`ModelIoError::Download`] if the Hugging Face client cannot be
 /// initialized or any required artifact download fails.
+///
+/// # Interruption Safety
+///
+/// hf-hub downloads each file to a `.part` temporary file and then atomically
+/// renames it to the final blob path (`std::fs::rename`). A signal (e.g. SIGINT)
+/// received during a download leaves only the `.part` file on disk; the final
+/// blob is never partially written.
+///
+/// On the next invocation, [`artifacts_if_cached`] finds no valid pointer and
+/// returns `None`, so the download retries cleanly — no manual cache cleanup needed.
 pub fn download_artifacts<Id: ModelArtifact>(model: Id) -> Result<ModelPaths, ModelIoError> {
     let api = hf_hub::api::sync::Api::new()
         .map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;


### PR DESCRIPTION
## 調査結果

hf-hub 0.5.0 のソースを調査した結果、ダウンロードは `.part` 一時ファイルへの書き込み後に `std::fs::rename` でアトミックに確定する実装になっていることを確認した（POSIX上でアトミック）。

- 中断時はキャッシュに `.part` ファイルのみ残り、不完全なblobは書き込まれない
- 次回起動時に `artifacts_if_cached` が `None` を返し、ダウンロードが再試行される
- コードの修正は不要

## 変更内容

`download_artifacts` 関数に `# Interruption Safety` セクションを追記し、上記の安全性を文書化した。

## 関連

yomu#92 の companion change。