### PR TITLE
unsafe FFI を rurico-ffi に分離して clippy lint を強制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,34 @@ jobs:
 
       - name: Format check
         run: cargo fmt -- --check
+
+  security:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: false
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Deny check
+        run: cargo deny check
+
+      - name: Audit
+        run: cargo audit

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-/target
-.claude/
 .yomu/
-adr/
+.claude/
 docs/
+target/
 workspace/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,15 +1826,23 @@ dependencies = [
  "hf-hub",
  "log",
  "mlx-rs",
- "mlx-sys",
+ "rurico-ffi",
  "rusqlite",
  "serde",
  "serde_json",
  "serial_test",
- "sqlite-vec",
  "tempfile",
  "thiserror",
  "tokenizers",
+]
+
+[[package]]
+name = "rurico-ffi"
+version = "0.1.0"
+dependencies = [
+ "mlx-sys",
+ "rusqlite",
+ "sqlite-vec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = [".", "crates/rurico-ffi"]
+
 [package]
 name = "rurico"
 version = "0.2.0"
@@ -6,6 +9,7 @@ rust-version = "1.94"
 description = "Shared embedding, reranking, and storage utilities for semantic search CLIs"
 license = "MIT"
 repository = "https://github.com/thkt/rurico"
+publish = false
 exclude = [".claude/", ".yomu/", "workspace/"]
 
 [features]
@@ -17,17 +21,37 @@ bytemuck = "1"
 hf-hub = "0.5"
 log = "0.4"
 mlx-rs = "0.25"
-mlx-sys = "0.2"
 rusqlite = { version = "0.39", features = ["bundled"] }
+rurico-ffi = { path = "crates/rurico-ffi" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlite-vec = "0.1.6"
 thiserror = "2"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
 
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[lints.clippy]
+# フルパス使用検出
+absolute_paths = "deny"
+# Rustイディオム (RUST.md idioms table)
+cast_possible_truncation = "deny"
+redundant_closure_for_method_calls = "deny"
+filter_map_next = "deny"
+flat_map_option = "deny"
+manual_filter_map = "deny"
+manual_find_map = "deny"
+# インポート
+wildcard_imports = "deny"
+enum_glob_use = "deny"
+# 文字列
+str_to_string = "deny"
+# 引数
+needless_pass_by_value = "deny"
 
 [profile.release]
 opt-level = 3

--- a/adr/0001-typed-fts-query-contract.md
+++ b/adr/0001-typed-fts-query-contract.md
@@ -1,0 +1,113 @@
+# ADR 0001: Adopt a Typed FTS Query Contract in `rurico`
+
+- Status: Proposed
+- Date: 2026-03-28
+- Confidence: high - The current API contract is ambiguous, and the migration path across downstream crates is clear.
+
+## Context
+
+`rurico::storage::sanitize_fts_query` currently returns a plain `String`. That leaves three contract gaps:
+
+1. Callers cannot tell whether the returned string is always safe to pass to FTS5 `MATCH`.
+2. Empty or fully stripped queries can still surface as runtime FTS syntax errors in downstream crates.
+3. `fts_expand_short_terms` still accepts raw `&str`, so sanitization is not enforced by the type system.
+
+Recent review found concrete failure modes:
+
+- operator-like terms such as `NOT` may be interpreted inconsistently across callers
+- malformed `NEAR(...)` input can collapse to an unusable query
+- different downstream crates (`recall`, `sae`, `yomu`) handle the edge cases inconsistently
+
+## Decision
+
+Adopt a typed FTS query contract in `rurico` and make `rurico` responsible for producing only validated query values for FTS5 `MATCH`.
+
+The storage API will move toward these types:
+
+- `SanitizedFtsQuery`
+- `MatchFtsQuery`
+- `SanitizeError`
+
+The first step is:
+
+1. Change `sanitize_fts_query` from `String` to `Result<SanitizedFtsQuery, SanitizeError>`.
+2. Define `SanitizeError` with two variants:
+   `EmptyInput`
+   `NoSearchableTerms`
+3. Preserve operator-like keywords (`AND`, `OR`, `NOT`) as literal terms during sanitization.
+4. Change `fts_expand_short_terms` to accept `&SanitizedFtsQuery` instead of raw `&str`.
+5. Return a typed value for final `MATCH` usage, either via `MatchFtsQuery` or a helper such as `build_match_fts_query`.
+
+The intended responsibility split is:
+
+- `rurico`: sanitize and build safe FTS query values
+- downstream crates: decide whether to skip search, return empty results, or show a user-facing message
+
+## Options Considered
+
+### Option A: Keep `String` and document caller-side empty checks
+
+Pros:
+
+- no breaking API change
+- smallest local diff
+
+Cons:
+
+- keeps the contract ambiguous
+- repeats empty checks in every downstream crate
+- still allows raw unsafe strings to reach `MATCH`
+
+### Option B: Return `Option<String>`
+
+Pros:
+
+- prevents `MATCH ''`
+- smaller API change than a richer error model
+
+Cons:
+
+- loses why sanitization failed
+- does not distinguish empty input from no searchable terms
+- still leaves the final query as an untyped `String`
+
+### Option C: Return `Result<SanitizedFtsQuery, SanitizeError>` and type the pipeline
+
+Pros:
+
+- makes the contract explicit
+- gives downstream crates enough signal to handle failures consistently
+- allows `fts_expand_short_terms` and later helpers to require typed inputs
+
+Cons:
+
+- breaking API change
+- requires coordinated updates in downstream crates
+
+## Consequences
+
+Positive:
+
+- `rurico` becomes the single source of truth for FTS query safety
+- downstream crates stop relying on duplicated local sanitizers
+- runtime FTS syntax errors from empty or stripped queries are reduced
+- literal `AND` / `OR` / `NOT` remain searchable across downstream crates
+
+Negative:
+
+- `recall`, `sae`, and `yomu` must be updated in lockstep
+- this introduces a short migration window across dependent crates
+
+## Migration Plan
+
+1. Update `rurico` storage API and tests.
+2. Migrate `recall` from local sanitization to `rurico`.
+3. Migrate `sae` from local sanitization to `rurico`.
+4. Add sanitization to `yomu` before short-term expansion.
+5. Run `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` in all affected crates.
+
+## Reassessment Triggers
+
+- A downstream crate needs more detailed failure causes than `EmptyInput` and `NoSearchableTerms`
+- FTS query construction grows beyond sanitize plus expansion into a true parser/validator
+- another storage backend with different query semantics is added

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| ID | Title | Status | Date |
+| --- | --- | --- | --- |
+| [0001](./0001-typed-fts-query-contract.md) | Adopt a Typed FTS Query Contract in `rurico` | Proposed | 2026-03-28 |

--- a/crates/rurico-ffi/Cargo.toml
+++ b/crates/rurico-ffi/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rurico-ffi"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94"
+description = "Safe FFI wrappers for rurico (mlx-sys, sqlite-vec)"
+license = "MIT"
+publish = false
+
+[lints.rust]
+unsafe_code = "deny"
+
+[dependencies]
+mlx-sys = "0.2"
+rusqlite = { version = "0.39", features = ["bundled"] }
+sqlite-vec = "0.1.6"

--- a/crates/rurico-ffi/src/lib.rs
+++ b/crates/rurico-ffi/src/lib.rs
@@ -1,0 +1,10 @@
+//! Safe FFI wrappers for rurico.
+//!
+//! This crate isolates all `unsafe` code behind safe public functions.
+//! `rurico` itself is `#![forbid(unsafe_code)]`; all FFI boundaries live here.
+
+mod mlx;
+mod storage;
+
+pub use mlx::{mlx_clear_cache, mlx_compile_clear_cache};
+pub use storage::sqlite_vec_register;

--- a/crates/rurico-ffi/src/mlx.rs
+++ b/crates/rurico-ffi/src/mlx.rs
@@ -1,0 +1,30 @@
+//! Safe wrappers for `mlx_sys` FFI functions.
+
+/// Clear the MLX buffer pool.
+///
+/// Returns the MLX return code (0 = success).
+///
+/// # Caller contract
+/// - No MLX arrays are borrowed by the caller after this returns.
+/// - Model weights remain live on the caller side.
+/// - Serialization across threads is the caller's responsibility
+///   (see `rurico::mlx_cache::MLX_CACHE_LOCK`).
+#[allow(unsafe_code)]
+pub fn mlx_clear_cache() -> i32 {
+    // SAFETY: mlx_clear_cache is a stateless global cache flush.
+    // The caller must ensure no MLX arrays are borrowed at this point
+    // and that concurrent calls are serialized via MLX_CACHE_LOCK.
+    unsafe { mlx_sys::mlx_clear_cache() }
+}
+
+/// Clear the MLX compiled Metal kernel cache.
+///
+/// Returns the MLX return code (0 = success).
+///
+/// # Caller contract
+/// Same as [`mlx_clear_cache`].
+#[allow(unsafe_code)]
+pub fn mlx_compile_clear_cache() -> i32 {
+    // SAFETY: same invariants as mlx_clear_cache.
+    unsafe { mlx_sys::mlx_detail_compile_clear_cache() }
+}

--- a/crates/rurico-ffi/src/storage.rs
+++ b/crates/rurico-ffi/src/storage.rs
@@ -1,0 +1,29 @@
+//! Safe wrapper for sqlite-vec FFI registration.
+
+use rusqlite::ffi::sqlite3_auto_extension;
+use sqlite_vec::sqlite3_vec_init;
+
+/// Register sqlite-vec as a process-global SQLite auto-extension.
+///
+/// Returns the SQLite return code (0 = success).
+///
+/// Idempotent — `sqlite3_auto_extension` deduplicates registrations by
+/// function pointer, so repeated calls are safe.
+#[allow(unsafe_code)]
+pub fn sqlite_vec_register() -> i32 {
+    // SAFETY: sqlite3_vec_init is the auto-extension entry point exported by
+    // sqlite-vec. sqlite-vec exports it as `unsafe extern "C" fn()`, while
+    // rusqlite's sqlite3_auto_extension expects the full init signature. Both
+    // are C fn pointers with compatible calling conventions; SQLite calls the
+    // function with the correct arguments at connection open time.
+    unsafe {
+        sqlite3_auto_extension(Some(std::mem::transmute::<
+            unsafe extern "C" fn(),
+            unsafe extern "C" fn(
+                *mut rusqlite::ffi::sqlite3,
+                *mut *mut std::os::raw::c_char,
+                *const rusqlite::ffi::sqlite3_api_routines,
+            ) -> std::os::raw::c_int,
+        >(sqlite3_vec_init)))
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,30 @@
+[advisories]
+version = 2
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "0BSD",
+    "Zlib",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+    "BSL-1.0",
+    "MPL-2.0",
+    "Unlicense",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,10 @@
 [advisories]
 version = 2
-ignore = []
+ignore = [
+    # paste is archived (no safe upgrade); used transitively by tokenizers and mlx-rs.
+    # Suppress until upstream crates migrate away from it.
+    "RUSTSEC-2024-0436",
+]
 
 [licenses]
 version = 2

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -7,8 +7,14 @@
 //! - [`embed::Artifacts`](crate::embed::Artifacts) = `VerifiedArtifacts<EmbedKind>`
 //! - [`reranker::Artifacts`](crate::reranker::Artifacts) = `VerifiedArtifacts<RerankerKind>`
 
-use std::io::Read;
+use std::fmt;
+use std::fs::{self, File};
+use std::io::{self, Read};
+use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
+
+use crate::model_io::{ModelIoError, ModelPaths, load_tokenizer, read_config};
+use crate::modernbert::Config;
 
 // ── Kind markers ────────────────────────────────────────────────────────────
 
@@ -33,14 +39,14 @@ pub struct RerankerKind(());
 /// - `tokenizer.json` loads without error.
 /// - The safetensors weights contain the expected keys for model kind `K`.
 pub struct VerifiedArtifacts<K> {
-    pub(crate) paths: crate::model_io::ModelPaths,
-    pub(crate) config: crate::modernbert::Config,
+    pub(crate) paths: ModelPaths,
+    pub(crate) config: Config,
     pub(crate) tokenizer: tokenizers::Tokenizer,
-    _kind: std::marker::PhantomData<K>,
+    _kind: PhantomData<K>,
 }
 
-impl<K> std::fmt::Debug for VerifiedArtifacts<K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<K> fmt::Debug for VerifiedArtifacts<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VerifiedArtifacts")
             .field("paths", &self.paths)
             .finish_non_exhaustive()
@@ -48,16 +54,12 @@ impl<K> std::fmt::Debug for VerifiedArtifacts<K> {
 }
 
 impl<K> VerifiedArtifacts<K> {
-    fn new(
-        paths: crate::model_io::ModelPaths,
-        config: crate::modernbert::Config,
-        tokenizer: tokenizers::Tokenizer,
-    ) -> Self {
+    fn new(paths: ModelPaths, config: Config, tokenizer: tokenizers::Tokenizer) -> Self {
         Self {
             paths,
             config,
             tokenizer,
-            _kind: std::marker::PhantomData,
+            _kind: PhantomData,
         }
     }
 
@@ -72,10 +74,10 @@ impl<K> VerifiedArtifacts<K> {
     ///
     /// Returns the first [`std::io::Error`] encountered. Remaining files are
     /// still attempted even if an earlier deletion fails.
-    pub fn delete_files(self) -> Result<(), std::io::Error> {
-        let mut first_err: Option<std::io::Error> = None;
+    pub fn delete_files(self) -> Result<(), io::Error> {
+        let mut first_err: Option<io::Error> = None;
         for path in [&self.paths.model, &self.paths.config, &self.paths.tokenizer] {
-            if let Err(e) = std::fs::remove_file(path)
+            if let Err(e) = fs::remove_file(path)
                 && first_err.is_none()
             {
                 first_err = Some(e);
@@ -127,14 +129,12 @@ pub enum ArtifactError {
 
 // ── Conversion helpers ───────────────────────────────────────────────────────
 
-impl From<crate::model_io::ModelIoError> for ArtifactError {
-    fn from(e: crate::model_io::ModelIoError) -> Self {
+impl From<ModelIoError> for ArtifactError {
+    fn from(e: ModelIoError) -> Self {
         match e {
-            crate::model_io::ModelIoError::Config { path, reason } => {
-                ArtifactError::InvalidConfig { path, reason }
-            }
-            crate::model_io::ModelIoError::Tokenizer(msg) => ArtifactError::InvalidTokenizer(msg),
-            crate::model_io::ModelIoError::Download(msg) => ArtifactError::DownloadFailed(msg),
+            ModelIoError::Config { path, reason } => ArtifactError::InvalidConfig { path, reason },
+            ModelIoError::Tokenizer(msg) => ArtifactError::InvalidTokenizer(msg),
+            ModelIoError::Download(msg) => ArtifactError::DownloadFailed(msg),
         }
     }
 }
@@ -146,7 +146,7 @@ impl From<crate::model_io::ModelIoError> for ArtifactError {
 /// Runs all verification steps in order: file existence → config parse →
 /// tokenizer load → embed kind check (classifier/head keys must be absent).
 pub(crate) fn verify_as_embed(
-    paths: crate::model_io::ModelPaths,
+    paths: ModelPaths,
 ) -> Result<VerifiedArtifacts<EmbedKind>, ArtifactError> {
     verify_files_exist(&paths)?;
     let config = verify_config(&paths)?;
@@ -160,7 +160,7 @@ pub(crate) fn verify_as_embed(
 /// Runs all verification steps in order: file existence → config parse →
 /// tokenizer load → reranker kind check (classifier/head keys must be present).
 pub(crate) fn verify_as_reranker(
-    paths: crate::model_io::ModelPaths,
+    paths: ModelPaths,
 ) -> Result<VerifiedArtifacts<RerankerKind>, ArtifactError> {
     verify_files_exist(&paths)?;
     let config = verify_config(&paths)?;
@@ -171,7 +171,7 @@ pub(crate) fn verify_as_reranker(
 
 // ── Verification steps ───────────────────────────────────────────────────────
 
-fn verify_files_exist(paths: &crate::model_io::ModelPaths) -> Result<(), ArtifactError> {
+fn verify_files_exist(paths: &ModelPaths) -> Result<(), ArtifactError> {
     for path in [&paths.model, &paths.config, &paths.tokenizer] {
         if !path.exists() {
             return Err(ArtifactError::MissingFile { path: path.clone() });
@@ -180,10 +180,8 @@ fn verify_files_exist(paths: &crate::model_io::ModelPaths) -> Result<(), Artifac
     Ok(())
 }
 
-fn verify_config(
-    paths: &crate::model_io::ModelPaths,
-) -> Result<crate::modernbert::Config, ArtifactError> {
-    let config = crate::model_io::read_config::<crate::modernbert::Config>(&paths.config)?;
+fn verify_config(paths: &ModelPaths) -> Result<Config, ArtifactError> {
+    let config = read_config::<Config>(&paths.config)?;
     config
         .validate()
         .map_err(|reason| ArtifactError::InvalidConfig {
@@ -193,10 +191,8 @@ fn verify_config(
     Ok(config)
 }
 
-fn verify_tokenizer(
-    paths: &crate::model_io::ModelPaths,
-) -> Result<tokenizers::Tokenizer, ArtifactError> {
-    Ok(crate::model_io::load_tokenizer(&paths.tokenizer)?)
+fn verify_tokenizer(paths: &ModelPaths) -> Result<tokenizers::Tokenizer, ArtifactError> {
+    Ok(load_tokenizer(&paths.tokenizer)?)
 }
 
 // ── Kind check (safetensors header inspection) ───────────────────────────────
@@ -211,11 +207,11 @@ const MODERNBERT_KEY_PREFIXES: &[&str] = &["layers."];
 /// Tensor key prefixes that are present in reranker models and absent in embed models.
 const RERANKER_KEY_PREFIXES: &[&str] = &["classifier.", "head.dense.", "head.norm."];
 
-fn verify_embed_kind(paths: &crate::model_io::ModelPaths) -> Result<(), ArtifactError> {
+fn verify_embed_kind(paths: &ModelPaths) -> Result<(), ArtifactError> {
     verify_model_kind(paths, "embed model", false)
 }
 
-fn verify_reranker_kind(paths: &crate::model_io::ModelPaths) -> Result<(), ArtifactError> {
+fn verify_reranker_kind(paths: &ModelPaths) -> Result<(), ArtifactError> {
     verify_model_kind(paths, "reranker model", true)
 }
 
@@ -225,7 +221,7 @@ fn verify_reranker_kind(paths: &crate::model_io::ModelPaths) -> Result<(), Artif
 /// When `require_reranker_keys` is `true`, classifier/head keys must also be present.
 /// When `false`, they must be absent.
 fn verify_model_kind(
-    paths: &crate::model_io::ModelPaths,
+    paths: &ModelPaths,
     expected: &'static str,
     require_reranker_keys: bool,
 ) -> Result<(), ArtifactError> {
@@ -276,7 +272,7 @@ fn verify_model_kind(
 /// header JSON length, followed by the JSON object mapping tensor names to
 /// metadata. Only the header is read; weight data is not accessed.
 fn scan_safetensors_keys(path: &Path, mut f: impl FnMut(&str)) -> Result<(), ArtifactError> {
-    let mut file = std::fs::File::open(path).map_err(|e| ArtifactError::WrongModelKind {
+    let mut file = File::open(path).map_err(|e| ArtifactError::WrongModelKind {
         expected: "valid safetensors file",
         keys_hint: format!("cannot open model file: {e}"),
     })?;
@@ -287,16 +283,17 @@ fn scan_safetensors_keys(path: &Path, mut f: impl FnMut(&str)) -> Result<(), Art
             expected: "valid safetensors file",
             keys_hint: format!("cannot read header length: {e}"),
         })?;
-    let header_len = u64::from_le_bytes(len_bytes) as usize;
+    let raw_len = u64::from_le_bytes(len_bytes);
 
     // Guard against corrupt files reporting implausible header sizes.
-    const MAX_HEADER_BYTES: usize = 100 * 1024 * 1024; // 100 MiB
-    if header_len > MAX_HEADER_BYTES {
+    const MAX_HEADER_BYTES: u64 = 100 * 1024 * 1024; // 100 MiB
+    if raw_len > MAX_HEADER_BYTES {
         return Err(ArtifactError::WrongModelKind {
             expected: "valid safetensors file",
-            keys_hint: format!("header length {header_len} exceeds 100 MiB limit"),
+            keys_hint: format!("header length {raw_len} exceeds 100 MiB limit"),
         });
     }
+    let header_len = usize::try_from(raw_len).expect("bounded by MAX_HEADER_BYTES");
 
     let mut header_json = vec![0u8; header_len];
     file.read_exact(&mut header_json)
@@ -338,14 +335,14 @@ mod tests {
 
     /// Write a minimal but structurally valid safetensors file containing the given
     /// tensor keys. Each tensor has one `f32` element of weight data.
-    fn write_fake_safetensors(path: &std::path::Path, tensor_keys: &[&str]) {
+    fn write_fake_safetensors(path: &Path, tensor_keys: &[&str]) {
         let mut header_obj = serde_json::Map::new();
-        header_obj.insert("__metadata__".to_string(), serde_json::json!({}));
+        header_obj.insert("__metadata__".to_owned(), serde_json::json!({}));
         let mut offset = 0usize;
         for &key in tensor_keys {
             let end = offset + 4; // 4 bytes per f32
             header_obj.insert(
-                key.to_string(),
+                key.to_owned(),
                 serde_json::json!({
                     "dtype": "F32",
                     "shape": [1],
@@ -363,7 +360,7 @@ mod tests {
         for _ in tensor_keys {
             data.extend_from_slice(&0f32.to_le_bytes());
         }
-        std::fs::write(path, data).unwrap();
+        fs::write(path, data).unwrap();
     }
 
     #[test]
@@ -372,9 +369,9 @@ mod tests {
         let path = dir.path().join("m.safetensors");
         write_fake_safetensors(&path, &["foo.weight", "bar.bias"]);
         let keys = read_safetensors_keys(&path).unwrap();
-        assert!(keys.contains(&"foo.weight".to_string()));
-        assert!(keys.contains(&"bar.bias".to_string()));
-        assert!(!keys.contains(&"__metadata__".to_string()));
+        assert!(keys.contains(&"foo.weight".to_owned()));
+        assert!(keys.contains(&"bar.bias".to_owned()));
+        assert!(!keys.contains(&"__metadata__".to_owned()));
     }
 
     #[test]
@@ -382,7 +379,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.safetensors");
         // 4 bytes — not enough for the 8-byte header length field
-        std::fs::write(&path, b"fake").unwrap();
+        fs::write(&path, b"fake").unwrap();
         let err = read_safetensors_keys(&path).unwrap_err();
         assert!(matches!(err, ArtifactError::WrongModelKind { .. }), "{err}");
     }
@@ -390,9 +387,9 @@ mod tests {
     #[test]
     fn verify_as_embed_returns_missing_file_for_absent_model() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
-        std::fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path()); // model.safetensors does not exist
+        fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
+        let paths = ModelPaths::from_dir(dir.path()); // model.safetensors does not exist
         let err = verify_as_embed(paths).unwrap_err();
         assert!(
             matches!(err, ArtifactError::MissingFile { ref path } if path.ends_with("model.safetensors")),
@@ -404,10 +401,10 @@ mod tests {
     fn verify_as_embed_returns_invalid_config_for_malformed_config() {
         let dir = tempfile::tempdir().unwrap();
         // model exists (content irrelevant — config check runs first)
-        std::fs::write(dir.path().join("model.safetensors"), b"placeholder").unwrap();
-        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
-        std::fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        fs::write(dir.path().join("model.safetensors"), b"placeholder").unwrap();
+        fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
+        let paths = ModelPaths::from_dir(dir.path());
         let err = verify_as_embed(paths).unwrap_err();
         assert!(matches!(err, ArtifactError::InvalidConfig { .. }), "{err}");
     }
@@ -415,9 +412,9 @@ mod tests {
     #[test]
     fn verify_as_embed_returns_invalid_config_for_zero_hidden_size() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("model.safetensors"), b"placeholder").unwrap();
+        fs::write(dir.path().join("model.safetensors"), b"placeholder").unwrap();
         // Parseable JSON but fails Config::validate() due to hidden_size == 0
-        std::fs::write(
+        fs::write(
             dir.path().join("config.json"),
             br#"{"vocab_size":1000,"hidden_size":0,"num_hidden_layers":2,
                 "num_attention_heads":12,"intermediate_size":3072,
@@ -427,8 +424,8 @@ mod tests {
                 "local_rope_theta":10000.0}"#,
         )
         .unwrap();
-        std::fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
+        let paths = ModelPaths::from_dir(dir.path());
         let err = verify_as_embed(paths).unwrap_err();
         assert!(
             matches!(err, ArtifactError::InvalidConfig { ref reason, .. } if reason.contains("hidden_size")),
@@ -443,7 +440,7 @@ mod tests {
             &dir.path().join("model.safetensors"),
             &["classifier.weight", "head.dense.weight", "head.norm.weight"],
         );
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         let err = verify_embed_kind(&paths).unwrap_err();
         assert!(
             matches!(
@@ -462,7 +459,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // embed-only keys — no classifier/head
         write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         let err = verify_reranker_kind(&paths).unwrap_err();
         assert!(
             matches!(
@@ -480,7 +477,7 @@ mod tests {
     fn verify_embed_kind_accepts_model_without_reranker_keys() {
         let dir = tempfile::tempdir().unwrap();
         write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(verify_embed_kind(&paths).is_ok());
     }
 
@@ -496,7 +493,7 @@ mod tests {
                 "head.norm.weight",
             ],
         );
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(verify_reranker_kind(&paths).is_ok());
     }
 
@@ -504,7 +501,7 @@ mod tests {
 
     #[test]
     fn from_model_io_error_maps_config_variant() {
-        let err = ArtifactError::from(crate::model_io::ModelIoError::Config {
+        let err = ArtifactError::from(ModelIoError::Config {
             path: "/p".into(),
             reason: "bad".into(),
         });
@@ -516,7 +513,7 @@ mod tests {
 
     #[test]
     fn from_model_io_error_maps_tokenizer_variant() {
-        let err = ArtifactError::from(crate::model_io::ModelIoError::Tokenizer("tok err".into()));
+        let err = ArtifactError::from(ModelIoError::Tokenizer("tok err".into()));
         assert!(
             matches!(err, ArtifactError::InvalidTokenizer(ref m) if m == "tok err"),
             "{err}"
@@ -525,7 +522,7 @@ mod tests {
 
     #[test]
     fn from_model_io_error_maps_download_variant() {
-        let err = ArtifactError::from(crate::model_io::ModelIoError::Download("dl err".into()));
+        let err = ArtifactError::from(ModelIoError::Download("dl err".into()));
         assert!(
             matches!(err, ArtifactError::DownloadFailed(ref m) if m == "dl err"),
             "{err}"
@@ -541,7 +538,7 @@ mod tests {
         let len: u64 = 200 * 1024 * 1024; // 200 MiB — exceeds 100 MiB limit
         let mut data = Vec::new();
         data.extend_from_slice(&len.to_le_bytes());
-        std::fs::write(&path, data).unwrap();
+        fs::write(&path, data).unwrap();
         let err = read_safetensors_keys(&path).unwrap_err();
         assert!(
             matches!(err, ArtifactError::WrongModelKind { ref keys_hint, .. } if keys_hint.contains("100 MiB")),
@@ -558,7 +555,7 @@ mod tests {
         let mut data = Vec::new();
         data.extend_from_slice(&len.to_le_bytes());
         data.extend_from_slice(header);
-        std::fs::write(&path, data).unwrap();
+        fs::write(&path, data).unwrap();
         let err = read_safetensors_keys(&path).unwrap_err();
         assert!(
             matches!(err, ArtifactError::WrongModelKind { ref keys_hint, .. } if keys_hint.contains("JSON parse error")),
@@ -583,12 +580,12 @@ mod tests {
 
     use crate::test_support::VALID_CONFIG_JSON;
 
-    fn write_valid_config(dir: &std::path::Path) {
-        std::fs::write(dir.join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();
+    fn write_valid_config(dir: &Path) {
+        fs::write(dir.join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();
     }
 
-    fn write_valid_tokenizer(dir: &std::path::Path) {
-        std::fs::write(
+    fn write_valid_tokenizer(dir: &Path) {
+        fs::write(
             dir.join("tokenizer.json"),
             MINIMAL_TOKENIZER_JSON.as_bytes(),
         )
@@ -601,7 +598,7 @@ mod tests {
         write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(
             verify_as_embed(paths).is_ok(),
             "verify_as_embed should succeed"
@@ -615,7 +612,7 @@ mod tests {
         write_fake_safetensors(&dir.path().join("model.safetensors"), &["foo.weight"]);
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(
             verify_as_embed(paths).is_err(),
             "verify_as_embed should reject unrelated safetensors"
@@ -637,7 +634,7 @@ mod tests {
         );
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(
             verify_as_reranker(paths).is_ok(),
             "verify_as_reranker should succeed"
@@ -654,7 +651,7 @@ mod tests {
         );
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         assert!(
             verify_as_reranker(paths).is_err(),
             "verify_as_reranker should reject safetensors without backbone keys"
@@ -669,7 +666,7 @@ mod tests {
         write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         let artifacts = verify_as_embed(paths).unwrap();
 
         artifacts.delete_files().unwrap();
@@ -685,11 +682,11 @@ mod tests {
         write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
         write_valid_config(dir.path());
         write_valid_tokenizer(dir.path());
-        let paths = crate::model_io::ModelPaths::from_dir(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
         let artifacts = verify_as_embed(paths).unwrap();
 
         // Pre-remove model so delete_files hits a missing-file error
-        std::fs::remove_file(dir.path().join("model.safetensors")).unwrap();
+        fs::remove_file(dir.path().join("model.safetensors")).unwrap();
 
         assert!(artifacts.delete_files().is_err());
     }

--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -7,10 +7,11 @@
 //! must be downloaded before running smoke tests.
 
 use rurico::embed::{self, Embed};
+use rurico::model_probe;
 
 fn main() {
     // Also acts as a probe subprocess when probe env vars are set.
-    rurico::model_probe::handle_probe_if_needed();
+    model_probe::handle_probe_if_needed();
 
     let artifacts = embed::cached_artifacts(embed::ModelId::default())
         .expect("cache lookup failed")

--- a/src/bin/probe_embed_smoke.rs
+++ b/src/bin/probe_embed_smoke.rs
@@ -8,19 +8,21 @@
 //! `Embedder::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
+use rurico::embed::{Embedder, ModelId, ProbeStatus, cached_artifacts};
+use rurico::model_probe;
+
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
-    rurico::model_probe::handle_probe_if_needed();
+    model_probe::handle_probe_if_needed();
 
-    let artifacts = rurico::embed::cached_artifacts(rurico::embed::ModelId::default())
+    let artifacts = cached_artifacts(ModelId::default())
         .expect("embed cache lookup failed")
         .expect("embed model not cached — download ruri-v3-310m before running");
 
-    let status = rurico::embed::Embedder::probe(&artifacts)
-        .expect("embed probe subprocess should not error");
+    let status = Embedder::probe(&artifacts).expect("embed probe subprocess should not error");
     assert_eq!(
         status,
-        rurico::embed::ProbeStatus::Available,
+        ProbeStatus::Available,
         "embed model should be available"
     );
     eprintln!("probe_embed_smoke: embed OK");

--- a/src/bin/probe_reranker_smoke.rs
+++ b/src/bin/probe_reranker_smoke.rs
@@ -8,20 +8,21 @@
 //! `Reranker::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
+use rurico::model_probe;
+use rurico::reranker::{ProbeStatus, Reranker, RerankerModelId, cached_artifacts};
+
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
-    rurico::model_probe::handle_probe_if_needed();
+    model_probe::handle_probe_if_needed();
 
-    let artifacts =
-        rurico::reranker::cached_artifacts(rurico::reranker::RerankerModelId::default())
-            .expect("reranker cache lookup failed")
-            .expect("reranker model not cached — download ruri-v3-reranker-310m before running");
+    let artifacts = cached_artifacts(RerankerModelId::default())
+        .expect("reranker cache lookup failed")
+        .expect("reranker model not cached — download ruri-v3-reranker-310m before running");
 
-    let status = rurico::reranker::Reranker::probe(&artifacts)
-        .expect("reranker probe subprocess should not error");
+    let status = Reranker::probe(&artifacts).expect("reranker probe subprocess should not error");
     assert_eq!(
         status,
-        rurico::reranker::ProbeStatus::Available,
+        ProbeStatus::Available,
         "reranker model should be available"
     );
     eprintln!("probe_reranker_smoke: reranker OK");

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -21,6 +21,14 @@ pub use embedder::Embedder;
 pub(crate) use pooling::postprocess_embedding;
 pub(crate) use probe::probe_env_to_paths;
 
+use crate::artifacts::verify_as_embed;
+use crate::model_io::{
+    ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts, truncate_with_eos,
+};
+use crate::model_probe::ProbeError;
+use std::fmt;
+#[cfg(any(test, feature = "test-support"))]
+use std::path::Path;
 use std::path::PathBuf;
 
 // ── Domain alias ─────────────────────────────────────────────────────────────
@@ -41,7 +49,7 @@ pub type Artifacts = VerifiedArtifacts<EmbedKind>;
 /// in test contexts), then call [`verify`](Self::verify) to obtain
 /// [`Artifacts`] that can be passed to [`Embedder::new`].
 pub struct CandidateArtifacts {
-    paths: crate::model_io::ModelPaths,
+    paths: ModelPaths,
 }
 
 impl CandidateArtifacts {
@@ -51,7 +59,7 @@ impl CandidateArtifacts {
     /// Call [`verify`](Self::verify) before passing the result to [`Embedder::new`].
     pub fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
         Self {
-            paths: crate::model_io::ModelPaths {
+            paths: ModelPaths {
                 model,
                 config,
                 tokenizer,
@@ -64,9 +72,9 @@ impl CandidateArtifacts {
     ///
     /// Available for development and test use only.
     #[cfg(any(test, feature = "test-support"))]
-    pub fn from_dir(dir: &std::path::Path) -> Self {
+    pub fn from_dir(dir: &Path) -> Self {
         Self {
-            paths: crate::model_io::ModelPaths::from_dir(dir),
+            paths: ModelPaths::from_dir(dir),
         }
     }
 
@@ -80,7 +88,7 @@ impl CandidateArtifacts {
     /// - `tokenizer.json` cannot be loaded ([`ArtifactError::InvalidTokenizer`])
     /// - Weights are for a reranker, not an embed model ([`ArtifactError::WrongModelKind`])
     pub fn verify(self) -> Result<Artifacts, ArtifactError> {
-        crate::artifacts::verify_as_embed(self.paths)
+        verify_as_embed(self.paths)
     }
 }
 
@@ -155,7 +163,7 @@ pub(crate) fn truncate_for_query(
     max_len: usize,
 ) -> (Vec<u32>, Vec<u32>, usize) {
     let orig_len = input_ids.len();
-    if crate::model_io::truncate_with_eos(&mut input_ids, &mut attention_mask, max_len) {
+    if truncate_with_eos(&mut input_ids, &mut attention_mask, max_len) {
         log::warn!("query exceeds max_seq_len ({orig_len} > {max_len}), truncating");
     }
     let len = input_ids.len();
@@ -203,7 +211,7 @@ impl ModelId {
     }
 }
 
-impl crate::model_io::ModelArtifact for ModelId {
+impl ModelArtifact for ModelId {
     fn repo_id(self) -> &'static str {
         ModelId::repo_id(self)
     }
@@ -233,21 +241,17 @@ pub enum EmbedInitError {
 }
 
 impl EmbedInitError {
-    pub(crate) fn backend(e: impl std::fmt::Display) -> Self {
+    pub(crate) fn backend(e: impl fmt::Display) -> Self {
         Self::Backend(e.to_string())
     }
 }
 
-impl From<crate::model_probe::ProbeError> for EmbedInitError {
-    fn from(e: crate::model_probe::ProbeError) -> Self {
+impl From<ProbeError> for EmbedInitError {
+    fn from(e: ProbeError) -> Self {
         match e {
-            crate::model_probe::ProbeError::HandlerNotInstalled => {
-                EmbedInitError::Backend(e.to_string())
-            }
-            crate::model_probe::ProbeError::ModelLoadFailed { reason } => {
-                EmbedInitError::ModelCorrupt { reason }
-            }
-            crate::model_probe::ProbeError::SubprocessFailed(msg) => EmbedInitError::Backend(msg),
+            ProbeError::HandlerNotInstalled => EmbedInitError::Backend(e.to_string()),
+            ProbeError::ModelLoadFailed { reason } => EmbedInitError::ModelCorrupt { reason },
+            ProbeError::SubprocessFailed(msg) => EmbedInitError::Backend(msg),
         }
     }
 }
@@ -283,11 +287,11 @@ pub enum EmbedError {
 }
 
 impl EmbedError {
-    pub(crate) fn inference(e: impl std::fmt::Display) -> Self {
+    pub(crate) fn inference(e: impl fmt::Display) -> Self {
         Self::Inference(e.to_string())
     }
 
-    pub(crate) fn tokenizer(e: impl std::fmt::Display) -> Self {
+    pub(crate) fn tokenizer(e: impl fmt::Display) -> Self {
         Self::Tokenizer(e.to_string())
     }
 }
@@ -361,8 +365,8 @@ pub trait Embed: Send + Sync {
 /// Returns other [`ArtifactError`] variants if verification of the downloaded
 /// files fails.
 pub fn download_model(model: ModelId) -> Result<Artifacts, ArtifactError> {
-    let paths = crate::model_io::download_artifacts(model)?;
-    crate::artifacts::verify_as_embed(paths)
+    let paths = download_artifacts(model)?;
+    verify_as_embed(paths)
 }
 
 /// Check whether embed model files exist in the local HF Hub cache and verify them.
@@ -375,10 +379,10 @@ pub fn download_model(model: ModelId) -> Result<Artifacts, ArtifactError> {
 /// Returns [`ArtifactError`] if cached files fail verification.
 /// Cache misses are reported as `Ok(None)`.
 pub fn cached_artifacts(model: ModelId) -> Result<Option<Artifacts>, ArtifactError> {
-    let Some(paths) = crate::model_io::artifacts_if_cached(model)? else {
+    let Some(paths) = artifacts_if_cached(model)? else {
         return Ok(None);
     };
-    crate::artifacts::verify_as_embed(paths).map(Some)
+    verify_as_embed(paths).map(Some)
 }
 
 // ── TokenizedInput ────────────────────────────────────────────────────────────

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -1,4 +1,5 @@
-use std::sync::Mutex;
+use std::fmt::{self, Debug, Formatter};
+use std::sync::{Mutex, MutexGuard};
 
 use super::mlx::EmbedderInner;
 use super::{
@@ -11,8 +12,8 @@ pub struct Embedder {
     embedding_dims: usize,
 }
 
-impl std::fmt::Debug for Embedder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for Embedder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Embedder").finish_non_exhaustive()
     }
 }
@@ -66,7 +67,7 @@ impl Embedder {
         super::probe::probe_via_subprocess(artifacts)
     }
 
-    fn lock_inner(&self) -> Result<std::sync::MutexGuard<'_, EmbedderInner>, EmbedError> {
+    fn lock_inner(&self) -> Result<MutexGuard<'_, EmbedderInner>, EmbedError> {
         self.inner
             .lock()
             .map_err(|_| EmbedError::inference("embedder lock poisoned"))

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -4,9 +4,12 @@ use super::{
     MAX_SEQ_LEN, extract_prefix_tokens, max_content, postprocess_embedding, tokenize_with_prefix,
     truncate_for_query,
 };
+use crate::mlx_cache::release_inference_output;
+use crate::model_io::pad_sequences;
+use crate::modernbert::ModernBert;
 
 pub(super) struct EmbedderInner {
-    model: crate::modernbert::ModernBert,
+    model: ModernBert,
     tokenizer: tokenizers::Tokenizer,
     doc_prefix_tokens: Vec<u32>,
     embedding_dims: usize,
@@ -17,8 +20,8 @@ impl EmbedderInner {
         let config = &artifacts.config;
         let tokenizer = artifacts.tokenizer.clone();
 
-        let model = crate::modernbert::ModernBert::load(&artifacts.paths.model, config)
-            .map_err(EmbedInitError::backend)?;
+        let model =
+            ModernBert::load(&artifacts.paths.model, config).map_err(EmbedInitError::backend)?;
 
         let doc_prefix_tokens =
             extract_prefix_tokens(&tokenizer, DOCUMENT_PREFIX).map_err(EmbedInitError::backend)?;
@@ -45,9 +48,10 @@ impl EmbedderInner {
         let (input_ids, attention_mask, seq_len) =
             truncate_for_query(tok.input_ids, tok.attention_mask, MAX_SEQ_LEN);
 
+        let seq_len_i32 = i32::try_from(seq_len).expect("seq_len fits in i32");
         let output = self
             .model
-            .forward(&input_ids, &attention_mask, 1, seq_len as i32)
+            .forward(&input_ids, &attention_mask, 1, seq_len_i32)
             .map_err(EmbedError::inference)?;
 
         let result = (|| {
@@ -55,7 +59,7 @@ impl EmbedderInner {
             let flat: &[f32] = output.as_slice();
             postprocess_embedding(flat, seq_len, &attention_mask)
         })();
-        crate::mlx_cache::release_inference_output(output);
+        release_inference_output(output);
         result
     }
 
@@ -93,22 +97,18 @@ impl EmbedderInner {
         // TOKEN_BUDGET = 256K positions ≈ 128 chunks × 2048 tokens, which matches
         // the empirically confirmed safe range for ruri-v3-310m on Apple Silicon.
         const TOKEN_BUDGET: usize = 256_000;
-        let max_len_overall = all_chunk_tokens.iter().map(|c| c.len()).max().unwrap_or(1);
+        let max_len_overall = all_chunk_tokens.iter().map(Vec::len).max().unwrap_or(1);
         let sub_batch_size = (TOKEN_BUDGET / max_len_overall).max(1);
 
         let mut all_embeddings = Vec::with_capacity(all_chunk_tokens.len());
         for sub_batch in all_chunk_tokens.chunks(sub_batch_size) {
-            let (input_ids, attention_mask, batch_size, max_len) =
-                crate::model_io::pad_sequences(sub_batch, None);
+            let (input_ids, attention_mask, batch_size, max_len) = pad_sequences(sub_batch, None);
 
+            let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
+            let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");
             let output = self
                 .model
-                .forward(
-                    &input_ids,
-                    &attention_mask,
-                    batch_size as i32,
-                    max_len as i32,
-                )
+                .forward(&input_ids, &attention_mask, batch_size_i32, max_len_i32)
                 .map_err(EmbedError::inference)?;
 
             let sub_result = (|| {
@@ -116,7 +116,7 @@ impl EmbedderInner {
                 let flat: &[f32] = output.as_slice();
                 unpack_batch_output(flat, batch_size, max_len, &attention_mask)
             })();
-            crate::mlx_cache::release_inference_output(output);
+            release_inference_output(output);
             all_embeddings.extend(sub_result?);
         }
 
@@ -270,16 +270,19 @@ pub(super) fn unpack_batch_output(
 /// Tests without spec references omit the prefix.
 #[cfg(test)]
 mod tests {
+    use std::panic::catch_unwind;
+    use std::sync::{Mutex, PoisonError};
+
     #[test]
     fn poison_recovery_pattern_works() {
-        let lock = std::sync::Mutex::new(());
-        let _ = std::panic::catch_unwind(|| {
+        let lock = Mutex::new(());
+        let _ = catch_unwind(|| {
             let _guard = lock.lock().unwrap();
             panic!("intentional panic to poison lock");
         });
         assert!(lock.is_poisoned());
         // Same pattern as mlx_cache::release_inference_output — unwrap_or_else recovers the guard
-        let guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
         drop(guard);
     }
 }

--- a/src/embed/probe.rs
+++ b/src/embed/probe.rs
@@ -1,6 +1,7 @@
 use super::{Artifacts, CandidateArtifacts, EmbedInitError};
 use crate::model_probe::{
-    self, EMBED_PROBE_ENV_CONFIG, EMBED_PROBE_ENV_MODEL, EMBED_PROBE_ENV_TOKENIZER,
+    self, EMBED_PROBE_ENV_CONFIG, EMBED_PROBE_ENV_MODEL, EMBED_PROBE_ENV_TOKENIZER, ProbeStatus,
+    resolve_probe_env,
 };
 
 /// Resolve probe env vars into a [`CandidateArtifacts`].
@@ -13,14 +14,12 @@ pub(crate) fn probe_env_to_paths(
     config: Option<String>,
     tokenizer: Option<String>,
 ) -> Option<Result<CandidateArtifacts, i32>> {
-    crate::model_probe::resolve_probe_env(model, config, tokenizer)
+    resolve_probe_env(model, config, tokenizer)
         .map(|r| r.map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t)))
 }
 
 /// Re-exec the current binary as a probe subprocess for the embedding model.
-pub(super) fn probe_via_subprocess(
-    artifacts: &Artifacts,
-) -> Result<crate::model_probe::ProbeStatus, EmbedInitError> {
+pub(super) fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, EmbedInitError> {
     let paths = &artifacts.paths;
     model_probe::probe_paths_via_subprocess(
         paths,

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -2,7 +2,9 @@ use super::mlx::{shrink_chunk_to_fit, unpack_batch_output};
 use super::pooling::{l2_normalize, mean_pooling};
 use super::probe::probe_env_to_paths;
 use super::*;
-use crate::model_io::{EOS_TOKEN_ID, load_tokenizer};
+use crate::model_io::{EOS_TOKEN_ID, artifacts_from_cache, load_tokenizer};
+use crate::test_support::setup_fake_hf_cache;
+use std::fs;
 
 #[test]
 fn mean_pooling_excludes_masked_tokens() {
@@ -91,7 +93,7 @@ fn postprocess_embedding_accepts_any_dims() {
 #[test]
 fn validate_partial_download_reports_missing_file() {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
+    fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
     let candidate = CandidateArtifacts::from_dir(dir.path());
     let err = candidate.verify().unwrap_err();
     let ArtifactError::MissingFile { path } = &err else {
@@ -200,8 +202,8 @@ fn unpack_batch_output_rejects_nan_embedding() {
     );
 }
 
-fn setup_fake_cache_for(hub_dir: &std::path::Path, model: ModelId) {
-    crate::test_support::setup_fake_hf_cache(
+fn setup_fake_cache_for(hub_dir: &Path, model: ModelId) {
+    setup_fake_hf_cache(
         hub_dir,
         model.repo_id(),
         model.revision(),
@@ -217,7 +219,7 @@ fn setup_fake_cache_for(hub_dir: &std::path::Path, model: ModelId) {
 fn cache_lookup_returns_none_when_empty() {
     let dir = tempfile::tempdir().unwrap();
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = crate::model_io::artifacts_from_cache(&cache, ModelId::default()).unwrap();
+    let result = artifacts_from_cache(&cache, ModelId::default()).unwrap();
     assert!(result.is_none());
 }
 
@@ -226,7 +228,7 @@ fn cache_lookup_returns_some_when_all_files_present() {
     let dir = tempfile::tempdir().unwrap();
     setup_fake_cache_for(dir.path(), ModelId::default());
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = crate::model_io::artifacts_from_cache(&cache, ModelId::default()).unwrap();
+    let result = artifacts_from_cache(&cache, ModelId::default()).unwrap();
     let paths = result.expect("should return Some when all files cached");
     assert!(paths.model.ends_with("model.safetensors"));
     assert!(paths.config.ends_with("config.json"));
@@ -241,11 +243,11 @@ fn cache_lookup_returns_none_when_partial() {
     let snapshot_dir = dir
         .path()
         .join(format!("models--{repo_slug}/snapshots/abc123"));
-    std::fs::remove_file(snapshot_dir.join("config.json")).unwrap();
-    std::fs::remove_file(snapshot_dir.join("tokenizer.json")).unwrap();
+    fs::remove_file(snapshot_dir.join("config.json")).unwrap();
+    fs::remove_file(snapshot_dir.join("tokenizer.json")).unwrap();
 
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = crate::model_io::artifacts_from_cache(&cache, ModelId::default()).unwrap();
+    let result = artifacts_from_cache(&cache, ModelId::default()).unwrap();
     assert!(result.is_none());
 }
 
@@ -265,9 +267,7 @@ fn cache_lookup_each_model_has_separate_cache_dir() {
 
         // The populated model should be found
         assert!(
-            crate::model_io::artifacts_from_cache(&cache, target)
-                .unwrap()
-                .is_some(),
+            artifacts_from_cache(&cache, target).unwrap().is_some(),
             "{:?} should be cached",
             target
         );
@@ -277,9 +277,7 @@ fn cache_lookup_each_model_has_separate_cache_dir() {
                 continue;
             }
             assert!(
-                crate::model_io::artifacts_from_cache(&cache, other)
-                    .unwrap()
-                    .is_none(),
+                artifacts_from_cache(&cache, other).unwrap().is_none(),
                 "{:?} should not be cached when only {:?} is populated",
                 other,
                 target
@@ -291,9 +289,9 @@ fn cache_lookup_each_model_has_separate_cache_dir() {
 #[test]
 fn candidate_verify_returns_invalid_config_for_malformed_config() {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
-    std::fs::write(dir.path().join("config.json"), b"not json").unwrap();
-    std::fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
+    fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
+    fs::write(dir.path().join("config.json"), b"not json").unwrap();
+    fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
     let candidate = CandidateArtifacts::from_dir(dir.path());
     let err = candidate.verify().unwrap_err();
     assert!(
@@ -390,7 +388,7 @@ fn shrink_chunk_to_fit_rejects_empty_range() {
     // end <= start → Inference error without calling tokenizer
     let dir = tempfile::TempDir::new().unwrap();
     let tok_path = dir.path().join("tokenizer.json");
-    std::fs::write(
+    fs::write(
         &tok_path,
         r#"{"model":{"type":"BPE","vocab":{},"merges":[]}}"#,
     )
@@ -411,7 +409,7 @@ fn shrink_chunk_to_fit_short_text_returns_immediately() {
     // first iteration without decrementing end.
     let dir = tempfile::TempDir::new().unwrap();
     let tok_path = dir.path().join("tokenizer.json");
-    std::fs::write(
+    fs::write(
         &tok_path,
         r#"{"model":{"type":"BPE","vocab":{},"merges":[]}}"#,
     )
@@ -490,6 +488,7 @@ fn t_008b_truncate_for_query_noop_when_short() {
 fn t_008c_truncate_for_query_noop_at_exact_boundary() {
     // [TC-003] Boundary: len == max_len → no truncation
     let max_len = 50;
+    #[allow(clippy::cast_possible_truncation)]
     let input_ids: Vec<u32> = (0..max_len as u32).collect();
     let attention_mask = vec![1u32; max_len];
     let expected_ids = input_ids.clone();

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -5,11 +5,13 @@
 //! inference to free GPU memory. A single `Mutex` ensures these calls are
 //! serialized.
 
+use std::sync::Mutex;
+
 /// Process-global lock for [`mlx_sys::mlx_clear_cache`] and [`mlx_sys::mlx_detail_compile_clear_cache`] calls.
 ///
 /// Recover from poison: cache-clear is stateless (guards `()`), safe to
 /// proceed after a panic in another thread.
-pub(crate) static MLX_CACHE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static MLX_CACHE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Consume an MLX output array and attempt to clear the GPU cache.
 ///
@@ -31,12 +33,11 @@ pub(crate) fn release_inference_output(output: mlx_rs::Array) {
         log::warn!("MLX cache lock was poisoned; recovering");
         e.into_inner()
     });
-    // SAFETY: enforced by the caller invariants documented above.
-    let code = unsafe { mlx_sys::mlx_clear_cache() };
+    let code = rurico_ffi::mlx_clear_cache();
     if code != 0 {
         log::warn!("mlx_clear_cache failed (code: {code})");
     }
-    let code = unsafe { mlx_sys::mlx_detail_compile_clear_cache() };
+    let code = rurico_ffi::mlx_compile_clear_cache();
     if code != 0 {
         log::warn!("mlx_detail_compile_clear_cache failed (code: {code})");
     }

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -3,7 +3,11 @@
 //! Provides config/tokenizer loading, model paths, and model constants shared by
 //! both [`embed`](crate::embed) and [`reranker`](crate::reranker) modules.
 
+use std::fs;
 use std::path::{Path, PathBuf};
+
+use hf_hub::api::sync::Api;
+use serde::de::DeserializeOwned;
 
 /// EOS (end of sequence) token ID for ruri-v3 models.
 pub(crate) const EOS_TOKEN_ID: u32 = 2;
@@ -79,8 +83,8 @@ impl ModelPaths {
 /// # Errors
 ///
 /// Returns [`ModelIoError::Config`] on IO failure or JSON parse error.
-pub fn read_config<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, ModelIoError> {
-    let text = std::fs::read_to_string(path).map_err(|e| ModelIoError::Config {
+pub fn read_config<T: DeserializeOwned>(path: &Path) -> Result<T, ModelIoError> {
+    let text = fs::read_to_string(path).map_err(|e| ModelIoError::Config {
         path: path.to_path_buf(),
         reason: e.to_string(),
     })?;
@@ -102,9 +106,9 @@ pub fn load_tokenizer(path: &Path) -> Result<tokenizers::Tokenizer, ModelIoError
 
 fn model_repo_for<Id: ModelArtifact>(model: Id) -> hf_hub::Repo {
     hf_hub::Repo::with_revision(
-        model.repo_id().to_string(),
+        model.repo_id().to_owned(),
         hf_hub::RepoType::Model,
-        model.revision().to_string(),
+        model.revision().to_owned(),
     )
 }
 
@@ -125,8 +129,7 @@ fn model_repo_for<Id: ModelArtifact>(model: Id) -> hf_hub::Repo {
 /// On the next invocation, [`artifacts_if_cached`] finds no valid pointer and
 /// returns `None`, so the download retries cleanly — no manual cache cleanup needed.
 pub fn download_artifacts<Id: ModelArtifact>(model: Id) -> Result<ModelPaths, ModelIoError> {
-    let api = hf_hub::api::sync::Api::new()
-        .map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
+    let api = Api::new().map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
     let repo = api.repo(model_repo_for(model));
 
     let get = |name: &str| {
@@ -189,12 +192,12 @@ pub(crate) fn pad_sequences(
     debug_assert!(
         masks.is_none_or(|m| m.len() == ids.len()),
         "masks length {} != ids length {}",
-        masks.map_or(0, |m| m.len()),
+        masks.map_or(0, <[Vec<u32>]>::len),
         ids.len(),
     );
 
     let batch_size = ids.len();
-    let max_len = ids.iter().map(|s| s.len()).max().unwrap_or(0);
+    let max_len = ids.iter().map(Vec::len).max().unwrap_or(0);
 
     let mut flat_ids = vec![0u32; batch_size * max_len];
     let mut flat_mask = vec![0u32; batch_size * max_len];
@@ -226,7 +229,7 @@ mod tests {
     fn read_config_returns_error_for_invalid_json() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        std::fs::write(&path, b"not json").unwrap();
+        fs::write(&path, b"not json").unwrap();
         let err = read_config::<serde_json::Value>(&path).unwrap_err();
         assert!(
             matches!(err, ModelIoError::Config { ref reason, .. } if reason.contains("parse error")),
@@ -242,10 +245,12 @@ mod tests {
 
     #[test]
     fn read_config_returns_error_for_missing_fields() {
+        use crate::modernbert::Config;
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        std::fs::write(&path, b"{ \"vocab_size\": 1000 }").unwrap();
-        let err = read_config::<crate::modernbert::Config>(&path).unwrap_err();
+        fs::write(&path, b"{ \"vocab_size\": 1000 }").unwrap();
+        let err = read_config::<Config>(&path).unwrap_err();
         assert!(
             matches!(err, ModelIoError::Config { ref reason, .. } if reason.contains("parse error")),
             "{err}"

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -4,6 +4,18 @@
 //! Individual modules (embed, reranker) call `probe_via_subprocess` to
 //! re-exec the current binary as an isolated probe.
 
+use std::env;
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::process::{self, Child, Command, ExitStatus, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::embed;
+use crate::model_io::ModelPaths;
+use crate::reranker;
+
 /// Handshake token written to stdout by probe subprocesses.
 pub const PROBE_ACK: &str = "RURICO_PROBE_OK";
 
@@ -59,7 +71,7 @@ pub(crate) fn resolve_probe_env(
     model: Option<String>,
     config: Option<String>,
     tokenizer: Option<String>,
-) -> Option<Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf), i32>> {
+) -> Option<Result<(PathBuf, PathBuf, PathBuf), i32>> {
     let model = model?;
     Some(match (config, tokenizer) {
         (Some(config), Some(tokenizer)) => Ok((model.into(), config.into(), tokenizer.into())),
@@ -68,7 +80,7 @@ pub(crate) fn resolve_probe_env(
 }
 
 /// Timeout for probe subprocesses.
-const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Single entry point for probe subprocess dispatch in host binaries.
 ///
@@ -88,28 +100,28 @@ const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// When the current process is not a probe subprocess, it returns immediately.
 pub fn handle_probe_if_needed() {
     // --- Embed probe ---
-    if let Some(result) = crate::embed::probe_env_to_paths(
-        std::env::var(EMBED_PROBE_ENV_MODEL).ok(),
-        std::env::var(EMBED_PROBE_ENV_CONFIG).ok(),
-        std::env::var(EMBED_PROBE_ENV_TOKENIZER).ok(),
+    if let Some(result) = embed::probe_env_to_paths(
+        env::var(EMBED_PROBE_ENV_MODEL).ok(),
+        env::var(EMBED_PROBE_ENV_CONFIG).ok(),
+        env::var(EMBED_PROBE_ENV_TOKENIZER).ok(),
     ) {
         dispatch_probe(result, |candidate| {
             let artifacts = candidate.verify().map_err(|e| e.to_string())?;
-            crate::embed::Embedder::new(&artifacts)
+            embed::Embedder::new(&artifacts)
                 .map(|_| ())
                 .map_err(|e| e.to_string())
         });
     }
 
     // --- Reranker probe ---
-    if let Some(result) = crate::reranker::probe_env_to_paths(
-        std::env::var(RERANKER_PROBE_ENV_MODEL).ok(),
-        std::env::var(RERANKER_PROBE_ENV_CONFIG).ok(),
-        std::env::var(RERANKER_PROBE_ENV_TOKENIZER).ok(),
+    if let Some(result) = reranker::probe_env_to_paths(
+        env::var(RERANKER_PROBE_ENV_MODEL).ok(),
+        env::var(RERANKER_PROBE_ENV_CONFIG).ok(),
+        env::var(RERANKER_PROBE_ENV_TOKENIZER).ok(),
     ) {
         dispatch_probe(result, |candidate| {
             let artifacts = candidate.verify().map_err(|e| e.to_string())?;
-            crate::reranker::Reranker::new(&artifacts)
+            reranker::Reranker::new(&artifacts)
                 .map(|_| ())
                 .map_err(|e| e.to_string())
         });
@@ -148,7 +160,7 @@ pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> Pro
 /// Execute a probe dispatch: emit ACK, load model, exit with appropriate code.
 ///
 /// Always terminates the process via [`std::process::exit`].
-fn dispatch_probe<P, E: std::fmt::Display>(
+fn dispatch_probe<P, E: fmt::Display>(
     result: Result<P, i32>,
     load: impl FnOnce(P) -> Result<(), E>,
 ) -> ! {
@@ -159,16 +171,14 @@ fn dispatch_probe<P, E: std::fmt::Display>(
     };
     let action = compute_probe_exit(outcome);
     if let Some(ref msg) = action.message {
-        use std::io::Write;
-        let _ = write!(std::io::stderr(), "{msg}");
+        let _ = write!(io::stderr(), "{msg}");
     }
-    std::process::exit(action.code);
+    process::exit(action.code);
 }
 
 fn emit_ack() {
-    use std::io::Write;
-    let _ = writeln!(std::io::stdout(), "{PROBE_ACK}");
-    let _ = std::io::stdout().flush();
+    let _ = writeln!(io::stdout(), "{PROBE_ACK}");
+    let _ = io::stdout().flush();
 }
 
 /// Re-exec the current binary as a probe subprocess with the given env vars.
@@ -180,16 +190,16 @@ fn emit_ack() {
 /// - Exit non-zero → [`ProbeError::ModelLoadFailed`] (reason from stderr)
 /// - Killed by signal / timeout / no exit code → [`ProbeStatus::BackendUnavailable`]
 pub fn probe_via_subprocess(env_pairs: &[(&str, &str)]) -> Result<ProbeStatus, ProbeError> {
-    let exe = std::env::current_exe()
+    let exe = env::current_exe()
         .map_err(|e| ProbeError::SubprocessFailed(format!("cannot locate executable: {e}")))?;
 
-    let mut cmd = std::process::Command::new(exe);
+    let mut cmd = Command::new(exe);
     for &(key, value) in env_pairs {
         cmd.env(key, value);
     }
     let mut child = cmd
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| ProbeError::SubprocessFailed(format!("probe spawn failed: {e}")))?;
 
@@ -197,10 +207,10 @@ pub fn probe_via_subprocess(env_pairs: &[(&str, &str)]) -> Result<ProbeStatus, P
     interpret_probe_output(&output)
 }
 
-fn drain_pipe(pipe: Option<impl std::io::Read>, label: &str) -> Vec<u8> {
+fn drain_pipe(pipe: Option<impl Read>, label: &str) -> Vec<u8> {
     pipe.map_or_else(Vec::new, |mut s| {
         let mut buf = Vec::new();
-        if let Err(e) = std::io::Read::read_to_end(&mut s, &mut buf) {
+        if let Err(e) = s.read_to_end(&mut buf) {
             log::warn!("probe: failed to drain child {label}: {e}");
         }
         buf
@@ -212,7 +222,7 @@ fn drain_pipe(pipe: Option<impl std::io::Read>, label: &str) -> Vec<u8> {
 /// Thin wrapper that converts [`crate::model_io::ModelPaths`] fields to string
 /// env-var pairs and delegates to [`probe_via_subprocess`].
 pub(crate) fn probe_paths_via_subprocess(
-    paths: &crate::model_io::ModelPaths,
+    paths: &ModelPaths,
     model_key: &str,
     config_key: &str,
     tokenizer_key: &str,
@@ -229,25 +239,22 @@ pub(crate) fn probe_paths_via_subprocess(
 
 /// Wait for a child process with a timeout. Kill and return a synthetic
 /// timeout output if the deadline is exceeded.
-fn wait_with_timeout(
-    child: &mut std::process::Child,
-    timeout: std::time::Duration,
-) -> Result<std::process::Output, ProbeError> {
-    let deadline = std::time::Instant::now() + timeout;
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<Output, ProbeError> {
+    let deadline = Instant::now() + timeout;
 
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
                 let stdout = drain_pipe(child.stdout.take(), "stdout");
                 let stderr = drain_pipe(child.stderr.take(), "stderr");
-                return Ok(std::process::Output {
+                return Ok(Output {
                     status,
                     stdout,
                     stderr,
                 });
             }
             Ok(None) => {
-                if std::time::Instant::now() >= deadline {
+                if Instant::now() >= deadline {
                     log::warn!(
                         "probe subprocess timed out after {}s, killing",
                         timeout.as_secs()
@@ -256,7 +263,7 @@ fn wait_with_timeout(
                     let _ = child.wait();
                     return Ok(build_timeout_output());
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                thread::sleep(Duration::from_millis(100));
             }
             Err(e) => {
                 return Err(ProbeError::SubprocessFailed(format!(
@@ -271,10 +278,10 @@ fn wait_with_timeout(
 /// `BackendUnavailable` (no exit code, PROBE_ACK present so it doesn't
 /// trigger the "handler not installed" error).
 #[cfg(unix)]
-fn build_timeout_output() -> std::process::Output {
+fn build_timeout_output() -> Output {
     use std::os::unix::process::ExitStatusExt;
-    std::process::Output {
-        status: std::process::ExitStatus::from_raw(9), // SIGKILL
+    Output {
+        status: ExitStatus::from_raw(9), // SIGKILL
         stdout: format!("{PROBE_ACK}\n").into_bytes(),
         stderr: b"probe timed out".to_vec(),
     }
@@ -286,9 +293,7 @@ fn build_timeout_output() -> std::process::Output {
 /// - Exit non-zero with ACK → [`ProbeError::ModelLoadFailed`]
 /// - Killed by signal with ACK → [`ProbeStatus::BackendUnavailable`]
 /// - No ACK in stdout → [`ProbeError::HandlerNotInstalled`]
-pub(crate) fn interpret_probe_output(
-    output: &std::process::Output,
-) -> Result<ProbeStatus, ProbeError> {
+pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, ProbeError> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     if !stdout.starts_with(PROBE_ACK) {
         return Err(ProbeError::HandlerNotInstalled);
@@ -305,7 +310,7 @@ pub(crate) fn interpret_probe_output(
     match output.status.code() {
         Some(0) => Ok(ProbeStatus::Available),
         Some(_) => {
-            let reason = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let reason = String::from_utf8_lossy(&output.stderr).trim().to_owned();
             Err(ProbeError::ModelLoadFailed {
                 reason: if reason.is_empty() {
                     "model load failed".into()
@@ -346,13 +351,13 @@ mod tests {
             resolve_probe_env(Some("/m".into()), Some("/c".into()), Some("/t".into()))
                 .unwrap()
                 .unwrap();
-        assert_eq!(model, std::path::PathBuf::from("/m"));
-        assert_eq!(config, std::path::PathBuf::from("/c"));
-        assert_eq!(tokenizer, std::path::PathBuf::from("/t"));
+        assert_eq!(model, PathBuf::from("/m"));
+        assert_eq!(config, PathBuf::from("/c"));
+        assert_eq!(tokenizer, PathBuf::from("/t"));
     }
 
-    fn exit_status(code: i32) -> std::process::ExitStatus {
-        std::process::Command::new("sh")
+    fn exit_status(code: i32) -> ExitStatus {
+        Command::new("sh")
             .args(["-c", &format!("exit {code}")])
             .status()
             .unwrap()
@@ -360,7 +365,7 @@ mod tests {
 
     #[test]
     fn interpret_available_on_exit_0() {
-        let output = std::process::Output {
+        let output = Output {
             status: exit_status(0),
             stdout: format!("{PROBE_ACK}\n").into_bytes(),
             stderr: Vec::new(),
@@ -373,7 +378,7 @@ mod tests {
 
     #[test]
     fn interpret_model_load_failed_on_nonzero_exit() {
-        let output = std::process::Output {
+        let output = Output {
             status: exit_status(1),
             stdout: format!("{PROBE_ACK}\n").into_bytes(),
             stderr: b"inference error: bad model".to_vec(),
@@ -387,7 +392,7 @@ mod tests {
 
     #[test]
     fn interpret_model_load_failed_empty_stderr() {
-        let output = std::process::Output {
+        let output = Output {
             status: exit_status(1),
             stdout: format!("{PROBE_ACK}\n").into_bytes(),
             stderr: Vec::new(),
@@ -401,7 +406,7 @@ mod tests {
 
     #[test]
     fn interpret_handler_not_installed_on_missing_ack() {
-        let output = std::process::Output {
+        let output = Output {
             status: exit_status(0),
             stdout: b"unexpected output".to_vec(),
             stderr: Vec::new(),
@@ -443,11 +448,11 @@ mod tests {
 
     #[test]
     fn interpret_backend_unavailable_on_signal() {
-        let status = std::process::Command::new("sh")
+        let status = Command::new("sh")
             .args(["-c", "kill -ABRT $$"])
             .status()
             .unwrap();
-        let output = std::process::Output {
+        let output = Output {
             status,
             stdout: format!("{PROBE_ACK}\n").into_bytes(),
             stderr: Vec::new(),

--- a/src/modernbert.rs
+++ b/src/modernbert.rs
@@ -3,3 +3,4 @@ mod model;
 
 pub use config::Config;
 pub use model::ModernBert;
+pub(crate) use model::layer_norm_eps_f32;

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -632,7 +632,12 @@ mod tests {
             let input_ids = vec![1u32; oversize];
             let mask = vec![1u32; oversize];
 
-            let result = model.forward(&input_ids, &mask, 1, oversize as i32);
+            let result = model.forward(
+                &input_ids,
+                &mask,
+                1,
+                i32::try_from(oversize).expect("bounded by model config"),
+            );
             assert!(
                 result.is_ok(),
                 "forward should truncate oversize input, not error: {result:?}"
@@ -642,8 +647,8 @@ mod tests {
                 output.shape(),
                 &[
                     1,
-                    config.max_position_embeddings as i32,
-                    config.hidden_size as i32
+                    i32::try_from(config.max_position_embeddings).expect("bounded by model config"),
+                    i32::try_from(config.hidden_size).expect("bounded by model config"),
                 ]
             );
         }
@@ -654,7 +659,8 @@ mod tests {
             let config = test_config(); // max_position_embeddings = 512
             let mut model = ModernBert::new(&config).expect("create model");
 
-            let oversize_seq = (config.max_position_embeddings + 100) as i32;
+            let oversize_seq = i32::try_from(config.max_position_embeddings + 100)
+                .expect("bounded by model config");
             let short_buf = vec![1u32; 5]; // much shorter than batch_size * seq_len
             let short_mask = vec![1u32; 5];
 

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -34,8 +34,9 @@ impl Attention {
         rope_theta: f32,
         uses_local_attention: bool,
     ) -> Result<Self, Exception> {
-        let h = config.hidden_size as i32;
-        let head_dim = h / config.num_attention_heads as i32;
+        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let num_heads = i32::try_from(config.num_attention_heads).expect("bounded by model config");
+        let head_dim = h / num_heads;
 
         #[allow(non_snake_case)]
         let Wqkv = nn::LinearBuilder::new(h, h * 3).bias(false).build()?;
@@ -50,7 +51,7 @@ impl Attention {
             Wqkv,
             Wo,
             rope,
-            num_heads: config.num_attention_heads as i32,
+            num_heads,
             head_dim,
             scale: (head_dim as f32).powf(-0.5),
             uses_local_attention,
@@ -108,8 +109,8 @@ struct Mlp {
 
 impl Mlp {
     fn new(config: &Config) -> Result<Self, Exception> {
-        let h = config.hidden_size as i32;
-        let inter = config.intermediate_size as i32;
+        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let inter = i32::try_from(config.intermediate_size).expect("bounded by model config");
         #[allow(non_snake_case)]
         let Wi = nn::LinearBuilder::new(h, inter * 2).bias(false).build()?;
         #[allow(non_snake_case)]
@@ -142,13 +143,9 @@ struct TransformerLayer {
 impl TransformerLayer {
     fn new(config: &Config, layer_id: usize) -> Result<Self, Exception> {
         let uses_local = !layer_id.is_multiple_of(config.global_attn_every_n_layers);
-        let rope_theta = if uses_local {
-            config.local_rope_theta as f32
-        } else {
-            config.global_rope_theta as f32
-        };
-        let h = config.hidden_size as i32;
-        let eps = config.layer_norm_eps as f32;
+        let rope_theta = rope_theta_f32(config, uses_local);
+        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let eps = layer_norm_eps_f32(config);
 
         let attn_norm = nn::LayerNormBuilder::new(h).eps(eps).build()?;
         let attn = Attention::new(config, rope_theta, uses_local)?;
@@ -223,10 +220,11 @@ impl ModernBert {
         config
             .validate()
             .map_err(|e| Exception::custom(format!("invalid config: {e}")))?;
-        let h = config.hidden_size as i32;
-        let eps = config.layer_norm_eps as f32;
+        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let eps = layer_norm_eps_f32(config);
+        let vocab_size = i32::try_from(config.vocab_size).expect("bounded by model config");
 
-        let tok_embeddings = nn::Embedding::new(config.vocab_size as i32, h)?;
+        let tok_embeddings = nn::Embedding::new(vocab_size, h)?;
         let emb_norm = nn::LayerNormBuilder::new(h).eps(eps).build()?;
 
         let layers = (0..config.num_hidden_layers)
@@ -316,7 +314,7 @@ impl ModernBert {
         assert_len("input_ids", input_ids)?;
         assert_len("attention_mask", attention_mask)?;
 
-        let max_seq = self.max_seq_len as i32;
+        let max_seq = i32::try_from(self.max_seq_len).expect("bounded by model config");
         if seq_len > max_seq {
             // Defense-in-depth: truncate oversize inputs, validating only the effective prefix.
             log::warn!(
@@ -359,7 +357,9 @@ impl ModernBert {
         let local_mask = match &self.local_mask_cache {
             Some((cached_len, cached)) if *cached_len == seq_len => cached.clone(),
             _ => {
-                let m = get_local_attention_mask(seq_len, self.local_attention_half as i32)?;
+                let half =
+                    i32::try_from(self.local_attention_half).expect("bounded by model config");
+                let m = get_local_attention_mask(seq_len, half)?;
                 self.local_mask_cache = Some((seq_len, m.clone()));
                 m
             }
@@ -376,6 +376,22 @@ impl ModernBert {
 // Use a large negative instead of -inf to avoid 0.0 * (-inf) = NaN on Metal kernels
 // for certain sequence lengths (threshold ~9 tokens on Apple Silicon).
 const MASK_FILL: f32 = -1e9;
+
+// Model config constant; layer norm epsilon fits in f32.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn layer_norm_eps_f32(config: &Config) -> f32 {
+    config.layer_norm_eps as f32
+}
+
+// Model config constants from config.json; RoPE base values fit in f32.
+#[allow(clippy::cast_possible_truncation)]
+fn rope_theta_f32(config: &Config, uses_local: bool) -> f32 {
+    if uses_local {
+        config.local_rope_theta as f32
+    } else {
+        config.global_rope_theta as f32
+    }
+}
 
 fn prepare_4d_attention_mask(
     mask: &Array,

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -7,8 +7,17 @@ mod test_support;
 mod tests;
 
 use self::mlx::RerankerInner;
+use crate::artifacts::verify_as_reranker;
+use crate::model_io::{ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts};
+use crate::model_probe::{
+    ProbeError, RERANKER_PROBE_ENV_CONFIG, RERANKER_PROBE_ENV_MODEL, RERANKER_PROBE_ENV_TOKENIZER,
+    probe_paths_via_subprocess, resolve_probe_env,
+};
+use std::fmt::{self, Debug, Display, Formatter};
+#[cfg(any(test, feature = "test-support"))]
+use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 pub use crate::artifacts::{ArtifactError, RerankerKind, VerifiedArtifacts};
 pub use crate::model_probe::ProbeStatus;
@@ -35,7 +44,7 @@ pub type Artifacts = VerifiedArtifacts<RerankerKind>;
 /// [`Artifacts`] that can be passed to [`Reranker::new`].
 #[derive(Debug)]
 pub struct CandidateArtifacts {
-    paths: crate::model_io::ModelPaths,
+    paths: ModelPaths,
 }
 
 impl CandidateArtifacts {
@@ -45,7 +54,7 @@ impl CandidateArtifacts {
     /// Call [`verify`](Self::verify) before passing the result to [`Reranker::new`].
     pub fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
         Self {
-            paths: crate::model_io::ModelPaths {
+            paths: ModelPaths {
                 model,
                 config,
                 tokenizer,
@@ -58,9 +67,9 @@ impl CandidateArtifacts {
     ///
     /// Available for development and test use only.
     #[cfg(any(test, feature = "test-support"))]
-    pub fn from_dir(dir: &std::path::Path) -> Self {
+    pub fn from_dir(dir: &Path) -> Self {
         Self {
-            paths: crate::model_io::ModelPaths::from_dir(dir),
+            paths: ModelPaths::from_dir(dir),
         }
     }
 
@@ -74,7 +83,7 @@ impl CandidateArtifacts {
     /// - `tokenizer.json` cannot be loaded ([`ArtifactError::InvalidTokenizer`])
     /// - Weights are for an embed model, not a reranker ([`ArtifactError::WrongModelKind`])
     pub fn verify(self) -> Result<Artifacts, ArtifactError> {
-        crate::artifacts::verify_as_reranker(self.paths)
+        verify_as_reranker(self.paths)
     }
 }
 
@@ -103,7 +112,7 @@ impl RerankerModelId {
     }
 }
 
-impl crate::model_io::ModelArtifact for RerankerModelId {
+impl ModelArtifact for RerankerModelId {
     fn repo_id(self) -> &'static str {
         RerankerModelId::repo_id(self)
     }
@@ -133,23 +142,17 @@ pub enum RerankerInitError {
 }
 
 impl RerankerInitError {
-    pub(crate) fn backend(e: impl std::fmt::Display) -> Self {
+    pub(crate) fn backend(e: impl Display) -> Self {
         Self::Backend(e.to_string())
     }
 }
 
-impl From<crate::model_probe::ProbeError> for RerankerInitError {
-    fn from(e: crate::model_probe::ProbeError) -> Self {
+impl From<ProbeError> for RerankerInitError {
+    fn from(e: ProbeError) -> Self {
         match e {
-            crate::model_probe::ProbeError::HandlerNotInstalled => {
-                RerankerInitError::Backend(e.to_string())
-            }
-            crate::model_probe::ProbeError::ModelLoadFailed { reason } => {
-                RerankerInitError::ModelCorrupt { reason }
-            }
-            crate::model_probe::ProbeError::SubprocessFailed(msg) => {
-                RerankerInitError::Backend(msg)
-            }
+            ProbeError::HandlerNotInstalled => RerankerInitError::Backend(e.to_string()),
+            ProbeError::ModelLoadFailed { reason } => RerankerInitError::ModelCorrupt { reason },
+            ProbeError::SubprocessFailed(msg) => RerankerInitError::Backend(msg),
         }
     }
 }
@@ -174,7 +177,7 @@ pub enum RerankerError {
 }
 
 impl RerankerError {
-    pub(crate) fn inference(e: impl std::fmt::Display) -> Self {
+    pub(crate) fn inference(e: impl Display) -> Self {
         Self::Inference(e.to_string())
     }
 }
@@ -225,8 +228,8 @@ pub struct Reranker {
     inner: Mutex<RerankerInner>,
 }
 
-impl std::fmt::Debug for Reranker {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for Reranker {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("Reranker").finish_non_exhaustive()
     }
 }
@@ -299,7 +302,7 @@ impl Reranker {
         probe_via_subprocess(artifacts)
     }
 
-    fn lock_inner(&self) -> Result<std::sync::MutexGuard<'_, RerankerInner>, RerankerError> {
+    fn lock_inner(&self) -> Result<MutexGuard<'_, RerankerInner>, RerankerError> {
         self.inner
             .lock()
             .map_err(|_| RerankerError::inference("reranker lock poisoned"))
@@ -341,8 +344,8 @@ fn sort_results(scores: &[f32]) -> Vec<RankedResult> {
 /// Returns other [`ArtifactError`] variants if verification of the downloaded
 /// files fails.
 pub fn download_model(model: RerankerModelId) -> Result<Artifacts, ArtifactError> {
-    let paths = crate::model_io::download_artifacts(model)?;
-    crate::artifacts::verify_as_reranker(paths)
+    let paths = download_artifacts(model)?;
+    verify_as_reranker(paths)
 }
 
 /// Check whether reranker model files exist in the local HF Hub cache and verify them.
@@ -355,10 +358,10 @@ pub fn download_model(model: RerankerModelId) -> Result<Artifacts, ArtifactError
 /// Returns [`ArtifactError`] if cached files fail verification.
 /// Cache misses are reported as `Ok(None)`.
 pub fn cached_artifacts(model: RerankerModelId) -> Result<Option<Artifacts>, ArtifactError> {
-    let Some(paths) = crate::model_io::artifacts_if_cached(model)? else {
+    let Some(paths) = artifacts_if_cached(model)? else {
         return Ok(None);
     };
-    crate::artifacts::verify_as_reranker(paths).map(Some)
+    verify_as_reranker(paths).map(Some)
 }
 
 // ── Probe infrastructure ──────────────────────────────────────────────────────
@@ -373,16 +376,16 @@ pub(crate) fn probe_env_to_paths(
     config: Option<String>,
     tokenizer: Option<String>,
 ) -> Option<Result<CandidateArtifacts, i32>> {
-    crate::model_probe::resolve_probe_env(model, config, tokenizer)
+    resolve_probe_env(model, config, tokenizer)
         .map(|r| r.map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t)))
 }
 
 fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, RerankerInitError> {
-    crate::model_probe::probe_paths_via_subprocess(
+    probe_paths_via_subprocess(
         &artifacts.paths,
-        crate::model_probe::RERANKER_PROBE_ENV_MODEL,
-        crate::model_probe::RERANKER_PROBE_ENV_CONFIG,
-        crate::model_probe::RERANKER_PROBE_ENV_TOKENIZER,
+        RERANKER_PROBE_ENV_MODEL,
+        RERANKER_PROBE_ENV_CONFIG,
+        RERANKER_PROBE_ENV_TOKENIZER,
     )
     .map_err(Into::into)
 }

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -1,5 +1,7 @@
 use super::{Artifacts, RerankerError, RerankerInitError};
-use crate::model_io::MAX_SEQ_LEN;
+use crate::mlx_cache::release_inference_output;
+use crate::model_io::{MAX_SEQ_LEN, pad_sequences, truncate_with_eos};
+use crate::modernbert::{Config, ModernBert, layer_norm_eps_f32};
 
 use mlx_rs::{
     builder::Builder,
@@ -9,6 +11,8 @@ use mlx_rs::{
     nn,
     ops::indexing::IndexOp,
 };
+
+use std::path::Path;
 
 pub(super) struct RerankerInner {
     model: RerankerModel,
@@ -45,12 +49,13 @@ impl RerankerInner {
             all_masks.push(mask);
         }
 
-        let (flat_ids, flat_mask, batch_size, max_len) =
-            crate::model_io::pad_sequences(&all_ids, Some(&all_masks));
+        let (flat_ids, flat_mask, batch_size, max_len) = pad_sequences(&all_ids, Some(&all_masks));
 
+        let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
+        let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");
         let output = self
             .model
-            .forward(&flat_ids, &flat_mask, batch_size as i32, max_len as i32)
+            .forward(&flat_ids, &flat_mask, batch_size_i32, max_len_i32)
             .map_err(RerankerError::inference)?;
 
         let result = (|| -> Result<Vec<f32>, RerankerError> {
@@ -68,7 +73,7 @@ impl RerankerInner {
             }
             Ok(scores)
         })();
-        crate::mlx_cache::release_inference_output(output);
+        release_inference_output(output);
         result
     }
 }
@@ -84,7 +89,7 @@ struct PredictionHead {
 #[derive(Debug, Clone, ModuleParameters)]
 struct RerankerModel {
     #[param]
-    model: crate::modernbert::ModernBert,
+    model: ModernBert,
     #[param]
     head: PredictionHead,
     #[param]
@@ -92,11 +97,11 @@ struct RerankerModel {
 }
 
 impl RerankerModel {
-    fn new(config: &crate::modernbert::Config) -> Result<Self, Exception> {
-        let h = config.hidden_size as i32;
-        let eps = config.layer_norm_eps as f32;
+    fn new(config: &Config) -> Result<Self, Exception> {
+        let h = i32::try_from(config.hidden_size).expect("hidden_size fits in i32");
+        let eps = layer_norm_eps_f32(config);
 
-        let model = crate::modernbert::ModernBert::new(config)?;
+        let model = ModernBert::new(config)?;
         let dense = nn::LinearBuilder::new(h, h).build()?;
         let norm = nn::LayerNormBuilder::new(h).eps(eps).build()?;
         let classifier = nn::LinearBuilder::new(h, 1).build()?;
@@ -108,7 +113,7 @@ impl RerankerModel {
         })
     }
 
-    fn load(path: &std::path::Path, config: &crate::modernbert::Config) -> Result<Self, Exception> {
+    fn load(path: &Path, config: &Config) -> Result<Self, Exception> {
         let mut model = Self::new(config)?;
         model
             .load_safetensors(path)
@@ -150,7 +155,7 @@ pub(super) fn truncate_pair(
     pair_idx: usize,
 ) {
     let orig_len = ids.len();
-    if crate::model_io::truncate_with_eos(ids, mask, max_len) {
+    if truncate_with_eos(ids, mask, max_len) {
         log::warn!("pair {pair_idx} exceeds max_seq_len ({orig_len} > {max_len}), truncating");
     }
 }

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -1,5 +1,8 @@
 use super::mlx::truncate_pair;
 use super::*;
+use crate::model_io::artifacts_from_cache;
+use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
+use std::fs;
 
 #[test]
 fn t_003_candidate_verify_returns_missing_file_for_nonexistent_paths() {
@@ -53,7 +56,7 @@ fn t_007_sort_results_descending_by_score() {
 fn t_013_cache_lookup_returns_some_when_all_files_present() {
     let dir = tempfile::tempdir().unwrap();
     let model = RerankerModelId::RuriV3Reranker310m;
-    crate::test_support::setup_fake_hf_cache(
+    setup_fake_hf_cache(
         dir.path(),
         model.repo_id(),
         model.revision(),
@@ -64,7 +67,7 @@ fn t_013_cache_lookup_returns_some_when_all_files_present() {
         ],
     );
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = crate::model_io::artifacts_from_cache(&cache, model).unwrap();
+    let result = artifacts_from_cache(&cache, model).unwrap();
     let paths = result.expect("should be Some");
     assert!(paths.model.ends_with("model.safetensors"));
     assert!(paths.config.ends_with("config.json"));
@@ -75,18 +78,16 @@ fn t_013_cache_lookup_returns_some_when_all_files_present() {
 fn t_021_cache_lookup_returns_none_when_cache_empty() {
     let dir = tempfile::tempdir().unwrap();
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = crate::model_io::artifacts_from_cache(&cache, RerankerModelId::default()).unwrap();
+    let result = artifacts_from_cache(&cache, RerankerModelId::default()).unwrap();
     assert!(result.is_none());
 }
-
-use crate::test_support::VALID_CONFIG_JSON;
 
 #[test]
 fn t_014_candidate_verify_returns_invalid_config_for_empty_config() {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
-    std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
-    std::fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
+    fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
+    fs::write(dir.path().join("config.json"), b"{}").unwrap();
+    fs::write(dir.path().join("tokenizer.json"), b"{}").unwrap();
     let candidate = CandidateArtifacts::from_dir(dir.path());
     let err = candidate.verify().unwrap_err();
     assert!(
@@ -98,9 +99,9 @@ fn t_014_candidate_verify_returns_invalid_config_for_empty_config() {
 #[test]
 fn t_015_candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
     let dir = tempfile::tempdir().unwrap();
-    std::fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
-    std::fs::write(dir.path().join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();
-    std::fs::write(dir.path().join("tokenizer.json"), b"not json").unwrap();
+    fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
+    fs::write(dir.path().join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();
+    fs::write(dir.path().join("tokenizer.json"), b"not json").unwrap();
     let candidate = CandidateArtifacts::from_dir(dir.path());
     let err = candidate.verify().unwrap_err();
     assert!(
@@ -114,9 +115,9 @@ fn probe_env_to_paths_returns_ok_when_all_present() {
     let result = super::probe_env_to_paths(Some("/m".into()), Some("/c".into()), Some("/t".into()));
     // CandidateArtifacts is returned — verify it was constructed (path accessible in submodule)
     let candidate = result.unwrap().unwrap();
-    assert_eq!(candidate.paths.model, std::path::PathBuf::from("/m"));
-    assert_eq!(candidate.paths.config, std::path::PathBuf::from("/c"));
-    assert_eq!(candidate.paths.tokenizer, std::path::PathBuf::from("/t"));
+    assert_eq!(candidate.paths.model, PathBuf::from("/m"));
+    assert_eq!(candidate.paths.config, PathBuf::from("/c"));
+    assert_eq!(candidate.paths.tokenizer, PathBuf::from("/t"));
 }
 
 #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,11 +1,10 @@
 mod search;
 
+use std::sync::OnceLock;
+
 pub use search::{
     MatchFtsQuery, SanitizeError, fts_quote, prepare_match_query, recency_decay, rrf_merge,
 };
-
-use rusqlite::ffi::sqlite3_auto_extension;
-use sqlite_vec::sqlite3_vec_init;
 
 #[cfg(not(target_endian = "little"))]
 compile_error!("rurico requires a little-endian target for f32↔u8 embedding storage");
@@ -26,22 +25,9 @@ pub fn f32_as_bytes(slice: &[f32]) -> &[u8] {
 /// includes the SQLite return code, but its exact text is not part of the
 /// stable API contract.
 pub fn ensure_sqlite_vec() -> Result<(), String> {
-    static INIT: std::sync::OnceLock<Result<(), i32>> = std::sync::OnceLock::new();
+    static INIT: OnceLock<Result<(), i32>> = OnceLock::new();
     let init_result = INIT.get_or_init(|| {
-        // SAFETY: sqlite3_vec_init is the auto-extension entry point exported by sqlite-vec.
-        // sqlite-vec exports it as `unsafe extern "C" fn()`, while rusqlite's
-        // sqlite3_auto_extension expects the full init signature. Both are C fn pointers
-        // with compatible calling conventions; SQLite calls it with the correct arguments.
-        let rc = unsafe {
-            sqlite3_auto_extension(Some(std::mem::transmute::<
-                unsafe extern "C" fn(),
-                unsafe extern "C" fn(
-                    *mut rusqlite::ffi::sqlite3,
-                    *mut *mut std::os::raw::c_char,
-                    *const rusqlite::ffi::sqlite3_api_routines,
-                ) -> std::os::raw::c_int,
-            >(sqlite3_vec_init)))
-        };
+        let rc = rurico_ffi::sqlite_vec_register();
         if rc == 0 { Ok(()) } else { Err(rc) }
     });
     if let Err(rc) = init_result {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::f64::consts::LN_2;
 use std::hash::Hash;
 
 use rusqlite::Connection;
@@ -11,7 +12,7 @@ pub fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
     if half_life_days <= 0.0 {
         return 0.0;
     }
-    (-std::f64::consts::LN_2 * age_days.max(0.0) / half_life_days).exp()
+    (-LN_2 * age_days.max(0.0) / half_life_days).exp()
 }
 
 /// Filter out `NEAR(...)` and `NEAR/N(...)` groups from whitespace-split tokens.
@@ -119,7 +120,7 @@ pub(crate) fn sanitize_fts_query(query: &str) -> Result<SanitizedFtsQuery, Sanit
                 let unquoted = cleaned.replace('"', "");
                 format!("\"{unquoted}\"")
             } else {
-                cleaned.to_string()
+                cleaned.to_owned()
             }
         })
         .filter(|w| !w.is_empty())
@@ -397,11 +398,11 @@ mod tests {
     }
 
     fn sanitized(s: &str) -> SanitizedFtsQuery {
-        SanitizedFtsQuery(s.to_string())
+        SanitizedFtsQuery(s.to_owned())
     }
 
     fn ok(s: &str) -> Result<SanitizedFtsQuery, SanitizeError> {
-        Ok(SanitizedFtsQuery(s.to_string()))
+        Ok(SanitizedFtsQuery(s.to_owned()))
     }
 
     #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,5 +1,8 @@
 //! Shared test helpers available to all modules within the crate.
 
+use std::fs;
+use std::path::Path;
+
 /// Valid ModernBERT config JSON with all required fields, for use in tests
 /// that need to bypass config parsing errors and reach later verification stages.
 ///
@@ -25,7 +28,7 @@ pub(crate) const VALID_CONFIG_JSON: &str = r#"{
 /// Builds the `models--{repo_slug}/refs/{revision}` → `snapshots/{hash}/`
 /// layout that `hf_hub::Cache` expects, with the given files populated.
 pub(crate) fn setup_fake_hf_cache(
-    hub_dir: &std::path::Path,
+    hub_dir: &Path,
     repo_id: &str,
     revision: &str,
     files: &[(&str, &[u8])],
@@ -33,14 +36,14 @@ pub(crate) fn setup_fake_hf_cache(
     let repo_slug = repo_id.replace('/', "--");
     let repo_dir = hub_dir.join(format!("models--{repo_slug}"));
     let refs_dir = repo_dir.join("refs");
-    std::fs::create_dir_all(&refs_dir).unwrap();
+    fs::create_dir_all(&refs_dir).unwrap();
     let commit_hash = "abc123";
-    std::fs::write(refs_dir.join(revision), commit_hash).unwrap();
+    fs::write(refs_dir.join(revision), commit_hash).unwrap();
 
     let snapshot_dir = repo_dir.join("snapshots").join(commit_hash);
-    std::fs::create_dir_all(&snapshot_dir).unwrap();
+    fs::create_dir_all(&snapshot_dir).unwrap();
     for &(name, content) in files {
-        std::fs::write(snapshot_dir.join(name), content).unwrap();
+        fs::write(snapshot_dir.join(name), content).unwrap();
     }
 }
 
@@ -63,7 +66,7 @@ mod tests {
             .path()
             .join("models--cl-nagoya--ruri-v3-310m/refs/some-revision-hash");
         assert!(refs_path.exists());
-        let commit = std::fs::read_to_string(&refs_path).unwrap();
+        let commit = fs::read_to_string(&refs_path).unwrap();
         assert_eq!(commit, "abc123");
 
         // snapshot files exist with correct content
@@ -71,13 +74,10 @@ mod tests {
             "models--cl-nagoya--ruri-v3-310m/snapshots/{commit}"
         ));
         assert_eq!(
-            std::fs::read(snapshot_dir.join("model.safetensors")).unwrap(),
+            fs::read(snapshot_dir.join("model.safetensors")).unwrap(),
             b"model-data"
         );
-        assert_eq!(
-            std::fs::read(snapshot_dir.join("config.json")).unwrap(),
-            b"{}"
-        );
+        assert_eq!(fs::read(snapshot_dir.join("config.json")).unwrap(), b"{}");
     }
 
     #[test]
@@ -89,9 +89,9 @@ mod tests {
 
         let cache = hf_hub::Cache::new(dir.path().to_path_buf());
         let repo = cache.repo(hf_hub::Repo::with_revision(
-            repo_id.to_string(),
+            repo_id.to_owned(),
             hf_hub::RepoType::Model,
-            revision.to_string(),
+            revision.to_owned(),
         ));
         let path = repo.get("weights.bin");
         assert!(path.is_some(), "hf_hub::Cache should resolve the file");

--- a/tests/mlx_smoke.rs
+++ b/tests/mlx_smoke.rs
@@ -7,7 +7,7 @@
 //! - `probe_embed_smoke_binary`: embed subprocess probe contract (via `probe_embed_smoke`)
 //! - `probe_reranker_smoke_binary`: reranker subprocess probe contract (via `probe_reranker_smoke`)
 
-use std::process::Command;
+use std::process::{Command, Output};
 
 /// Run the embed smoke binary and check it succeeds.
 ///
@@ -55,7 +55,7 @@ fn probe_reranker_smoke_binary() {
     assert_smoke_success(&output);
 }
 
-fn assert_smoke_success(output: &std::process::Output) {
+fn assert_smoke_success(output: &Output) {
     if output.status.success() {
         return;
     }


### PR DESCRIPTION
## 背景・目的

ルートクレートに `unsafe_code = "forbid"` を設定し、すべてのunsafe FFI呼び出しを新しい `rurico-ffi` クレートに集約する。あわせて12個のclippy lintをdenyに昇格し、サプライチェーンセキュリティ検査とADR基盤を追加する。

## 変更内容

### コミット 1: unsafe FFI の分離と clippy lint 強制 (`d39b002`)

| 項目 | 内容 |
| --- | --- |
| 新クレート `crates/rurico-ffi/` | `mlx-sys`・`sqlite-vec` への unsafe 呼び出しを安全なラッパー越しに隔離 |
| `unsafe_code = "forbid"` | ルートクレートで `#[allow]` による上書き不可にした |
| clippy lints (12 個) deny 昇格 | `absolute_paths`, `cast_possible_truncation`, `redundant_closure_for_method_calls`, `filter_map_next`, `flat_map_option`, `manual_filter_map`, `manual_find_map`, `wildcard_imports`, `enum_glob_use`, `str_to_string`, `needless_pass_by_value` |
| 約 170 件の違反修正 | `as i32` → `i32::try_from(x).expect(...)`, `.to_string()` → `.to_owned()`, 明示的 `use` インポート追加など |
| モジュール構造のフラット化 | `sub/mod.rs` → `sub.rs` に 4 ファイルをリネーム |
| `publish = false` | ルートマニフェストに追加 |

### コミット 2: サプライチェーンセキュリティと ADR 基盤 (`5b0125f`)

| 項目 | 内容 |
| --- | --- |
| CI `security` ジョブ | push ごとに `cargo deny check` + `cargo audit` を実行 |
| `deny.toml` 追加 | advisories・ライセンス許可リスト・bans・ソースポリシーを定義 |
| `adr/` ディレクトリ追加 | README と `0001-typed-fts-query-contract.md` (typed FTS クエリ契約の意思決定記録) |

## 検証

| チェック | 結果 |
| --- | --- |
| `cargo clippy --all-targets` | エラー 0, 警告 0 |
| `cargo test --lib` | 159 passed, 0 failed, 3 ignored |
| `cargo fmt --check` | クリーン |
| `cargo build` | 成功 |

## 既知の後続対応 (このPR外)

- downstreamクレート (yomu, sae, recall, amici) はgit ref経由で `rurico` を参照しており、path depへの切り替えは行わない。必要に応じて各リポにIssueを起票する。
- ADR 0001の実装 (typed FTSクエリ契約の導入) は別PRで対応する。

## テスト計画

- [ ] `cargo clippy --all-targets` がエラー・警告なしで通ること
- [ ] `cargo test --lib` が159 passedで通ること
- [ ] `cargo fmt --check` がクリーンなこと
- [ ] `cargo build` が成功すること
- [ ] CI `security` ジョブ (`cargo deny check` + `cargo audit`) が通ること
- [ ] `unsafe_code = "forbid"` がルートクレートに設定されており、`crates/rurico-ffi/` のunsafeブロックが外から見えないことを確認
- [ ] `adr/0001-typed-fts-query-contract.md` の内容が意思決定を正確に記録していることをレビュー
