### PR TITLE
rurico-ffi クレートの rust-version を 1.95 に引き上げ

### DIFF
--- a/crates/rurico-ffi/Cargo.toml
+++ b/crates/rurico-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rurico-ffi"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "Safe FFI wrappers for rurico (mlx-sys, sqlite-vec)"
 license = "MIT"
 publish = false


### PR DESCRIPTION
## 背景と目的

PR #36 でワークスペース全体の MSRV を 1.94 から 1.95 へ引き上げたが、`rurico-ffi` サブクレートの `Cargo.toml` が更新されず 1.94 のまま残っていた。本 PR でその差分を解消する。

## 変更内容

- `crates/rurico-ffi/Cargo.toml`: `rust-version` を `"1.94"` から `"1.95"` へ変更

## スコープ

- **含まない**: 動作変更なし。`rust-version` フィールドの整合のみ。

## 検証手順

1. `cargo check -p rurico-ffi` が通ることを確認
2. `grep rust-version crates/rurico-ffi/Cargo.toml` で `1.95` が返ることを確認

## 関連

- Related: #36 (ワークスペース MSRV 1.95 bump — `rurico-ffi` が対象外だった)