### PR TITLE
prepare_match_query の vocab テーブル名をパラメータ化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1491,9 +1491,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
 dependencies = [
  "cc",
  "js-sys",
@@ -2647,11 +2647,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2660,7 +2660,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2959,6 +2959,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ let conn = Connection::open("my.db")?;
 ```rust
 use rurico::storage::{prepare_match_query, SanitizeError};
 
-match prepare_match_query(&conn, user_input) {
+match prepare_match_query(&conn, user_input, "fts_chunks_vocab") {
     Ok(matched) => {
         // matched.as_str() を MATCH に渡す
         stmt.query_map([matched.as_str()], |row| { /* ... */ })?;
@@ -154,7 +154,9 @@ match prepare_match_query(&conn, user_input) {
 }
 ```
 
-`NEAR()` グループ、`^`/`+`/`-` プレフィックス、コロン、不均衡な引用符は内部で無害化される。`AND`/`OR`/`NOT` のようなoperator-like keywordは、前後に非operatorの語がある場合のみliteral termとして引用符で囲まれる。前後が欠けたdangling operator（例: 先頭の `NOT`、NEAR除去後に孤立した `OR`）は除去される。短い語（1-2文字）は `fts_chunks_vocab` テーブルがあればprefix展開される（なければそのまま引用）。
+第3引数の `vocab_table` は `fts5vocab` 仮想テーブル名を受け取る。呼び出し側のスキーマ規約に応じて `"fts_chunks_vocab"` や `"messages_vocab"` などを指定する。`row` または `col` 型の vocabulary のみ対応する（`instance` 型には `cnt` カラムが無いため）。値はSQLにエスケープなしで埋め込まれるため、SQL identifier として妥当な文字列（先頭が ASCII 英字または `_`、以降 ASCII 英数字または `_`）のみ許容され、違反すると panic する。
+
+`NEAR()` グループ、`^`/`+`/`-` プレフィックス、コロン、不均衡な引用符は内部で無害化される。`AND`/`OR`/`NOT` のようなoperator-like keywordは、前後に非operatorの語がある場合のみliteral termとして引用符で囲まれる。前後が欠けたdangling operator（例: 先頭の `NOT`、NEAR除去後に孤立した `OR`）は除去される。短い語（1-2文字）は指定した vocab テーブルがあればprefix展開される（なければそのまま引用）。
 
 ### ハイブリッド検索ユーティリティ
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -168,17 +168,33 @@ pub fn fts_quote(s: &str) -> String {
 ///
 /// Combines `sanitize_fts_query` and `fts_expand_short_terms` into a single call.
 ///
+/// `vocab_table` names the `fts5vocab` virtual table to consult for short-term
+/// expansion (e.g. `"fts_chunks_vocab"` or `"messages_vocab"`). Must be created
+/// with the `row` or `col` vocabulary type — the `instance` type lacks the
+/// `cnt` column this query relies on. The value is interpolated into the SQL
+/// unescaped.
+///
 /// # Errors
 ///
 /// Returns:
 /// - [`SanitizeError::EmptyInput`] if `query` is empty or whitespace-only
 /// - [`SanitizeError::NoSearchableTerms`] if sanitization strips all searchable terms
 ///
-/// SQLite failures while consulting `fts_chunks_vocab` do not surface as
+/// SQLite failures while consulting the vocab table do not surface as
 /// `Err`; they are logged and treated as "no expansion".
-pub fn prepare_match_query(conn: &Connection, query: &str) -> Result<MatchFtsQuery, SanitizeError> {
+///
+/// # Panics
+///
+/// Panics if `vocab_table` is not a valid SQL identifier (ASCII alphanumerics
+/// and `_`, non-empty). The check runs in release builds to protect against
+/// SQL injection via untrusted identifiers.
+pub fn prepare_match_query(
+    conn: &Connection,
+    query: &str,
+    vocab_table: &str,
+) -> Result<MatchFtsQuery, SanitizeError> {
     let sanitized = sanitize_fts_query(query)?;
-    Ok(fts_expand_short_terms(conn, &sanitized))
+    Ok(fts_expand_short_terms(conn, &sanitized, vocab_table))
 }
 
 /// Expand a single short token via vocab prefix matching.
@@ -207,17 +223,38 @@ fn expand_token_via_vocab(stmt: &mut rusqlite::CachedStatement<'_>, token: &str)
     }
 }
 
-/// Expand short terms (1-2 chars) via `fts_chunks_vocab` prefix matching.
+/// Expand short terms (1-2 chars) via `fts5vocab` prefix matching.
 /// Falls back to quoting as-is when the vocab table is unavailable.
+///
+/// `vocab_table` must be an `fts5vocab` of type `row` or `col` (the SQL
+/// references the `term` and `cnt` columns). The name is interpolated into
+/// the SQL unescaped.
+///
+/// # Panics
+///
+/// Panics if `vocab_table` is not a valid SQL identifier: non-empty,
+/// leading character ASCII alphabetic or `_`, remaining characters ASCII
+/// alphanumeric or `_`.
 pub(crate) fn fts_expand_short_terms(
     conn: &Connection,
     query: &SanitizedFtsQuery,
+    vocab_table: &str,
 ) -> MatchFtsQuery {
-    let mut stmt = match conn.prepare_cached(
-        "SELECT term FROM fts_chunks_vocab \
+    let mut chars = vocab_table.chars();
+    let head_ok = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+    let tail_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    assert!(
+        head_ok && tail_ok,
+        "vocab_table must be a valid SQL identifier: {vocab_table:?}"
+    );
+    let sql = format!(
+        "SELECT term FROM {vocab_table} \
          WHERE term LIKE ?1 ESCAPE '\\' \
-         ORDER BY cnt DESC LIMIT 25",
-    ) {
+         ORDER BY cnt DESC LIMIT 25"
+    );
+    let mut stmt = match conn.prepare_cached(&sql) {
         Ok(s) => Some(s),
         Err(rusqlite::Error::SqliteFailure(_, Some(ref msg))) if msg.contains("no such table") => {
             None
@@ -301,14 +338,15 @@ mod tests {
     #[test]
     fn expand_long_term_quoted_as_is() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("authentication"));
+        let result =
+            fts_expand_short_terms(&conn, &sanitized("authentication"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"authentication\"");
     }
 
     #[test]
     fn expand_short_term_with_vocab_matches() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("au"));
+        let result = fts_expand_short_terms(&conn, &sanitized("au"), "fts_chunks_vocab");
         assert!(result.as_str().contains("\"audit\""), "{}", result.as_str());
         assert!(
             result.as_str().contains("\"authentication\""),
@@ -321,14 +359,14 @@ mod tests {
     #[test]
     fn expand_short_term_no_matches() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("zz"));
+        let result = fts_expand_short_terms(&conn, &sanitized("zz"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"zz\"");
     }
 
     #[test]
     fn expand_mixed_short_and_long() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("au login"));
+        let result = fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab");
         assert!(result.as_str().contains("\"login\""), "{}", result.as_str());
         assert!(result.as_str().contains(" OR "), "{}", result.as_str());
     }
@@ -338,20 +376,20 @@ mod tests {
         let conn = setup_fts_db();
         // NOT (3 chars) and OR (2 chars) must both be quoted as-is,
         // not expanded via vocab (e.g. OR must not become "order" OR ...).
-        let result = fts_expand_short_terms(&conn, &sanitized("NOT secret"));
+        let result = fts_expand_short_terms(&conn, &sanitized("NOT secret"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"NOT\" \"secret\"");
 
-        let result = fts_expand_short_terms(&conn, &sanitized("OR"));
+        let result = fts_expand_short_terms(&conn, &sanitized("OR"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"OR\"");
 
-        let result = fts_expand_short_terms(&conn, &sanitized("foo or bar"));
+        let result = fts_expand_short_terms(&conn, &sanitized("foo or bar"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"foo\" \"or\" \"bar\"");
     }
 
     #[test]
     fn expand_special_chars_escaped() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("a%"));
+        let result = fts_expand_short_terms(&conn, &sanitized("a%"), "fts_chunks_vocab");
         assert!(
             result.as_str().contains("\"audit\"") || result.as_str() == "\"a%\"",
             "{}",
@@ -362,21 +400,21 @@ mod tests {
     #[test]
     fn expand_without_vocab_table_degrades() {
         let conn = Connection::open_in_memory().unwrap();
-        let result = fts_expand_short_terms(&conn, &sanitized("au login"));
+        let result = fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab");
         assert_eq!(result.as_str(), "\"au\" \"login\"");
     }
 
     #[test]
     fn expand_single_char_term() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("a"));
+        let result = fts_expand_short_terms(&conn, &sanitized("a"), "fts_chunks_vocab");
         assert!(result.as_str().contains("\"audit\"") || result.as_str() == "\"a\"");
     }
 
     #[test]
     fn prepare_match_query_end_to_end() {
         let conn = setup_fts_db();
-        let result = prepare_match_query(&conn, "au login").unwrap();
+        let result = prepare_match_query(&conn, "au login", "fts_chunks_vocab").unwrap();
         assert!(result.as_str().contains("\"login\""), "{}", result.as_str());
         assert!(result.as_str().contains(" OR "), "{}", result.as_str());
     }
@@ -385,7 +423,7 @@ mod tests {
     fn prepare_match_query_empty_input() {
         let conn = setup_fts_db();
         assert_eq!(
-            prepare_match_query(&conn, ""),
+            prepare_match_query(&conn, "", "fts_chunks_vocab"),
             Err(SanitizeError::EmptyInput)
         );
     }
@@ -393,8 +431,22 @@ mod tests {
     #[test]
     fn prepare_match_query_operators_are_quoted() {
         let conn = setup_fts_db();
-        let result = prepare_match_query(&conn, "foo OR bar").unwrap();
+        let result = prepare_match_query(&conn, "foo OR bar", "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"foo\" \"OR\" \"bar\"");
+    }
+
+    #[test]
+    #[should_panic(expected = "vocab_table must be a valid SQL identifier")]
+    fn expand_rejects_leading_digit_vocab_name() {
+        let conn = setup_fts_db();
+        let _ = fts_expand_short_terms(&conn, &sanitized("au"), "1vocab");
+    }
+
+    #[test]
+    #[should_panic(expected = "vocab_table must be a valid SQL identifier")]
+    fn expand_rejects_empty_vocab_name() {
+        let conn = setup_fts_db();
+        let _ = fts_expand_short_terms(&conn, &sanitized("au"), "");
     }
 
     fn sanitized(s: &str) -> SanitizedFtsQuery {


### PR DESCRIPTION
## 概要と動機

`prepare_match_query` と `fts_expand_short_terms` の vocab テーブル名をハードコードから引数へ切り出し、呼び出し側が任意のテーブル名を渡せるようにする。

旧 API では SQL 内に `fts_chunks_vocab` が固定記述されていたため、異なるテーブル名を持つ依存クレート（例: recall の `messages_vocab`）では短語展開が無音で無効化されていた。

## 変更内容

- `prepare_match_query(conn, query, vocab_table: &str)` — 第三引数を追加（破壊的変更）
- `pub(crate) fts_expand_short_terms(conn, query, vocab_table: &str)` — 同様に第三引数を追加
- `vocab_table` の実行時バリデーションを `assert!` で実施（空文字禁止、先頭 `[A-Za-z_]`、残余 `[A-Za-z0-9_]`）。`debug_assert!` ではなく `assert!` — public API 契約として release ビルドでも保証する
- `# Panics` セクションを rustdoc に追加。fts5vocab の `row`/`col` インスタンスタイプ要件（`cnt` 列を持たない instance タイプは不可）を明記
- 13 箇所の呼び出しサイトを更新し、既存動作と同じ `"fts_chunks_vocab"` を渡すように修正
- 無効な vocab 名でパニックすることを確認するリグレッションテスト 2 件を追加
- README の古いサンプルコードを最新 API に合わせて修正
- Cargo の推移的依存関係を `cargo update` で更新

## 設計判断

- `assert!` を採用（`debug_assert!` 不使用）: vocab テーブル名は SQL に直接展開されるため、release ビルドでも不正な値を即座に検出してパニックさせる方が、SQLite のエラーや無音の誤動作より安全
- 引数として渡す設計: 呼び出しごとに異なるテーブルを使えるよう柔軟性を確保し、依存の注入を明示的にする

## スコープ

- **対象外**: 依存クレート（sae / yomu / recall）の更新は Phase 2 として別途実施予定

## テスト方法

1. `cargo test` を実行し、全テストがパスすることを確認する（40 passed）
2. リグレッションテスト 2 件が `should_panic` でパスすることを確認する
   - 空文字列 `""` を渡したときにパニックする
   - 先頭が数字 `"1vocab"` の名前でパニックする

## 破壊的変更

`prepare_match_query` および `fts_expand_short_terms` のシグネチャが変更された。依存クレートは以下のとおり更新が必要。

| クレート | 必要な変更 | 備考 |
| --- | --- | --- |
| sae | rev を bump し、`"fts_chunks_vocab"` を渡す | 動作変更なし |
| yomu | rev を bump し、`"fts_chunks_vocab"` を渡す | 動作変更なし |
| recall | rev を bump し、`"messages_vocab"` を渡す。ローカルの `sanitize_fts_query` / `expand_short_terms` を削除 | recall#13 クローズ、短語展開が復元される |