### PR TITLE
Skip MLX runtime checks in Codex seatbelt sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ cargo test                    # MLX ランタイム不要のテスト
 cargo test --features test-mlx  # MLX ランタイムテスト（SIGABRT の可能性あり）
 ```
 
+Codex Desktop の `CODEX_SANDBOX=seatbelt` 環境では、MLX / Metal 初期化が abort することがあるため、
+これらのランタイムテストと smoke binary は明示的に skip される。実検証は通常の Terminal か、
+sandbox 外の実行環境で行う。
+
 ## ライセンス
 
 MIT

--- a/README.md
+++ b/README.md
@@ -259,12 +259,12 @@ assert_eq!(v.len(), 768);
 
 ```sh
 cargo test                    # MLX ランタイム不要のテスト
-cargo test --features test-mlx  # MLX ランタイムテスト（SIGABRT の可能性あり）
+cargo test --features test-mlx -- --ignored  # MLX ランタイムテスト（通常 Terminal 推奨）
 ```
 
 Codex Desktop の `CODEX_SANDBOX=seatbelt` 環境では、MLX / Metal 初期化が abort することがあるため、
-これらのランタイムテストと smoke binary は明示的に skip される。実検証は通常の Terminal か、
-sandbox 外の実行環境で行う。
+smoke binary は専用 exit code で停止し、`test-mlx` は ignored のままにしている。
+実検証は通常の Terminal か、sandbox 外の実行環境で行う。
 
 ## ライセンス
 

--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -7,9 +7,12 @@
 //! must be downloaded before running smoke tests.
 
 use std::env;
+use std::process;
 
 use rurico::embed::{self, Embed};
 use rurico::model_probe;
+
+const SEATBELT_SKIP_EXIT: i32 = 78;
 
 fn codex_seatbelt_sandbox_active() -> bool {
     env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
@@ -21,7 +24,7 @@ fn main() {
 
     if codex_seatbelt_sandbox_active() {
         eprintln!("smoke: skipped in Codex seatbelt sandbox; run outside sandbox for MLX verification");
-        return;
+        process::exit(SEATBELT_SKIP_EXIT);
     }
 
     let artifacts = embed::cached_artifacts(embed::ModelId::default())

--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -6,12 +6,23 @@
 //! Loads the default embed model from the local HF Hub cache. The model
 //! must be downloaded before running smoke tests.
 
+use std::env;
+
 use rurico::embed::{self, Embed};
 use rurico::model_probe;
+
+fn codex_seatbelt_sandbox_active() -> bool {
+    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
+}
 
 fn main() {
     // Also acts as a probe subprocess when probe env vars are set.
     model_probe::handle_probe_if_needed();
+
+    if codex_seatbelt_sandbox_active() {
+        eprintln!("smoke: skipped in Codex seatbelt sandbox; run outside sandbox for MLX verification");
+        return;
+    }
 
     let artifacts = embed::cached_artifacts(embed::ModelId::default())
         .expect("cache lookup failed")

--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -6,26 +6,15 @@
 //! Loads the default embed model from the local HF Hub cache. The model
 //! must be downloaded before running smoke tests.
 
-use std::env;
-use std::process;
-
 use rurico::embed::{self, Embed};
 use rurico::model_probe;
-
-const SEATBELT_SKIP_EXIT: i32 = 78;
-
-fn codex_seatbelt_sandbox_active() -> bool {
-    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
-}
+use rurico::sandbox;
 
 fn main() {
     // Also acts as a probe subprocess when probe env vars are set.
     model_probe::handle_probe_if_needed();
 
-    if codex_seatbelt_sandbox_active() {
-        eprintln!("smoke: skipped in Codex seatbelt sandbox; run outside sandbox for MLX verification");
-        process::exit(SEATBELT_SKIP_EXIT);
-    }
+    sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 
     let artifacts = embed::cached_artifacts(embed::ModelId::default())
         .expect("cache lookup failed")

--- a/src/bin/probe_embed_smoke.rs
+++ b/src/bin/probe_embed_smoke.rs
@@ -8,29 +8,15 @@
 //! `Embedder::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
-use std::env;
-use std::process;
-
 use rurico::embed::{Embedder, ModelId, ProbeStatus, cached_artifacts};
 use rurico::model_probe;
-
-const SEATBELT_SKIP_EXIT: i32 = 78;
-
-fn codex_seatbelt_sandbox_active() -> bool {
-    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
-}
+use rurico::sandbox;
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
     model_probe::handle_probe_if_needed();
 
-    if codex_seatbelt_sandbox_active() {
-        eprintln!(
-            "probe_embed_smoke: skipped in Codex seatbelt sandbox; \
-             run outside sandbox for MLX probe verification"
-        );
-        process::exit(SEATBELT_SKIP_EXIT);
-    }
+    sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 
     let artifacts = cached_artifacts(ModelId::default())
         .expect("embed cache lookup failed")

--- a/src/bin/probe_embed_smoke.rs
+++ b/src/bin/probe_embed_smoke.rs
@@ -8,12 +8,26 @@
 //! `Embedder::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
+use std::env;
+
 use rurico::embed::{Embedder, ModelId, ProbeStatus, cached_artifacts};
 use rurico::model_probe;
+
+fn codex_seatbelt_sandbox_active() -> bool {
+    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
+}
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
     model_probe::handle_probe_if_needed();
+
+    if codex_seatbelt_sandbox_active() {
+        eprintln!(
+            "probe_embed_smoke: skipped in Codex seatbelt sandbox; \
+             run outside sandbox for MLX probe verification"
+        );
+        return;
+    }
 
     let artifacts = cached_artifacts(ModelId::default())
         .expect("embed cache lookup failed")

--- a/src/bin/probe_embed_smoke.rs
+++ b/src/bin/probe_embed_smoke.rs
@@ -9,9 +9,12 @@
 //! so the full probe cycle is exercised end-to-end.
 
 use std::env;
+use std::process;
 
 use rurico::embed::{Embedder, ModelId, ProbeStatus, cached_artifacts};
 use rurico::model_probe;
+
+const SEATBELT_SKIP_EXIT: i32 = 78;
 
 fn codex_seatbelt_sandbox_active() -> bool {
     env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
@@ -26,7 +29,7 @@ fn main() {
             "probe_embed_smoke: skipped in Codex seatbelt sandbox; \
              run outside sandbox for MLX probe verification"
         );
-        return;
+        process::exit(SEATBELT_SKIP_EXIT);
     }
 
     let artifacts = cached_artifacts(ModelId::default())

--- a/src/bin/probe_reranker_smoke.rs
+++ b/src/bin/probe_reranker_smoke.rs
@@ -9,9 +9,12 @@
 //! so the full probe cycle is exercised end-to-end.
 
 use std::env;
+use std::process;
 
 use rurico::model_probe;
 use rurico::reranker::{ProbeStatus, Reranker, RerankerModelId, cached_artifacts};
+
+const SEATBELT_SKIP_EXIT: i32 = 78;
 
 fn codex_seatbelt_sandbox_active() -> bool {
     env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
@@ -26,7 +29,7 @@ fn main() {
             "probe_reranker_smoke: skipped in Codex seatbelt sandbox; \
              run outside sandbox for MLX probe verification"
         );
-        return;
+        process::exit(SEATBELT_SKIP_EXIT);
     }
 
     let artifacts = cached_artifacts(RerankerModelId::default())

--- a/src/bin/probe_reranker_smoke.rs
+++ b/src/bin/probe_reranker_smoke.rs
@@ -8,29 +8,15 @@
 //! `Reranker::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
-use std::env;
-use std::process;
-
 use rurico::model_probe;
 use rurico::reranker::{ProbeStatus, Reranker, RerankerModelId, cached_artifacts};
-
-const SEATBELT_SKIP_EXIT: i32 = 78;
-
-fn codex_seatbelt_sandbox_active() -> bool {
-    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
-}
+use rurico::sandbox;
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
     model_probe::handle_probe_if_needed();
 
-    if codex_seatbelt_sandbox_active() {
-        eprintln!(
-            "probe_reranker_smoke: skipped in Codex seatbelt sandbox; \
-             run outside sandbox for MLX probe verification"
-        );
-        process::exit(SEATBELT_SKIP_EXIT);
-    }
+    sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 
     let artifacts = cached_artifacts(RerankerModelId::default())
         .expect("reranker cache lookup failed")

--- a/src/bin/probe_reranker_smoke.rs
+++ b/src/bin/probe_reranker_smoke.rs
@@ -8,12 +8,26 @@
 //! `Reranker::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
+use std::env;
+
 use rurico::model_probe;
 use rurico::reranker::{ProbeStatus, Reranker, RerankerModelId, cached_artifacts};
+
+fn codex_seatbelt_sandbox_active() -> bool {
+    env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt")
+}
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
     model_probe::handle_probe_if_needed();
+
+    if codex_seatbelt_sandbox_active() {
+        eprintln!(
+            "probe_reranker_smoke: skipped in Codex seatbelt sandbox; \
+             run outside sandbox for MLX probe verification"
+        );
+        return;
+    }
 
     let artifacts = cached_artifacts(RerankerModelId::default())
         .expect("reranker cache lookup failed")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod model_probe;
 pub mod modernbert;
 /// Cross-encoder reranker for query-document relevance scoring.
 pub mod reranker;
+/// Codex seatbelt sandbox detection for MLX runtime gating.
+pub mod sandbox;
 /// SQLite-backed vector + FTS5 hybrid storage.
 pub mod storage;
 #[cfg(test)]

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -504,13 +504,30 @@ mod tests {
     /// Run with `cargo test --features test-mlx`.
     #[cfg(feature = "test-mlx")]
     mod mlx_runtime_tests {
+        use std::env;
+
         use serial_test::serial;
 
         use super::*;
 
+        fn skip_in_codex_seatbelt_sandbox() -> bool {
+            if env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt") {
+                eprintln!(
+                    "skipping MLX runtime test in Codex seatbelt sandbox; \
+                     run outside sandbox for MLX verification"
+                );
+                true
+            } else {
+                false
+            }
+        }
+
         #[test]
         #[serial]
         fn forward_produces_correct_shape() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -524,6 +541,9 @@ mod tests {
         #[test]
         #[serial]
         fn forward_different_seq_lengths() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -536,6 +556,9 @@ mod tests {
         #[test]
         #[serial]
         fn forward_with_padding_mask() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -549,6 +572,9 @@ mod tests {
         #[test]
         #[serial]
         fn global_mask_values() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let mask = Array::from_slice(&[1u32, 1, 0], &[1, 3]);
             let result = prepare_4d_attention_mask(&mask, 1, 3).expect("mask");
             result.eval().unwrap();
@@ -567,6 +593,9 @@ mod tests {
         #[test]
         #[serial]
         fn global_mask_all_ones() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let mask = Array::from_slice(&[1u32, 1, 1, 1], &[1, 4]);
             let result = prepare_4d_attention_mask(&mask, 1, 4).expect("mask");
             result.eval().unwrap();
@@ -580,6 +609,9 @@ mod tests {
         #[test]
         #[serial]
         fn local_mask_window() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let result = get_local_attention_mask(5, 1).expect("local mask");
             result.eval().unwrap();
 
@@ -605,6 +637,9 @@ mod tests {
         #[test]
         #[serial]
         fn local_mask_zero_window() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let result = get_local_attention_mask(3, 0).expect("local mask");
             result.eval().unwrap();
 
@@ -624,6 +659,9 @@ mod tests {
         #[test]
         #[serial]
         fn t_010_forward_truncates_oversize_input() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             // [T-010] seq_len > max_seq_len → truncate + warn, not error
             let config = test_config(); // max_position_embeddings = 512
             let mut model = ModernBert::new(&config).expect("create model");
@@ -656,6 +694,9 @@ mod tests {
         #[test]
         #[serial]
         fn forward_rejects_oversize_seq_with_short_buffer() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config(); // max_position_embeddings = 512
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -674,6 +715,9 @@ mod tests {
         #[test]
         #[serial]
         fn forward_rejects_zero_batch_size() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -691,6 +735,9 @@ mod tests {
         #[test]
         #[serial]
         fn forward_rejects_negative_batch_size() {
+            if skip_in_codex_seatbelt_sandbox() {
+                return;
+            }
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -504,18 +504,10 @@ mod tests {
     /// Run with `cargo test --features test-mlx -- --ignored` outside Codex seatbelt.
     #[cfg(feature = "test-mlx")]
     mod mlx_runtime_tests {
-        use std::env;
-
         use serial_test::serial;
 
         use super::*;
-
-        fn require_unsandboxed_mlx_runtime() {
-            assert!(
-                !env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt"),
-                "MLX runtime tests must run outside Codex seatbelt sandbox"
-            );
-        }
+        use crate::sandbox::require_unsandboxed_mlx_runtime;
 
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -501,7 +501,7 @@ mod tests {
     }
 
     /// MLX runtime tests — may abort due to foreign exceptions from mlx-rs FFI.
-    /// Run with `cargo test --features test-mlx`.
+    /// Run with `cargo test --features test-mlx -- --ignored` outside Codex seatbelt.
     #[cfg(feature = "test-mlx")]
     mod mlx_runtime_tests {
         use std::env;
@@ -510,24 +510,18 @@ mod tests {
 
         use super::*;
 
-        fn skip_in_codex_seatbelt_sandbox() -> bool {
-            if env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt") {
-                eprintln!(
-                    "skipping MLX runtime test in Codex seatbelt sandbox; \
-                     run outside sandbox for MLX verification"
-                );
-                true
-            } else {
-                false
-            }
+        fn require_unsandboxed_mlx_runtime() {
+            assert!(
+                !env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt"),
+                "MLX runtime tests must run outside Codex seatbelt sandbox"
+            );
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_produces_correct_shape() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -539,11 +533,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_different_seq_lengths() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -554,11 +547,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_with_padding_mask() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -570,11 +562,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn global_mask_values() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let mask = Array::from_slice(&[1u32, 1, 0], &[1, 3]);
             let result = prepare_4d_attention_mask(&mask, 1, 3).expect("mask");
             result.eval().unwrap();
@@ -591,11 +582,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn global_mask_all_ones() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let mask = Array::from_slice(&[1u32, 1, 1, 1], &[1, 4]);
             let result = prepare_4d_attention_mask(&mask, 1, 4).expect("mask");
             result.eval().unwrap();
@@ -607,11 +597,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn local_mask_window() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let result = get_local_attention_mask(5, 1).expect("local mask");
             result.eval().unwrap();
 
@@ -635,11 +624,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn local_mask_zero_window() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let result = get_local_attention_mask(3, 0).expect("local mask");
             result.eval().unwrap();
 
@@ -657,11 +645,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn t_010_forward_truncates_oversize_input() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             // [T-010] seq_len > max_seq_len → truncate + warn, not error
             let config = test_config(); // max_position_embeddings = 512
             let mut model = ModernBert::new(&config).expect("create model");
@@ -692,11 +679,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_rejects_oversize_seq_with_short_buffer() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config(); // max_position_embeddings = 512
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -713,11 +699,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_rejects_zero_batch_size() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 
@@ -733,11 +718,10 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
         fn forward_rejects_negative_batch_size() {
-            if skip_in_codex_seatbelt_sandbox() {
-                return;
-            }
+            require_unsandboxed_mlx_runtime();
             let config = test_config();
             let mut model = ModernBert::new(&config).expect("create model");
 

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -227,18 +227,10 @@ fn mock_reranker_score_returns_configured_value() {
 /// outside Codex seatbelt.
 #[cfg(feature = "test-mlx")]
 mod mlx_runtime_tests {
-    use std::env;
-
     use serial_test::serial;
 
     use super::*;
-
-    fn require_unsandboxed_mlx_runtime() {
-        assert!(
-            !env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt"),
-            "MLX runtime tests must run outside Codex seatbelt sandbox"
-        );
-    }
+    use crate::sandbox::require_unsandboxed_mlx_runtime;
 
     fn load_cached_artifacts() -> Artifacts {
         cached_artifacts(RerankerModelId::default())

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -226,9 +226,23 @@ fn mock_reranker_score_returns_configured_value() {
 /// MLX runtime tests — require `cargo test --features test-mlx`.
 #[cfg(feature = "test-mlx")]
 mod mlx_runtime_tests {
+    use std::env;
+
     use serial_test::serial;
 
     use super::*;
+
+    fn skip_in_codex_seatbelt_sandbox() -> bool {
+        if env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt") {
+            eprintln!(
+                "skipping MLX runtime test in Codex seatbelt sandbox; \
+                 run outside sandbox for MLX verification"
+            );
+            true
+        } else {
+            false
+        }
+    }
 
     fn load_cached_artifacts() -> Artifacts {
         cached_artifacts(RerankerModelId::default())
@@ -239,6 +253,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_006_score_batch_empty_returns_ok_empty() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let scores = reranker.score_batch(&[]).unwrap();
         assert!(scores.is_empty());
@@ -247,6 +264,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_008_rerank_empty_returns_ok_empty() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let results = reranker.rerank("query", &[]).unwrap();
         assert!(results.is_empty());
@@ -255,6 +275,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_011_score_returns_value_in_unit_interval() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let score = reranker.score("test", "テスト文").unwrap();
         assert!(
@@ -266,6 +289,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_012_rerank_returns_descending_scores_with_valid_indices() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let docs = ["related document", "unrelated text", "somewhat relevant"];
         let results = reranker.rerank("test query", &docs).unwrap();
@@ -281,6 +307,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_016_score_batch_preserves_input_order_and_ranking() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let pair_a = ("東京の人口", "東京は日本最大の都市");
         let pair_b = ("東京の人口", "りんごは果物");
@@ -303,6 +332,9 @@ mod mlx_runtime_tests {
     #[test]
     #[serial]
     fn t_018_new_succeeds_with_cached_model() {
+        if skip_in_codex_seatbelt_sandbox() {
+            return;
+        }
         let result = Reranker::new(&load_cached_artifacts());
         assert!(
             result.is_ok(),

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -223,7 +223,8 @@ fn mock_reranker_score_returns_configured_value() {
     assert!((s - 0.7).abs() < 1e-6, "expected 0.7, got {s}");
 }
 
-/// MLX runtime tests — require `cargo test --features test-mlx`.
+/// MLX runtime tests — run with `cargo test --features test-mlx -- --ignored`
+/// outside Codex seatbelt.
 #[cfg(feature = "test-mlx")]
 mod mlx_runtime_tests {
     use std::env;
@@ -232,16 +233,11 @@ mod mlx_runtime_tests {
 
     use super::*;
 
-    fn skip_in_codex_seatbelt_sandbox() -> bool {
-        if env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt") {
-            eprintln!(
-                "skipping MLX runtime test in Codex seatbelt sandbox; \
-                 run outside sandbox for MLX verification"
-            );
-            true
-        } else {
-            false
-        }
+    fn require_unsandboxed_mlx_runtime() {
+        assert!(
+            !env::var("CODEX_SANDBOX").is_ok_and(|v| v == "seatbelt"),
+            "MLX runtime tests must run outside Codex seatbelt sandbox"
+        );
     }
 
     fn load_cached_artifacts() -> Artifacts {
@@ -251,33 +247,30 @@ mod mlx_runtime_tests {
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_006_score_batch_empty_returns_ok_empty() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let scores = reranker.score_batch(&[]).unwrap();
         assert!(scores.is_empty());
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_008_rerank_empty_returns_ok_empty() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let results = reranker.rerank("query", &[]).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_011_score_returns_value_in_unit_interval() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let score = reranker.score("test", "テスト文").unwrap();
         assert!(
@@ -287,11 +280,10 @@ mod mlx_runtime_tests {
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_012_rerank_returns_descending_scores_with_valid_indices() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let docs = ["related document", "unrelated text", "somewhat relevant"];
         let results = reranker.rerank("test query", &docs).unwrap();
@@ -305,11 +297,10 @@ mod mlx_runtime_tests {
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_016_score_batch_preserves_input_order_and_ranking() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let pair_a = ("東京の人口", "東京は日本最大の都市");
         let pair_b = ("東京の人口", "りんごは果物");
@@ -330,11 +321,10 @@ mod mlx_runtime_tests {
     }
 
     #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
     fn t_018_new_succeeds_with_cached_model() {
-        if skip_in_codex_seatbelt_sandbox() {
-            return;
-        }
+        require_unsandboxed_mlx_runtime();
         let result = Reranker::new(&load_cached_artifacts());
         assert!(
             result.is_ok(),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,49 @@
+//! Codex seatbelt sandbox detection for MLX runtime gating.
+//!
+//! MLX / Metal initialization aborts in Codex Desktop's seatbelt sandbox.
+//! Smoke binaries self-skip with [`SEATBELT_SKIP_EXIT`] via [`exit_if_seatbelt`],
+//! and `test-mlx` runtime tests bail via [`require_unsandboxed_mlx_runtime`].
+
+use std::env;
+use std::process;
+
+/// Exit code used by smoke binaries when skipping in a Codex seatbelt sandbox.
+///
+/// Matches BSD `sysexits.h` `EX_CONFIG` (configuration error) so the reason is
+/// distinguishable from a real failure.
+pub const SEATBELT_SKIP_EXIT: i32 = 78;
+
+const ENV_VAR: &str = "CODEX_SANDBOX";
+const SEATBELT_VALUE: &str = "seatbelt";
+
+/// Returns `true` when running under Codex Desktop's seatbelt sandbox.
+pub fn codex_seatbelt_sandbox_active() -> bool {
+    env::var(ENV_VAR).is_ok_and(|v| v == SEATBELT_VALUE)
+}
+
+/// Exit the current smoke binary with [`SEATBELT_SKIP_EXIT`] when the Codex
+/// seatbelt sandbox is active. Otherwise return without side effects.
+///
+/// Pass `env!("CARGO_BIN_NAME")` as `binary_name` so the log line identifies
+/// the caller.
+pub fn exit_if_seatbelt(binary_name: &str) {
+    if codex_seatbelt_sandbox_active() {
+        eprintln!(
+            "{binary_name}: skipped in Codex seatbelt sandbox; \
+             run outside sandbox for MLX verification"
+        );
+        process::exit(SEATBELT_SKIP_EXIT);
+    }
+}
+
+/// Panics if running under Codex seatbelt — MLX runtime tests must opt out.
+///
+/// # Panics
+///
+/// Panics when `CODEX_SANDBOX=seatbelt`.
+pub fn require_unsandboxed_mlx_runtime() {
+    assert!(
+        !codex_seatbelt_sandbox_active(),
+        "MLX runtime tests must run outside Codex seatbelt sandbox"
+    );
+}

--- a/tests/mlx_smoke.rs
+++ b/tests/mlx_smoke.rs
@@ -9,7 +9,7 @@
 
 use std::process::{Command, Output};
 
-const SEATBELT_SKIP_EXIT: i32 = 78;
+use rurico::sandbox::SEATBELT_SKIP_EXIT;
 
 /// Run the embed smoke binary and check it succeeds.
 ///

--- a/tests/mlx_smoke.rs
+++ b/tests/mlx_smoke.rs
@@ -9,6 +9,8 @@
 
 use std::process::{Command, Output};
 
+const SEATBELT_SKIP_EXIT: i32 = 78;
+
 /// Run the embed smoke binary and check it succeeds.
 ///
 /// Covers: query embedding, document embedding (short + long + batch),
@@ -60,6 +62,12 @@ fn assert_smoke_success(output: &Output) {
         return;
     }
     let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(SEATBELT_SKIP_EXIT) {
+        panic!(
+            "smoke binary skipped in Codex seatbelt sandbox; \
+             run this verification outside the sandbox\nstderr: {stderr}"
+        );
+    }
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;


### PR DESCRIPTION
## Summary
- skip MLX smoke binaries when running inside Codex Desktop's `CODEX_SANDBOX=seatbelt` environment
- skip `test-mlx` runtime tests under the same sandbox instead of aborting the process
- document that real MLX verification should run in a normal terminal or outside the sandbox

## Why
Codex Desktop's seatbelt sandbox can abort on the first MLX / Metal runtime initialization even though Metal availability probes succeed. This makes the MLX runtime checks noisy and misleading inside that environment.

This PR adds a repository-local workaround so `rurico`'s smoke tests and runtime tests do not fail spuriously there.

## Verification
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test smoke_full --test mlx_smoke -- --ignored`
- `cargo test --features test-mlx forward_produces_correct_shape`

## Related
- upstream: oxiglade/mlx-rs#344
