### PR TITLE
rerank の同点スコア時の順序を決定的にする

### DIFF
--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -212,7 +212,9 @@ pub trait Rerank: Send + Sync {
 
     /// Rerank documents by relevance to a query.
     ///
-    /// Returns `Vec<RankedResult>` sorted by score descending.
+    /// Returns `Vec<RankedResult>` sorted by score descending. Ties on
+    /// `score` are broken by ascending original input index, so repeated
+    /// calls with identical scores produce identical ordering.
     fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<RankedResult>, RerankerError>;
 }
 
@@ -275,8 +277,9 @@ impl Reranker {
 
     /// Rerank documents by relevance to a query.
     ///
-    /// Returns `Vec<RankedResult>` sorted by score descending. Each result
-    /// contains the original index in `documents` and the relevance score.
+    /// Returns `Vec<RankedResult>` sorted by score descending, with ties on
+    /// `score` broken by ascending original input index. Each result contains
+    /// the original index in `documents` and the relevance score.
     pub fn rerank(
         &self,
         query: &str,

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -329,7 +329,11 @@ fn sort_results(scores: &[f32]) -> Vec<RankedResult> {
         .enumerate()
         .map(|(index, &score)| RankedResult { index, score })
         .collect();
-    results.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+    results.sort_unstable_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| a.index.cmp(&b.index))
+    });
     results
 }
 

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -54,6 +54,7 @@ fn t_007_sort_results_descending_by_score() {
 
 #[test]
 fn t_007b_sort_results_ties_break_by_original_index() {
+    // scores: [0.5, 0.7, 0.7, 0.5] — desc by score, asc by index on ties.
     let scores = vec![0.5, 0.7, 0.7, 0.5];
     let results = sort_results(&scores);
     let indices: Vec<usize> = results.iter().map(|r| r.index).collect();

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -53,6 +53,14 @@ fn t_007_sort_results_descending_by_score() {
 }
 
 #[test]
+fn t_007b_sort_results_ties_break_by_original_index() {
+    let scores = vec![0.5, 0.7, 0.7, 0.5];
+    let results = sort_results(&scores);
+    let indices: Vec<usize> = results.iter().map(|r| r.index).collect();
+    assert_eq!(indices, vec![1, 2, 0, 3]);
+}
+
+#[test]
 fn t_013_cache_lookup_returns_some_when_all_files_present() {
     let dir = tempfile::tempdir().unwrap();
     let model = RerankerModelId::RuriV3Reranker310m;


### PR DESCRIPTION
## 概要
- `sort_results` の `sort_unstable_by` に二次キー `.then_with(|a, b| a.index.cmp(&b.index))` を追加し、score が等しい場合は元の入力 index 昇順で並び替え
- 実行ごとに同じスコア群で同じ順序を返すようになり、ページング / スナップショット / CLI 出力の安定性を担保
- 回帰テスト `t_007b_sort_results_ties_break_by_original_index` を追加。入力スコアと期待順序のマッピングをコメントで明記
- 並び替え契約の観察可能化のため、`Rerank` trait と `Reranker::rerank` 両方の rustdoc に "ties broken by ascending original input index" を明記

## 背景
`sort_results` は従来 `sort_unstable_by` でスコアのみを比較していたため、同じスコアを持つ複数のドキュメントの相対順序が未規定だった。これによりページング、スナップショット、CLI 出力の再現性が損なわれ、ユーザー側に「前回と並びが違う」という体感バグが発生し得た。本 PR では安定した二次キー(元入力の index 昇順)で tie-break を入れ、rustdoc で観察可能な契約として明文化する。

## 検証
- `cargo test --lib reranker` → 26 passed
- `cargo test` (全体) → green
- `cargo clippy --all-targets --all-features -- -D warnings` → クリーン

## ブランチ名に関する注記
本ブランチ名は `codex/fix-rerank-tie-order-42` だが、実体的に対応する Issue は **#40** (`enhancement: make rerank ordering deterministic for equal scores`)。Issue #42 は modernbert config bounds の別件で、PR #45 でマージ済み。自動生成時の番号誤記のため、本 PR は #40 をクローズする。

Closes #40