### PR TITLE
FTS クエリ準備時の失敗を typed error として公開

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,20 @@ match prepare_match_query(&conn, user_input, "fts_chunks_vocab") {
     Err(SanitizeError::NoSearchableTerms) => {
         // NEAR() グループのみ等、検索可能な語がない
     }
+    Err(SanitizeError::InvalidVocabTable(name)) => {
+        // 呼び出し側のスキーマ設定ミス
+        eprintln!("invalid vocab table: {name}");
+    }
+    Err(SanitizeError::VocabLookupFailed(reason)) => {
+        // vocab テーブル参照中の想定外 SQLite 障害
+        eprintln!("fts vocab lookup failed: {reason}");
+    }
 }
 ```
 
-第3引数の `vocab_table` は `fts5vocab` 仮想テーブル名を受け取る。呼び出し側のスキーマ規約に応じて `"fts_chunks_vocab"` や `"messages_vocab"` などを指定する。`row` または `col` 型の vocabulary のみ対応する（`instance` 型には `cnt` カラムが無いため）。値はSQLにエスケープなしで埋め込まれるため、SQL identifier として妥当な文字列（先頭が ASCII 英字または `_`、以降 ASCII 英数字または `_`）のみ許容され、違反すると panic する。
+第3引数の `vocab_table` は `fts5vocab` 仮想テーブル名を受け取る。呼び出し側のスキーマ規約に応じて `"fts_chunks_vocab"` や `"messages_vocab"` などを指定する。`row` または `col` 型の vocabulary のみ対応する（`instance` 型には `cnt` カラムが無いため）。値はSQLにエスケープなしで埋め込まれるため、SQL identifier として妥当な文字列（先頭が ASCII 英字または `_`、以降 ASCII 英数字または `_`）のみ許容され、違反した場合は `SanitizeError::InvalidVocabTable` を返す。
 
-`NEAR()` グループ、`^`/`+`/`-` プレフィックス、コロン、不均衡な引用符は内部で無害化される。`AND`/`OR`/`NOT` のようなoperator-like keywordは、前後に非operatorの語がある場合のみliteral termとして引用符で囲まれる。前後が欠けたdangling operator（例: 先頭の `NOT`、NEAR除去後に孤立した `OR`）は除去される。短い語（1-2文字）は指定した vocab テーブルがあればprefix展開される（なければそのまま引用）。
+`NEAR()` グループ、`^`/`+`/`-` プレフィックス、コロン、不均衡な引用符は内部で無害化される。`AND`/`OR`/`NOT` のようなoperator-like keywordは、前後に非operatorの語がある場合のみliteral termとして引用符で囲まれる。前後が欠けたdangling operator（例: 先頭の `NOT`、NEAR除去後に孤立した `OR`）は除去される。短い語（1-2文字）は指定した vocab テーブルがあればprefix展開される。vocab テーブルが存在しない場合だけはそのまま引用に劣化し、それ以外の SQLite 障害は `SanitizeError::VocabLookupFailed` を返す。
 
 ### ハイブリッド検索ユーティリティ
 

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -219,13 +219,19 @@ fn expand_token_via_vocab(
             Ok(Some(format!("({})", quoted.join(" OR "))))
         }
         Ok(_) => Ok(None),
-        Err(rusqlite::Error::SqliteFailure(_, Some(ref msg))) if msg.contains("no such table") => {
-            Ok(None)
-        }
-        Err(e) => {
-            Err(SanitizeError::VocabLookupFailed(e.to_string()))
-        }
+        Err(e) if is_missing_table_error(&e) => Ok(None),
+        Err(e) => Err(SanitizeError::VocabLookupFailed(e.to_string())),
     }
+}
+
+// SQLite reports missing tables via `SqliteFailure` with an English `errmsg`
+// containing "no such table". The extended code (`SQLITE_ERROR = 1`) covers
+// many other causes, so the message substring is the only portable signal.
+fn is_missing_table_error(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains("no such table")
+    )
 }
 
 fn is_valid_sql_identifier(value: &str) -> bool {
@@ -238,12 +244,21 @@ fn is_valid_sql_identifier(value: &str) -> bool {
 }
 
 /// Expand short terms (1-2 chars) via `fts5vocab` prefix matching.
-/// Falls back to quoting as-is when the vocab table is unavailable.
+/// Falls back to quoting as-is when the vocab table is missing.
 ///
 /// `vocab_table` must be an `fts5vocab` of type `row` or `col` (the SQL
 /// references the `term` and `cnt` columns). The name is interpolated into
 /// the SQL unescaped.
 ///
+/// # Errors
+///
+/// Returns:
+/// - [`SanitizeError::InvalidVocabTable`] if `vocab_table` is not a valid
+///   SQL identifier (non-empty, leading character ASCII alphabetic or `_`,
+///   remaining characters ASCII alphanumeric or `_`).
+/// - [`SanitizeError::VocabLookupFailed`] if SQLite fails while preparing
+///   or executing the vocab query for any reason other than the vocab table
+///   being absent.
 pub(crate) fn fts_expand_short_terms(
     conn: &Connection,
     query: &SanitizedFtsQuery,
@@ -259,12 +274,8 @@ pub(crate) fn fts_expand_short_terms(
     );
     let mut stmt = match conn.prepare_cached(&sql) {
         Ok(s) => Some(s),
-        Err(rusqlite::Error::SqliteFailure(_, Some(ref msg))) if msg.contains("no such table") => {
-            None
-        }
-        Err(e) => {
-            return Err(SanitizeError::VocabLookupFailed(e.to_string()));
-        }
+        Err(e) if is_missing_table_error(&e) => None,
+        Err(e) => return Err(SanitizeError::VocabLookupFailed(e.to_string())),
     };
 
     let mut parts = Vec::new();
@@ -496,6 +507,42 @@ mod tests {
             matches!(result, Err(SanitizeError::VocabLookupFailed(_))),
             "expected vocab lookup failure, got {result:?}"
         );
+    }
+
+    #[test]
+    fn prepare_match_query_with_missing_vocab_degrades() {
+        let conn = Connection::open_in_memory().unwrap();
+        let result = prepare_match_query(&conn, "au login", "fts_chunks_vocab").unwrap();
+        assert_eq!(result.as_str(), "\"au\" \"login\"");
+    }
+
+    fn prepare_err(conn: &Connection, sql: &str) -> rusqlite::Error {
+        let Err(e) = conn.prepare_cached(sql) else {
+            panic!("expected prepare_cached to fail for: {sql}");
+        };
+        e
+    }
+
+    #[test]
+    fn is_missing_table_error_detects_sqlite_no_such_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        let err = prepare_err(&conn, "SELECT * FROM definitely_nonexistent");
+        assert!(is_missing_table_error(&err), "got {err:?}");
+    }
+
+    #[test]
+    fn is_missing_table_error_rejects_syntax_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        let err = prepare_err(&conn, "SELECT FROM");
+        assert!(!is_missing_table_error(&err), "got {err:?}");
+    }
+
+    #[test]
+    fn is_missing_table_error_rejects_missing_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE t(x INTEGER)", []).unwrap();
+        let err = prepare_err(&conn, "SELECT y FROM t");
+        assert!(!is_missing_table_error(&err), "got {err:?}");
     }
 
     fn sanitized(s: &str) -> SanitizedFtsQuery {

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -100,6 +100,12 @@ pub enum SanitizeError {
     /// (e.g. only `NEAR()` groups or prefix characters).
     #[error("search query contains no searchable terms")]
     NoSearchableTerms,
+    /// The supplied vocab table name is not a safe SQL identifier.
+    #[error("invalid vocab table name: {0:?}")]
+    InvalidVocabTable(String),
+    /// SQLite failed while consulting the vocab table for short-term expansion.
+    #[error("fts vocab lookup failed: {0}")]
+    VocabLookupFailed(String),
 }
 
 /// Neutralize FTS5 special syntax in user queries: `NEAR()` grouping,
@@ -180,28 +186,25 @@ pub fn fts_quote(s: &str) -> String {
 /// - [`SanitizeError::EmptyInput`] if `query` is empty or whitespace-only
 /// - [`SanitizeError::NoSearchableTerms`] if sanitization strips all searchable terms
 ///
-/// SQLite failures while consulting the vocab table do not surface as
-/// `Err`; they are logged and treated as "no expansion".
-///
-/// # Panics
-///
-/// Panics if `vocab_table` is not a valid SQL identifier (ASCII alphanumerics
-/// and `_`, non-empty). The check runs in release builds to protect against
-/// SQL injection via untrusted identifiers.
+/// SQLite failures while consulting the vocab table surface as `Err`, except
+/// for the specific "no such table" case which degrades to "no expansion".
 pub fn prepare_match_query(
     conn: &Connection,
     query: &str,
     vocab_table: &str,
 ) -> Result<MatchFtsQuery, SanitizeError> {
     let sanitized = sanitize_fts_query(query)?;
-    Ok(fts_expand_short_terms(conn, &sanitized, vocab_table))
+    fts_expand_short_terms(conn, &sanitized, vocab_table)
 }
 
 /// Expand a single short token via vocab prefix matching.
 ///
 /// Returns `Some(expanded_group)` when matches are found, `None` when the
-/// vocab lookup fails or returns no results (caller falls back to quoting as-is).
-fn expand_token_via_vocab(stmt: &mut rusqlite::CachedStatement<'_>, token: &str) -> Option<String> {
+/// vocab lookup returns no results or the vocab table disappeared.
+fn expand_token_via_vocab(
+    stmt: &mut rusqlite::CachedStatement<'_>,
+    token: &str,
+) -> Result<Option<String>, SanitizeError> {
     let escaped = token
         .replace('\\', "\\\\")
         .replace('%', "\\%")
@@ -213,14 +216,25 @@ fn expand_token_via_vocab(stmt: &mut rusqlite::CachedStatement<'_>, token: &str)
     {
         Ok(terms) if !terms.is_empty() => {
             let quoted: Vec<String> = terms.iter().map(|t| fts_quote(t)).collect();
-            Some(format!("({})", quoted.join(" OR ")))
+            Ok(Some(format!("({})", quoted.join(" OR "))))
         }
-        Ok(_) => None,
+        Ok(_) => Ok(None),
+        Err(rusqlite::Error::SqliteFailure(_, Some(ref msg))) if msg.contains("no such table") => {
+            Ok(None)
+        }
         Err(e) => {
-            log::warn!("fts vocab query failed: {e}");
-            None
+            Err(SanitizeError::VocabLookupFailed(e.to_string()))
         }
     }
+}
+
+fn is_valid_sql_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let head_ok = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+    let tail_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    head_ok && tail_ok
 }
 
 /// Expand short terms (1-2 chars) via `fts5vocab` prefix matching.
@@ -230,25 +244,14 @@ fn expand_token_via_vocab(stmt: &mut rusqlite::CachedStatement<'_>, token: &str)
 /// references the `term` and `cnt` columns). The name is interpolated into
 /// the SQL unescaped.
 ///
-/// # Panics
-///
-/// Panics if `vocab_table` is not a valid SQL identifier: non-empty,
-/// leading character ASCII alphabetic or `_`, remaining characters ASCII
-/// alphanumeric or `_`.
 pub(crate) fn fts_expand_short_terms(
     conn: &Connection,
     query: &SanitizedFtsQuery,
     vocab_table: &str,
-) -> MatchFtsQuery {
-    let mut chars = vocab_table.chars();
-    let head_ok = chars
-        .next()
-        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
-    let tail_ok = chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
-    assert!(
-        head_ok && tail_ok,
-        "vocab_table must be a valid SQL identifier: {vocab_table:?}"
-    );
+) -> Result<MatchFtsQuery, SanitizeError> {
+    if !is_valid_sql_identifier(vocab_table) {
+        return Err(SanitizeError::InvalidVocabTable(vocab_table.to_owned()));
+    }
     let sql = format!(
         "SELECT term FROM {vocab_table} \
          WHERE term LIKE ?1 ESCAPE '\\' \
@@ -260,8 +263,7 @@ pub(crate) fn fts_expand_short_terms(
             None
         }
         Err(e) => {
-            log::warn!("fts vocab prepare failed: {e}");
-            None
+            return Err(SanitizeError::VocabLookupFailed(e.to_string()));
         }
     };
 
@@ -272,10 +274,13 @@ pub(crate) fn fts_expand_short_terms(
             parts.push(fts_quote(token));
             continue;
         }
-        let expanded = stmt.as_mut().and_then(|s| expand_token_via_vocab(s, token));
+        let expanded = match stmt.as_mut() {
+            Some(s) => expand_token_via_vocab(s, token)?,
+            None => None,
+        };
         parts.push(expanded.unwrap_or_else(|| fts_quote(token)));
     }
-    MatchFtsQuery(parts.join(" "))
+    Ok(MatchFtsQuery(parts.join(" ")))
 }
 
 #[cfg(test)]
@@ -339,14 +344,15 @@ mod tests {
     fn expand_long_term_quoted_as_is() {
         let conn = setup_fts_db();
         let result =
-            fts_expand_short_terms(&conn, &sanitized("authentication"), "fts_chunks_vocab");
+            fts_expand_short_terms(&conn, &sanitized("authentication"), "fts_chunks_vocab")
+                .unwrap();
         assert_eq!(result.as_str(), "\"authentication\"");
     }
 
     #[test]
     fn expand_short_term_with_vocab_matches() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("au"), "fts_chunks_vocab");
+        let result = fts_expand_short_terms(&conn, &sanitized("au"), "fts_chunks_vocab").unwrap();
         assert!(result.as_str().contains("\"audit\""), "{}", result.as_str());
         assert!(
             result.as_str().contains("\"authentication\""),
@@ -359,14 +365,15 @@ mod tests {
     #[test]
     fn expand_short_term_no_matches() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("zz"), "fts_chunks_vocab");
+        let result = fts_expand_short_terms(&conn, &sanitized("zz"), "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"zz\"");
     }
 
     #[test]
     fn expand_mixed_short_and_long() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab");
+        let result =
+            fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab").unwrap();
         assert!(result.as_str().contains("\"login\""), "{}", result.as_str());
         assert!(result.as_str().contains(" OR "), "{}", result.as_str());
     }
@@ -376,20 +383,22 @@ mod tests {
         let conn = setup_fts_db();
         // NOT (3 chars) and OR (2 chars) must both be quoted as-is,
         // not expanded via vocab (e.g. OR must not become "order" OR ...).
-        let result = fts_expand_short_terms(&conn, &sanitized("NOT secret"), "fts_chunks_vocab");
+        let result =
+            fts_expand_short_terms(&conn, &sanitized("NOT secret"), "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"NOT\" \"secret\"");
 
-        let result = fts_expand_short_terms(&conn, &sanitized("OR"), "fts_chunks_vocab");
+        let result = fts_expand_short_terms(&conn, &sanitized("OR"), "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"OR\"");
 
-        let result = fts_expand_short_terms(&conn, &sanitized("foo or bar"), "fts_chunks_vocab");
+        let result =
+            fts_expand_short_terms(&conn, &sanitized("foo or bar"), "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"foo\" \"or\" \"bar\"");
     }
 
     #[test]
     fn expand_special_chars_escaped() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("a%"), "fts_chunks_vocab");
+        let result = fts_expand_short_terms(&conn, &sanitized("a%"), "fts_chunks_vocab").unwrap();
         assert!(
             result.as_str().contains("\"audit\"") || result.as_str() == "\"a%\"",
             "{}",
@@ -400,14 +409,15 @@ mod tests {
     #[test]
     fn expand_without_vocab_table_degrades() {
         let conn = Connection::open_in_memory().unwrap();
-        let result = fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab");
+        let result =
+            fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab").unwrap();
         assert_eq!(result.as_str(), "\"au\" \"login\"");
     }
 
     #[test]
     fn expand_single_char_term() {
         let conn = setup_fts_db();
-        let result = fts_expand_short_terms(&conn, &sanitized("a"), "fts_chunks_vocab");
+        let result = fts_expand_short_terms(&conn, &sanitized("a"), "fts_chunks_vocab").unwrap();
         assert!(result.as_str().contains("\"audit\"") || result.as_str() == "\"a\"");
     }
 
@@ -436,17 +446,56 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "vocab_table must be a valid SQL identifier")]
-    fn expand_rejects_leading_digit_vocab_name() {
+    fn prepare_match_query_rejects_invalid_vocab_table_name() {
         let conn = setup_fts_db();
-        let _ = fts_expand_short_terms(&conn, &sanitized("au"), "1vocab");
+        assert_eq!(
+            prepare_match_query(&conn, "au", "1vocab"),
+            Err(SanitizeError::InvalidVocabTable("1vocab".into()))
+        );
     }
 
     #[test]
-    #[should_panic(expected = "vocab_table must be a valid SQL identifier")]
+    fn prepare_match_query_surfaces_non_missing_vocab_errors() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE bad_vocab(term TEXT)", [])
+            .unwrap();
+
+        let result = prepare_match_query(&conn, "au", "bad_vocab");
+        assert!(
+            matches!(result, Err(SanitizeError::VocabLookupFailed(_))),
+            "expected vocab lookup failure, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn expand_rejects_leading_digit_vocab_name() {
+        let conn = setup_fts_db();
+        assert_eq!(
+            fts_expand_short_terms(&conn, &sanitized("au"), "1vocab"),
+            Err(SanitizeError::InvalidVocabTable("1vocab".into()))
+        );
+    }
+
+    #[test]
     fn expand_rejects_empty_vocab_name() {
         let conn = setup_fts_db();
-        let _ = fts_expand_short_terms(&conn, &sanitized("au"), "");
+        assert_eq!(
+            fts_expand_short_terms(&conn, &sanitized("au"), ""),
+            Err(SanitizeError::InvalidVocabTable("".into()))
+        );
+    }
+
+    #[test]
+    fn expand_surfaces_non_missing_vocab_errors() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE bad_vocab(term TEXT)", [])
+            .unwrap();
+
+        let result = fts_expand_short_terms(&conn, &sanitized("au"), "bad_vocab");
+        assert!(
+            matches!(result, Err(SanitizeError::VocabLookupFailed(_))),
+            "expected vocab lookup failure, got {result:?}"
+        );
     }
 
     fn sanitized(s: &str) -> SanitizedFtsQuery {


### PR DESCRIPTION
## 概要
- `SanitizeError` に 2 つの variant を追加: `InvalidVocabTable(String)` と `VocabLookupFailed(String)`
- `vocab_table` 識別子検証の `assert!` を `Err(SanitizeError::InvalidVocabTable)` に置換し、`prepare_match_query` と `fts_expand_short_terms` が呼び出し側の入力で panic しないようにする
- `fts5vocab` テーブル欠落時の意図的 degrade 経路(`Ok(MatchFtsQuery)` でトークンをそのまま引用)は維持し、それ以外の SQLite 障害は `Err(SanitizeError::VocabLookupFailed)` で surface する
- `no such table` 判定を `is_missing_table_error` helper に集約し、`prepare_cached` と `query_map` の両経路で共有
- `is_valid_sql_identifier` を単体テスト可能な形に抽出。`fts_expand_short_terms` の rustdoc に `# Errors` 欄を追加
- 新規テスト 9 件: 無効識別子の rejection、missing-table degrade、non-missing SQLite failure の surface、実 SQLite エラーで駆動する `is_missing_table_error` helper テスト

## 背景
`prepare_match_query` は 2 つの silent failure mode を抱えていた。1 つは呼び出し側が渡した無効な `vocab_table` 識別子で panic する `assert!`。もう 1 つは、意図的 degrade(missing table)と意図せざる SQLite 障害を同じ fallback 経路に collapse してしまう挙動。呼び出し側は「想定された degrade」と「障害による degrade」を区別できず、失敗が observable でも recoverable でもなかった。

## 検証
- `cargo test --lib storage::search` → 47 passed
- `cargo test` (全体) → 168 passed / 3 ignored (MLX runtime tests)
- `cargo clippy --all-targets --all-features -- -D warnings` → クリーン

Closes #41