### PR TITLE
dependabot を有効化して CI actions と cargo 依存の自動更新を受ける

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - rust
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      patch-and-minor:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## 概要
- `.github/dependabot.yml` を追加
- `github-actions`(CI の pinned SHA 更新)と `cargo`(依存 crate 更新)の 2 ecosystem を weekly で監視
- cargo の minor/patch は `patch-and-minor` group に集約して PR 氾濫を抑制。major bump のみ個別 PR として surface
- ラベル `dependencies` / `ci` / `rust` を付与して PR フィルタと自動トリアージを容易に

## 背景
CI の actions は現時点で全て最新 SHA に pin されているが、`dependabot.yml` が存在しないため更新が完全に手動運用だった。pin の老朽化とセキュリティアラートの抜け漏れを避けるため、自動更新パイプラインを有効化する。cargo 側も同様に、依存の minor/patch bump を自動化しつつノイズを抑える運用が必要。

## 検証
- 設定ファイルの構文は push 後に GitHub Dependabot が validate するため、本 PR では別途のローカルテストなし
- コード変更なしのため既存 CI (`cargo test` / `cargo clippy` / `cargo audit` / `cargo deny`) はそのまま pass する想定