### PR TITLE
embed パイプラインにフェーズ計測とバッチ形状メトリクスを追加

### DIFF
--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -10,7 +10,40 @@ use rurico::embed::{self, Embed};
 use rurico::model_probe;
 use rurico::sandbox;
 
+/// Minimal `log` crate subscriber that writes every record to stderr.
+///
+/// Kept inside the smoke binary so that debug logs emitted by the library are
+/// visible when this binary runs, without forcing a logging backend on
+/// library consumers.
+struct StderrLogger;
+
+impl log::Log for StderrLogger {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            eprintln!(
+                "[{}] {}: {}",
+                record.level(),
+                record.target(),
+                record.args()
+            );
+        }
+    }
+    fn flush(&self) {}
+}
+
+static LOGGER: StderrLogger = StderrLogger;
+
+fn init_logger() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Debug);
+}
+
 fn main() {
+    init_logger();
+
     // Also acts as a probe subprocess when probe env vars are set.
     model_probe::handle_probe_if_needed();
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,4 +1,5 @@
 mod embedder;
+mod metrics;
 mod mlx;
 mod probe;
 

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -1,0 +1,119 @@
+//! Phase timing and batch shape counters for the embed pipeline.
+//!
+//! One `log::debug!` line per `embed_*` call so that bottlenecks can be read
+//! from a run log without extra infrastructure.
+
+use std::time::Duration;
+
+/// Phase timings and batch counters for one `embed_*` call.
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct PhaseMetrics {
+    /// Identifies which entry point produced this record (e.g. `"query"`, `"batch"`).
+    pub kind: &'static str,
+    pub tokenize: Duration,
+    pub chunk_plan: Duration,
+    pub forward_eval: Duration,
+    pub readback_pool: Duration,
+    pub cache_clear: Duration,
+    /// Number of tokens whose attention mask is non-zero (real work).
+    pub real_tokens: usize,
+    /// Total positions processed, including padding. Equals the sum of
+    /// `batch_size × max_seq_len` across all sub-batches.
+    pub padded_tokens: usize,
+    pub num_chunks: usize,
+    /// Largest sub-batch size observed in this call.
+    pub batch_size: usize,
+    /// Largest `max_seq_len` observed in this call.
+    pub max_seq_len: usize,
+}
+
+impl PhaseMetrics {
+    pub(super) fn new(kind: &'static str) -> Self {
+        Self {
+            kind,
+            ..Self::default()
+        }
+    }
+
+    /// `padded_tokens / real_tokens` — a value of 1.0 means no padding.
+    pub(super) fn padding_ratio(&self) -> f32 {
+        padding_ratio(self.real_tokens, self.padded_tokens)
+    }
+
+    /// Emit one structured debug line summarising this call.
+    pub(super) fn log(&self) {
+        log::debug!(
+            "embed[{kind}] \
+             tokenize_ms={tokenize} chunk_plan_ms={plan} forward_eval_ms={forward} \
+             readback_pool_ms={readback} cache_clear_ms={clear} \
+             real_tokens={real} padded_tokens={padded} padding_ratio={ratio:.3} \
+             num_chunks={chunks} batch_size={batch} max_seq_len={max_seq}",
+            kind = self.kind,
+            tokenize = self.tokenize.as_millis(),
+            plan = self.chunk_plan.as_millis(),
+            forward = self.forward_eval.as_millis(),
+            readback = self.readback_pool.as_millis(),
+            clear = self.cache_clear.as_millis(),
+            real = self.real_tokens,
+            padded = self.padded_tokens,
+            ratio = self.padding_ratio(),
+            chunks = self.num_chunks,
+            batch = self.batch_size,
+            max_seq = self.max_seq_len,
+        );
+    }
+}
+
+/// `padded / real`. Returns `0.0` when `real == 0` to avoid division by zero.
+pub(super) fn padding_ratio(real: usize, padded: usize) -> f32 {
+    if real == 0 {
+        return 0.0;
+    }
+    padded as f32 / real as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // padding_ratio: safe on zero real, ratio = padded / real otherwise
+    #[test]
+    fn padding_ratio_zero_real_returns_zero() {
+        assert_eq!(padding_ratio(0, 0), 0.0);
+        assert_eq!(padding_ratio(0, 100), 0.0);
+    }
+
+    #[test]
+    fn padding_ratio_no_padding_returns_one() {
+        assert!((padding_ratio(100, 100) - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn padding_ratio_half_real_returns_two() {
+        assert!((padding_ratio(50, 100) - 2.0).abs() < f32::EPSILON);
+    }
+
+    // PhaseMetrics::padding_ratio delegates to the free function
+    #[test]
+    fn phase_metrics_padding_ratio_matches_fields() {
+        let m = PhaseMetrics {
+            real_tokens: 80,
+            padded_tokens: 160,
+            ..Default::default()
+        };
+        assert!((m.padding_ratio() - 2.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn phase_metrics_default_padding_ratio_is_zero() {
+        let m = PhaseMetrics::default();
+        assert_eq!(m.padding_ratio(), 0.0);
+    }
+
+    #[test]
+    fn phase_metrics_new_sets_kind() {
+        let m = PhaseMetrics::new("query");
+        assert_eq!(m.kind, "query");
+        assert_eq!(m.padded_tokens, 0);
+    }
+}

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -1,4 +1,7 @@
+use std::time::Instant;
+
 use super::Artifacts;
+use super::metrics::PhaseMetrics;
 use super::{
     CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, EmbedInitError,
     MAX_SEQ_LEN, extract_prefix_tokens, max_content, postprocess_embedding, tokenize_with_prefix,
@@ -44,11 +47,16 @@ impl EmbedderInner {
         text: &str,
         prefix: &str,
     ) -> Result<Vec<f32>, EmbedError> {
+        let mut metrics = PhaseMetrics::new("query");
+
+        let t_tok = Instant::now();
         let tok = tokenize_with_prefix(&self.tokenizer, text, prefix)?;
         let (input_ids, attention_mask, seq_len) =
             truncate_for_query(tok.input_ids, tok.attention_mask, MAX_SEQ_LEN);
+        metrics.tokenize = t_tok.elapsed();
 
         let seq_len_i32 = i32::try_from(seq_len).expect("seq_len fits in i32");
+        let t_forward = Instant::now();
         let output = self
             .model
             .forward(&input_ids, &attention_mask, 1, seq_len_i32)
@@ -56,10 +64,27 @@ impl EmbedderInner {
 
         let result = (|| {
             output.eval().map_err(EmbedError::inference)?;
+            metrics.forward_eval = t_forward.elapsed();
+
+            let t_readback = Instant::now();
             let flat: &[f32] = output.as_slice();
-            postprocess_embedding(flat, seq_len, &attention_mask)
+            let pooled = postprocess_embedding(flat, seq_len, &attention_mask)?;
+            metrics.readback_pool = t_readback.elapsed();
+            Ok(pooled)
         })();
+        let t_clear = Instant::now();
         release_inference_output(output);
+        metrics.cache_clear = t_clear.elapsed();
+
+        // Query tokenization produces no padding (truncate, not pad), so every
+        // mask entry is non-zero — real_tokens equals seq_len.
+        metrics.real_tokens = seq_len;
+        metrics.padded_tokens = seq_len;
+        metrics.num_chunks = 1;
+        metrics.batch_size = 1;
+        metrics.max_seq_len = seq_len;
+        metrics.log();
+
         result
     }
 
@@ -84,6 +109,9 @@ impl EmbedderInner {
             return Ok(Vec::new());
         }
 
+        let mut metrics = PhaseMetrics::new("batch");
+
+        let t_plan = Instant::now();
         let max_content_tokens = max_content(self.doc_prefix_tokens.len());
         let (all_chunk_tokens, chunks_per_doc) = plan_document_chunks(
             &self.tokenizer,
@@ -91,6 +119,8 @@ impl EmbedderInner {
             &self.doc_prefix_tokens,
             max_content_tokens,
         )?;
+        metrics.chunk_plan = t_plan.elapsed();
+        metrics.num_chunks = all_chunk_tokens.len();
 
         // Split into sub-batches bounded by TOKEN_BUDGET total positions to avoid
         // Metal OOM when long sequences produce large padded tensors.
@@ -103,9 +133,15 @@ impl EmbedderInner {
         let mut all_embeddings = Vec::with_capacity(all_chunk_tokens.len());
         for sub_batch in all_chunk_tokens.chunks(sub_batch_size) {
             let (input_ids, attention_mask, batch_size, max_len) = pad_sequences(sub_batch, None);
+            // Pre-padding lengths sum to the real token count (pad_sequences pads with 0).
+            metrics.real_tokens += sub_batch.iter().map(Vec::len).sum::<usize>();
+            metrics.padded_tokens += batch_size * max_len;
+            metrics.batch_size = metrics.batch_size.max(batch_size);
+            metrics.max_seq_len = metrics.max_seq_len.max(max_len);
 
             let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
             let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");
+            let t_forward = Instant::now();
             let output = self
                 .model
                 .forward(&input_ids, &attention_mask, batch_size_i32, max_len_i32)
@@ -113,12 +149,21 @@ impl EmbedderInner {
 
             let sub_result = (|| {
                 output.eval().map_err(EmbedError::inference)?;
+                metrics.forward_eval += t_forward.elapsed();
+
+                let t_readback = Instant::now();
                 let flat: &[f32] = output.as_slice();
-                unpack_batch_output(flat, batch_size, max_len, &attention_mask)
+                let unpacked = unpack_batch_output(flat, batch_size, max_len, &attention_mask)?;
+                metrics.readback_pool += t_readback.elapsed();
+                Ok(unpacked)
             })();
+            let t_clear = Instant::now();
             release_inference_output(output);
+            metrics.cache_clear += t_clear.elapsed();
             all_embeddings.extend(sub_result?);
         }
+
+        metrics.log();
 
         // Regroup by document, preserving input order
         let mut results = Vec::with_capacity(texts.len());


### PR DESCRIPTION
## 目的と背景

embed パイプラインの各フェーズ（トークナイズ・チャンクプラン・forward・readback・キャッシュクリア）の所要時間とバッチ形状を計測する仕組みを追加する。

実機計測なしでは最適化の効果を予測できないため、Phase 2（バケットバッチング）以降の改善判断の根拠となるベースライン数値を取得することが目的。

## 変更点

- `src/embed/metrics.rs` (新規): `PhaseMetrics` 構造体・`padding_ratio` ヘルパー・ユニットテスト 6 件を追加。フェーズごとの ms 値とバッチ形状（`real_tokens`、`padded_tokens`、`padding_ratio`、`num_chunks`、`batch_size`、`max_seq_len`）を保持する。
- `src/embed/mlx.rs`: `embed_query_truncated` と `embed_documents_batch_chunked` に `Instant::now()` 計測を組み込み、呼び出しごとに `log::debug!` 1 行を出力する。ライブラリ API・戻り値の型に変更なし。
- `src/bin/mlx_smoke.rs`: ライブラリ利用者にロギングバックエンドを強制しないまま smoke バイナリで debug 出力を確認できるよう、ローカルの `StderrLogger` を追加。
- `src/embed.rs`: `mod metrics;` を追加（1 行）。

## スコープ

- **含まない**: Phase 2（長さバケットバッチング）、Phase 3（GPU 側プーリング）、Phase 4（キャッシュクリアポリシー）、Phase 5（mutex スコープ／トークナイズ重複排除）は別 PR で対応する。
- `mlx_cache.rs` と `reranker/mlx.rs` はレビュー中に一時変更したのち元に戻した。最終差分は embed スコープへの純粋な追加のみで API 変更なし。

## 設計判断

- **`log::debug!` 1 行／呼び出し**: 構造化ロギングライブラリへの依存を増やさず、既存の `log` ファサードだけで出力できる最小構成を選んだ。集計・可視化はログ収集層の責務とする。
- **`StderrLogger` を `mlx_smoke` に限定**: ロギングバックエンドの選択をライブラリ利用者に委ねるため、グローバル初期化はバイナリ内にのみ置く。
- **実機計測結果の活用**: Apple Silicon + ruri-v3-310m（キャッシュ済み）での計測で `forward_eval_ms ≈ 16,896` が end-to-end の約 97% を占めることを確認。`padding_ratio = 1.405`（長文バッチ）は Phase 2 で解消すべき「40% 無駄ポジション」仮説を裏付ける。`readback_pool_ms ≈ 111` は forward に対して微小であり、Phase 3 の改善余地は当初仮説より小さいことが判明した。

## 検証方法

1. `cargo test --workspace` を実行し、185 passed・3 ignored (Metal smoke) を確認する。
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` がクリーンであることを確認する。
3. `cargo fmt -- --check` がクリーンであることを確認する。
4. Apple Silicon 環境で `cargo run --bin mlx_smoke` を実行し、各 `embed_*` 呼び出しのたびに stderr へ `PhaseMetrics` の debug 行が出力されることを確認する。
5. ライブラリクレートを直接使用しているコードでロギング設定が不要なままであることを確認する。

## 関連

- Part of #52 (Phase 1 of 5 — baseline measurement)
