### PR TITLE
embed: 長さバケツ割り当てによるバッチ最適化 (#52)

### DIFF
--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -17,15 +17,21 @@
 //! - `measure-baseline`: run W1/W2/W3 timing `embed_documents_batch` and a
 //!   sequential equivalent, emitting one `baseline[wN] ...` line per workload
 //!   so the numbers can be copied into `docs/benchmarks/phase1_baseline.md`.
+//! - `verify-fixture`: run W1/W2/W3, load the committed fixtures, and assert
+//!   numerical equivalence within Spec NFR-001 tolerances
+//!   (`cosine_similarity ≥ 0.99999 AND max_abs_diff ≤ 1e-5`). Fails non-zero
+//!   when any workload diverges; used by `tests/mlx_smoke.rs::smoke_verify_fixture`
+//!   to drive T-BIT-001〜003.
 
 use std::env;
 use std::fs::{self, File};
-use std::io::BufWriter;
+use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
 use std::time::Instant;
 
 use rurico::embed::{
-    self, Embed, fixtures,
+    self, Embed,
+    fixtures::{self, DEFAULT_COSINE_MIN, DEFAULT_MAX_ABS_DIFF},
     workloads::{workload_w1, workload_w2, workload_w3},
 };
 use rurico::model_probe;
@@ -80,10 +86,12 @@ fn main() {
     match mode.as_str() {
         "capture-fixture" => run_capture_fixture(&embedder),
         "measure-baseline" => run_measure_baseline(&embedder),
+        "verify-fixture" => run_verify_fixture(&embedder),
         "" => run_assertions(&embedder),
         unknown => {
             eprintln!(
-                "mlx_smoke: unknown mode {unknown:?} (known: capture-fixture, measure-baseline); \
+                "mlx_smoke: unknown mode {unknown:?} \
+                 (known: capture-fixture, measure-baseline, verify-fixture); \
                  running default assertions"
             );
             run_assertions(&embedder);
@@ -169,6 +177,56 @@ fn run_capture_fixture(embedder: &embed::Embedder) {
         );
     }
     eprintln!("capture-fixture: done");
+}
+
+// ── verify-fixture mode ──────────────────────────────────────────────────────
+
+fn run_verify_fixture(embedder: &embed::Embedder) {
+    let dir = fixture_dir();
+    let mut failures = Vec::new();
+
+    for (name, texts) in [
+        ("w1", workload_w1()),
+        ("w2", workload_w2()),
+        ("w3", workload_w3()),
+    ] {
+        let refs = as_refs(&texts);
+        let actual = embedder
+            .embed_documents_batch(&refs)
+            .unwrap_or_else(|e| panic!("embed {name}: {e}"));
+
+        let path = dir.join(format!("{name}.bin"));
+        let file =
+            File::open(&path).unwrap_or_else(|e| panic!("open fixture {}: {e}", path.display()));
+        let mut r = BufReader::new(file);
+        let expected = fixtures::load(&mut r).unwrap_or_else(|e| panic!("load {name}: {e}"));
+
+        match fixtures::compare(&expected, &actual) {
+            Ok(diff) => {
+                eprintln!(
+                    "verify[{name}] cosine_min={:.6} max_abs_diff={:.3e} \
+                     (thresholds: cos>={DEFAULT_COSINE_MIN}, diff<={DEFAULT_MAX_ABS_DIFF:.0e})",
+                    diff.cosine_min, diff.max_abs_diff
+                );
+                if diff.cosine_min < DEFAULT_COSINE_MIN || diff.max_abs_diff > DEFAULT_MAX_ABS_DIFF
+                {
+                    failures.push(format!(
+                        "{name}: cosine_min={:.6} max_abs_diff={:.3e} exceeds NFR-001",
+                        diff.cosine_min, diff.max_abs_diff
+                    ));
+                }
+            }
+            Err(shape) => failures.push(format!("{name}: shape mismatch: {shape:?}")),
+        }
+    }
+
+    if !failures.is_empty() {
+        for f in &failures {
+            eprintln!("verify-fixture FAIL: {f}");
+        }
+        panic!("verify-fixture: {} workload(s) diverged", failures.len());
+    }
+    eprintln!("verify-fixture: all workloads match fixtures within NFR-001");
 }
 
 // ── measure-baseline mode ────────────────────────────────────────────────────

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -11,6 +11,66 @@ use crate::mlx_cache::release_inference_output;
 use crate::model_io::pad_sequences;
 use crate::modernbert::ModernBert;
 
+/// Length-bucket upper bounds. A chunk with `len` tokens lands in the first
+/// bucket whose `BUCKET_BOUNDS[i] >= len`. Final bucket equals [`MAX_SEQ_LEN`]
+/// so every valid chunk (post-shrink) resolves to some bucket.
+///
+/// Bucketing keeps padding waste bounded by the bucket ceiling rather than the
+/// global max chunk length, so a short chunk batched with a long one pays
+/// at most the bucket's padding cost (Spec R-M01, AC-4, NFR-003).
+pub(super) const BUCKET_BOUNDS: [usize; 4] = [128, 512, 2048, MAX_SEQ_LEN];
+
+/// Per-chunk metadata carried through bucket forward so the flat output can be
+/// restored to the original position after bucket passes reorder by length.
+#[derive(Debug, Clone)]
+pub(super) struct IndexedChunk {
+    /// Position in the flat `all_chunk_tokens` ordering emitted by planning.
+    global_idx: usize,
+    /// Tokenized chunk payload (includes prefix + BOS/EOS).
+    tokens: Vec<u32>,
+}
+
+/// Assign `len` to a bucket via the first `BUCKET_BOUNDS[i] >= len`.
+///
+/// # Panics
+///
+/// Panics if `len > MAX_SEQ_LEN`. Callers must ensure chunks have already
+/// been shrunk to fit (via `shrink_chunk_to_fit`).
+pub(super) fn assign_bucket(len: usize) -> usize {
+    BUCKET_BOUNDS
+        .iter()
+        .position(|&max| len <= max)
+        .expect("chunk len exceeds MAX_SEQ_LEN; shrink_chunk_to_fit must run first")
+}
+
+/// Partition indexed chunks into the four length buckets.
+///
+/// Kept as a standalone helper so the pure distribution logic can be tested
+/// without spinning up MLX (T-BKT-005, T-BKT-006).
+pub(super) fn distribute_into_buckets(chunks: Vec<IndexedChunk>) -> [Vec<IndexedChunk>; 4] {
+    let mut buckets: [Vec<IndexedChunk>; 4] = [Vec::new(), Vec::new(), Vec::new(), Vec::new()];
+    for chunk in chunks {
+        let b = assign_bucket(chunk.tokens.len());
+        buckets[b].push(chunk);
+    }
+    buckets
+}
+
+/// Wrap flat chunk tokens into indexed chunks. `global_idx` anchors each
+/// chunk to its pre-bucketing position so bucket forward can reorder by
+/// length yet still restore output order via the `global_idx` lookup.
+fn build_indexed_chunks(all_chunk_tokens: Vec<Vec<u32>>) -> Vec<IndexedChunk> {
+    all_chunk_tokens
+        .into_iter()
+        .enumerate()
+        .map(|(global_idx, tokens)| IndexedChunk { global_idx, tokens })
+        .collect()
+}
+
+/// Token-count ceiling for a single forward pass. Matches the pre-bucketing
+/// value so the memory budget is unchanged by bucketing.
+const TOKEN_BUDGET: usize = 256_000;
+
 pub(super) struct EmbedderInner {
     model: ModernBert,
     tokenizer: tokenizers::Tokenizer,
@@ -99,8 +159,9 @@ impl EmbedderInner {
     /// Batch-embed documents with chunking support.
     ///
     /// Short documents produce a single chunk identical to pre-chunking output.
-    /// Long documents are split into overlapping chunks. All chunks from all
-    /// documents are flattened into a single forward pass.
+    /// Long documents are split into overlapping chunks. Chunks are routed into
+    /// four length buckets (`[128, 512, 2048, MAX_SEQ_LEN]`) and forwarded per
+    /// bucket, keeping padding waste bounded by the bucket ceiling.
     pub(super) fn embed_documents_batch_chunked(
         &mut self,
         texts: &[&str],
@@ -120,52 +181,35 @@ impl EmbedderInner {
             max_content_tokens,
         )?;
         metrics.chunk_plan = t_plan.elapsed();
-        metrics.num_chunks = all_chunk_tokens.len();
+        let total_chunks = all_chunk_tokens.len();
+        metrics.num_chunks = total_chunks;
 
-        // Split into sub-batches bounded by TOKEN_BUDGET total positions to avoid
-        // Metal OOM when long sequences produce large padded tensors.
-        // TOKEN_BUDGET = 256K positions ≈ 128 chunks × 2048 tokens, which matches
-        // the empirically confirmed safe range for ruri-v3-310m on Apple Silicon.
-        const TOKEN_BUDGET: usize = 256_000;
-        let max_len_overall = all_chunk_tokens.iter().map(Vec::len).max().unwrap_or(1);
-        let sub_batch_size = (TOKEN_BUDGET / max_len_overall).max(1);
+        let buckets = distribute_into_buckets(build_indexed_chunks(all_chunk_tokens));
 
-        let mut all_embeddings = Vec::with_capacity(all_chunk_tokens.len());
-        for sub_batch in all_chunk_tokens.chunks(sub_batch_size) {
-            let (input_ids, attention_mask, batch_size, max_len) = pad_sequences(sub_batch, None);
-            // Pre-padding lengths sum to the real token count (pad_sequences pads with 0).
-            metrics.real_tokens += sub_batch.iter().map(Vec::len).sum::<usize>();
-            metrics.padded_tokens += batch_size * max_len;
-            metrics.batch_size = metrics.batch_size.max(batch_size);
-            metrics.max_seq_len = metrics.max_seq_len.max(max_len);
+        let mut out: Vec<Option<Vec<f32>>> = (0..total_chunks).map(|_| None).collect();
 
-            let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
-            let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");
-            let t_forward = Instant::now();
-            let output = self
-                .model
-                .forward(&input_ids, &attention_mask, batch_size_i32, max_len_i32)
-                .map_err(EmbedError::inference)?;
-
-            let sub_result = (|| {
-                output.eval().map_err(EmbedError::inference)?;
-                metrics.forward_eval += t_forward.elapsed();
-
-                let t_readback = Instant::now();
-                let flat: &[f32] = output.as_slice();
-                let unpacked = unpack_batch_output(flat, batch_size, max_len, &attention_mask)?;
-                metrics.readback_pool += t_readback.elapsed();
-                Ok(unpacked)
-            })();
-            let t_clear = Instant::now();
-            release_inference_output(output);
-            metrics.cache_clear += t_clear.elapsed();
-            all_embeddings.extend(sub_result?);
+        for (bucket_idx, bucket) in buckets.into_iter().enumerate() {
+            if bucket.is_empty() {
+                continue;
+            }
+            // sub_batch_size against the bucket ceiling keeps every possible
+            // sub-batch under TOKEN_BUDGET even when every chunk is at the
+            // bucket_max boundary — same OOM guarantee as pre-bucketing.
+            let sub_batch_size = (TOKEN_BUDGET / BUCKET_BOUNDS[bucket_idx]).max(1);
+            for sub_batch in bucket.chunks(sub_batch_size) {
+                self.forward_sub_batch(sub_batch, &mut out, &mut metrics)?;
+            }
         }
 
         metrics.log();
 
-        // Regroup by document, preserving input order
+        // Invariant: each global_idx was written exactly once across all bucket
+        // forwards. None here signals a distribution or unpack bug, not input.
+        let all_embeddings: Vec<Vec<f32>> = out
+            .into_iter()
+            .map(|slot| slot.expect("every chunk slot must be filled by bucket forward"))
+            .collect();
+
         let mut results = Vec::with_capacity(texts.len());
         let mut iter = all_embeddings.into_iter();
         for &count in &chunks_per_doc {
@@ -174,6 +218,49 @@ impl EmbedderInner {
         }
 
         Ok(results)
+    }
+
+    /// Forward one sub-batch of indexed chunks, write pooled embeddings into
+    /// `out` at each chunk's `global_idx`, and accumulate metrics.
+    fn forward_sub_batch(
+        &mut self,
+        sub_batch: &[IndexedChunk],
+        out: &mut [Option<Vec<f32>>],
+        metrics: &mut PhaseMetrics,
+    ) -> Result<(), EmbedError> {
+        let sub_tokens: Vec<Vec<u32>> = sub_batch.iter().map(|c| c.tokens.clone()).collect();
+        let (input_ids, attention_mask, batch_size, max_len) = pad_sequences(&sub_tokens, None);
+        metrics.real_tokens += sub_tokens.iter().map(Vec::len).sum::<usize>();
+        metrics.padded_tokens += batch_size * max_len;
+        metrics.batch_size = metrics.batch_size.max(batch_size);
+        metrics.max_seq_len = metrics.max_seq_len.max(max_len);
+
+        let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
+        let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");
+        let t_forward = Instant::now();
+        let output = self
+            .model
+            .forward(&input_ids, &attention_mask, batch_size_i32, max_len_i32)
+            .map_err(EmbedError::inference)?;
+
+        let sub_result: Result<Vec<Vec<f32>>, EmbedError> = (|| {
+            output.eval().map_err(EmbedError::inference)?;
+            metrics.forward_eval += t_forward.elapsed();
+
+            let t_readback = Instant::now();
+            let flat: &[f32] = output.as_slice();
+            let unpacked = unpack_batch_output(flat, batch_size, max_len, &attention_mask)?;
+            metrics.readback_pool += t_readback.elapsed();
+            Ok(unpacked)
+        })();
+        let t_clear = Instant::now();
+        release_inference_output(output);
+        metrics.cache_clear += t_clear.elapsed();
+
+        for (chunk, emb) in sub_batch.iter().zip(sub_result?) {
+            out[chunk.global_idx] = Some(emb);
+        }
+        Ok(())
     }
 }
 
@@ -318,6 +405,10 @@ mod tests {
     use std::panic::catch_unwind;
     use std::sync::{Mutex, PoisonError};
 
+    use super::{
+        BUCKET_BOUNDS, IndexedChunk, assign_bucket, build_indexed_chunks, distribute_into_buckets,
+    };
+
     #[test]
     fn poison_recovery_pattern_works() {
         let lock = Mutex::new(());
@@ -329,5 +420,87 @@ mod tests {
         // Same pattern as mlx_cache::release_inference_output — unwrap_or_else recovers the guard
         let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
         drop(guard);
+    }
+
+    fn make_chunk(global_idx: usize, token_count: usize) -> IndexedChunk {
+        IndexedChunk {
+            global_idx,
+            tokens: vec![0u32; token_count],
+        }
+    }
+
+    // T-BKT-001: assign_bucket boundary at 128 / 129
+    #[test]
+    fn t_bkt_001_assign_bucket_boundary_128_129() {
+        assert_eq!(assign_bucket(1), 0, "len=1 is in bucket 0");
+        assert_eq!(
+            assign_bucket(128),
+            0,
+            "len=128 is in bucket 0 (upper bound)"
+        );
+        assert_eq!(assign_bucket(129), 1, "len=129 crosses into bucket 1");
+    }
+
+    // T-BKT-002: assign_bucket boundary at 512 / 513
+    #[test]
+    fn t_bkt_002_assign_bucket_boundary_512_513() {
+        assert_eq!(
+            assign_bucket(512),
+            1,
+            "len=512 is in bucket 1 (upper bound)"
+        );
+        assert_eq!(assign_bucket(513), 2, "len=513 crosses into bucket 2");
+    }
+
+    // T-BKT-003: assign_bucket boundary at 2048 / 2049
+    #[test]
+    fn t_bkt_003_assign_bucket_boundary_2048_2049() {
+        assert_eq!(
+            assign_bucket(2048),
+            2,
+            "len=2048 is in bucket 2 (upper bound)"
+        );
+        assert_eq!(assign_bucket(2049), 3, "len=2049 crosses into bucket 3");
+    }
+
+    // T-BKT-004: assign_bucket accepts up to MAX_SEQ_LEN (8192)
+    #[test]
+    fn t_bkt_004_assign_bucket_max_seq_len() {
+        assert_eq!(
+            assign_bucket(BUCKET_BOUNDS[3]),
+            3,
+            "len=MAX_SEQ_LEN is in final bucket"
+        );
+    }
+
+    // T-BKT-005: all chunks at len=300 land in bucket 1; other buckets stay empty
+    #[test]
+    fn t_bkt_005_uniform_length_single_bucket() {
+        let chunks: Vec<IndexedChunk> = (0..10).map(|i| make_chunk(i, 300)).collect();
+        let buckets = distribute_into_buckets(chunks);
+        assert_eq!(buckets[0].len(), 0, "bucket 0 (<=128) should be empty");
+        assert_eq!(buckets[1].len(), 10, "all len=300 chunks in bucket 1");
+        assert_eq!(buckets[2].len(), 0, "bucket 2 (<=2048) should be empty");
+        assert_eq!(buckets[3].len(), 0, "bucket 3 should be empty");
+    }
+
+    // T-BKT-006: single-chunk distribution — other buckets empty, one bucket has 1
+    #[test]
+    fn t_bkt_006_single_chunk_distribution() {
+        let buckets = distribute_into_buckets(vec![make_chunk(0, 50)]);
+        let total: usize = buckets.iter().map(Vec::len).sum();
+        assert_eq!(total, 1, "single chunk routes to exactly one bucket");
+        assert_eq!(buckets[0].len(), 1, "len=50 lands in bucket 0");
+    }
+
+    #[test]
+    fn build_indexed_chunks_assigns_sequential_global_idx() {
+        let all_chunks = vec![vec![1u32; 10], vec![2u32; 20], vec![3u32; 30]];
+        let indexed = build_indexed_chunks(all_chunks);
+        let shape: Vec<(usize, usize)> = indexed
+            .iter()
+            .map(|c| (c.global_idx, c.tokens.len()))
+            .collect();
+        assert_eq!(shape, vec![(0, 10), (1, 20), (2, 30)]);
     }
 }

--- a/tests/mlx_smoke.rs
+++ b/tests/mlx_smoke.rs
@@ -4,6 +4,10 @@
 //! kills only the subprocess, not the test runner.
 //!
 //! - `smoke_full`: embed model functionality end-to-end (via `mlx_smoke`)
+//! - `smoke_verify_fixture`: Phase 2 numerical equivalence (T-BIT-001〜003)
+//!   — invokes `mlx_smoke verify-fixture` which compares W1/W2/W3 output
+//!   against `tests/fixtures/phase2_baseline/w{1,2,3}.bin` at Spec NFR-001
+//!   tolerances.
 //! - `probe_embed_smoke_binary`: embed subprocess probe contract (via `probe_embed_smoke`)
 //! - `probe_reranker_smoke_binary`: reranker subprocess probe contract (via `probe_reranker_smoke`)
 
@@ -24,6 +28,24 @@ fn smoke_full() {
     let output = Command::new(env!("CARGO_BIN_EXE_mlx_smoke"))
         .output()
         .expect("spawn smoke binary");
+    assert_smoke_success(&output);
+}
+
+/// T-BIT-001〜003: Phase 2 numerical equivalence check.
+///
+/// Runs the bucket-batched `embed_documents_batch` on W1/W2/W3, loads the
+/// committed Phase 1 fixtures, and verifies `cosine_similarity ≥ 0.99999`
+/// AND `max_abs_diff ≤ 1e-5` on every chunk pair (Spec NFR-001).
+///
+/// Re-generate the fixtures via `mlx_smoke capture-fixture` when the expected
+/// output genuinely changes (model upgrade, intentional algorithm change).
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon)
+fn smoke_verify_fixture() {
+    let output = Command::new(env!("CARGO_BIN_EXE_mlx_smoke"))
+        .arg("verify-fixture")
+        .output()
+        .expect("spawn mlx_smoke verify-fixture");
     assert_smoke_success(&output);
 }
 


### PR DESCRIPTION
## 概要

`embed_documents_batch_chunked` に 4 段階の長さバケット ([128, 512, 2048, MAX_SEQ_LEN]) による chunk 振り分けを導入し、sub-batch 内のパディング比率を削減する。TOKEN_BUDGET を bucket の上限トークン長で割って `sub_batch_size` を決定することで、既存の OOM 保証を維持したまま forward 効率を改善する。

Sub-phase 2A-a (#52)。

## 変更点

- `src/embed/mlx.rs`: `BUCKET_BOUNDS`・`IndexedChunk`・`assign_bucket`・`distribute_into_buckets`・`build_indexed_chunks`・`forward_sub_batch` を追加。`embed_documents_batch_chunked` をバケット方式に書き換え。`global_idx` で元順序を復元。ユニットテスト T-BKT-001〜006 + メタテスト 1 件を追加 (計 +261 行)
- `src/bin/mlx_smoke.rs`: `verify-fixture` モードを追加。W1/W2/W3 の fixture 照合を CLI から実行可能にした (+64 行)
- `tests/mlx_smoke.rs`: `smoke_verify_fixture` サブプロセステスト (T-BIT-001〜003) を追加 (+22 行)

## 検証

- `cargo test --lib`: 205 passed, 3 ignored
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt -- --check`: clean
- `smoke_verify_fixture` (W1/W2/W3): `cosine_min=1.0, max_abs_diff=0.0` — bit-exact 確認済み

## Phase 2 内の位置付け

Phase 2 全 8 PR のうち **1 本目** (2A-a)。次の PR (#2) では T-BKT-007/009 のカバレッジを追加し、順序保証エッジケース (`doc_idx` 境界・空 bucket) の検証を完成させる。進捗トラッキング: #52。

## レビュー反映 (polish pass)

初版コミット後に 3 agents (reuse/quality/efficiency) + codex で review。surviving findings を適用:

- CQ-1 (YAGNI): `IndexedChunk` の `doc_idx` / `chunk_in_doc` フィールドを PR #3 (2B) の sort 導入時まで defer。spec 2A-a では 4 フィールド指定だったが、未使用フィールドの `#[allow(dead_code)]` より defer が clean
- CQ-2: `embed_documents_batch_chunked` の内側 sub-batch forward を `forward_sub_batch` method に抽出 (THRESHOLDS 超過解消)
- CQ-3: 冗長な narration コメントを削除、invariant コメントのみ残す
- codex: No actionable regressions

## Test plan

- [ ] `cargo test --lib` が 205 passed で完了する
- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` がクリーンである
- [ ] `cargo fmt -- --check` がクリーンである
- [ ] `smoke_verify_fixture` が W1/W2/W3 全ワークロードで `cosine_min=1.0, max_abs_diff=0.0` を返す
- [ ] `embed_documents_batch_chunked` の公開シグネチャが変更されていないことを確認する
- [ ] `Embed` trait の公開シグネチャが変更されていないことを確認する

## 関連

- Part of [#52](https://github.com/thkt/rurico/issues/52) — Phase 2 PR #1 of 8
- 設計参照: `.claude/workspace/planning/2026-04-24-phase2-bucket-batching/sow.md`, `spec.md`
- IDR: `.claude/workspace/planning/2026-04-24/idr-04.md`
