### PR TITLE
embed: バケツ順序保持と空入力のテスト追加 (#52)

### DIFF
--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -126,6 +126,10 @@ fn run_assertions(embedder: &embed::Embedder) {
         .expect("batch");
     assert_eq!(batch.len(), 2, "batch count");
 
+    // T-BKT-009: empty `texts` → `Vec::new()` (early-return branch regression guard)
+    let empty = embedder.embed_documents_batch(&[]).expect("empty batch");
+    assert!(empty.is_empty(), "empty texts must return Vec::new()");
+
     let sentence = "apple pie is a traditional dessert enjoyed around the world. ";
     let long_text = sentence.repeat(800);
     let ld = embedder.embed_document(&long_text).expect("long doc");

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -503,4 +503,66 @@ mod tests {
             .collect();
         assert_eq!(shape, vec![(0, 10), (1, 20), (2, 30)]);
     }
+
+    // T-BKT-007: 10 chunks spanning all 4 buckets round-trip in original order
+    //
+    // Mirrors the restoration that `embed_documents_batch_chunked` performs:
+    // forward writes `out[chunk.global_idx]`, so flattening every bucket and
+    // sorting by `global_idx` must recover the original insertion order.
+    // Testing this on `distribute_into_buckets` keeps the check MLX-free.
+    #[test]
+    fn t_bkt_007_cross_bucket_order_preserved() {
+        // bucket 0 (≤128): idx 0, 4 | bucket 1 (≤512): idx 3, 6, 8
+        // bucket 2 (≤2048): idx 1, 7 | bucket 3 (≤MAX): idx 2, 5, 9
+        let lengths = [50usize, 1500, 3000, 200, 100, 5000, 300, 800, 400, 7000];
+        let chunks: Vec<IndexedChunk> = lengths
+            .iter()
+            .enumerate()
+            .map(|(i, &len)| make_chunk(i, len))
+            .collect();
+
+        let buckets = distribute_into_buckets(chunks);
+
+        let sizes: Vec<usize> = buckets.iter().map(Vec::len).collect();
+        assert!(
+            buckets.iter().all(|b| !b.is_empty()),
+            "test input must span all 4 buckets (got {sizes:?})"
+        );
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            lengths.len(),
+            "every chunk must land in exactly one bucket"
+        );
+
+        let mut flat: Vec<&IndexedChunk> = buckets.iter().flatten().collect();
+        flat.sort_by_key(|c| c.global_idx);
+        let recovered: Vec<usize> = flat.iter().map(|c| c.tokens.len()).collect();
+        assert_eq!(
+            recovered,
+            lengths.to_vec(),
+            "flatten + sort-by-global_idx must recover original chunk order"
+        );
+    }
+
+    // T-BKT-009: empty input pipeline produces zero work
+    //
+    // Guards the building blocks behind `texts.is_empty() → Vec::new()` in
+    // `embed_documents_batch_chunked`: even if the early return were removed,
+    // an empty `all_chunk_tokens` would yield all-empty buckets, the forward
+    // loop would not execute, and the `Vec<Option<Vec<f32>>>` (size 0) would
+    // collect to `Vec::new()`. MLX-free proxy for the end-to-end contract.
+    #[test]
+    fn t_bkt_009_empty_input_zero_subbatches() {
+        let indexed = build_indexed_chunks(Vec::new());
+        assert!(
+            indexed.is_empty(),
+            "empty chunk tokens → empty IndexedChunk vec"
+        );
+
+        let buckets = distribute_into_buckets(indexed);
+        assert!(
+            buckets.iter().all(Vec::is_empty),
+            "empty input → every bucket stays empty"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- T-BKT-007: 全 4 bucket (128/512/2048/MAX_SEQ_LEN) に跨る 10 chunks を
  `distribute_into_buckets` に投入 → flatten + `sort_by_key(global_idx)` で
  元挿入順の `tokens.len()` 列が復元されることを検証
- T-BKT-009: 空 `texts` → `Vec::new()` の regression guard を 2 層で追加
  (pure chain unit test + `run_assertions` 内 2 行の E2E assertion)
- 挙動変更なし。PR #56 で入った順序復元ロジックの coverage を閉じる
- bit-exact 維持: `smoke_verify_fixture` は W1/W2/W3 全て `cosine_min=1.000000,
  max_abs_diff=0.000e0` のまま

## Spec coverage

| Spec ID | Scenario | 検証内容 |
| --- | --- | --- |
| T-BKT-007 | cross-bucket 10 chunks → 元順で返却 | `sort_by_key(global_idx)` 後の `tokens.len()` 列 = `[50, 1500, 3000, 200, 100, 5000, 300, 800, 400, 7000]` |
| T-BKT-009 (unit) | `build_indexed_chunks(vec![]) + distribute_into_buckets(empty)` | 全 4 bucket が empty |
| T-BKT-009 (E2E) | `embed_documents_batch(&[])` | `Vec::new()` を返す (`texts.is_empty()` 早期リターン分岐を exercise) |

## Test plan

- [x] `cargo test --lib embed::mlx::tests::t_bkt` → 8 passed (T-BKT-001〜007, 009 + meta)
- [x] `cargo test --lib` → 207 passed, 3 ignored, 0 failed (205 → 207)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt -- --check` → clean
- [x] `cargo test --test mlx_smoke smoke_verify_fixture -- --ignored` → ok (25.5s, cosine_min=1.000000 / max_abs_diff=0.000e0 全 3 workload)
- [x] `cargo test --test mlx_smoke smoke_full -- --ignored` → ok (18.2s, 空 texts E2E exercise 済)

## Refs

- Issue: #52 (Phase 2: length-bucket batching)
- Prior PR: #56 (bucket 割り当て機構)
