### PR TITLE
Phase 2 PR #5 (2D) smoke ハーネスひな型と phase2_result.md

### DIFF
--- a/docs/benchmarks/phase2_result.md
+++ b/docs/benchmarks/phase2_result.md
@@ -1,0 +1,66 @@
+# Phase 2 Result — embed pipeline
+
+Target document for Phase 2 (issue [#52](https://github.com/thkt/rurico/issues/52)) bucket-batching outcomes. Numbers are placeholders — captured and filled in by PR #6 (sub-phase 2E) once all Phase 2 changes land. Comparison target is [`phase1_baseline.md`](./phase1_baseline.md).
+
+Regenerate via `target/debug/mlx_smoke measure-baseline` on a Phase 2 commit. Fixtures themselves continue to be validated bit-exact through `mlx_smoke verify-fixture`; this file tracks the *performance* outcome.
+
+## Workloads
+
+Same W1/W2/W3 as Phase 1, defined in [`src/embed/workloads.rs`](../../src/embed/workloads.rs). Any workload edit invalidates both fixtures (`mlx_smoke capture-fixture`) and these numbers.
+
+| ID | Shape | Characterisation |
+| --- | --- | --- |
+| W1 | 2 long texts (~48K + ~22K chars) | Long-document mix. 3 chunks total after splitting |
+| W2 | 100 short texts (~55 chars each) | Short-text batch. One chunk per text, `max_seq_len=19` |
+| W3 | 10 alternating long/short (5 + 5) | Long × short interleave. Heavy length dispersion |
+
+## Batch vs Sequential
+
+Spec AC-2 target: `batch_ms / sequential_ms ≤ 0.80` (W2 allows negotiated relaxation per PR #0 observation).
+
+| Workload | Phase 1 `batch_ms` | Phase 2 `batch_ms` | Phase 1 ratio | Phase 2 ratio | AC-2 pass? |
+| --- | --- | --- | --- | --- | --- |
+| W1 | 17,024 | TBD (PR #6) | 1.243 | TBD | TBD |
+| W2 | 565 | TBD (PR #6) | 0.094 | TBD | TBD (already passes) |
+| W3 | 5,150 | TBD (PR #6) | 1.443 | TBD | TBD |
+
+## Per-phase metrics (from `PhaseMetrics::log()`)
+
+Phase 2 adds `bucket_hist=[N0,N1,N2,N3]` to this log line (see R-S01, PR #4). NFR-003 target: `padding_ratio ≤ 1.10` on every workload.
+
+| Workload | `tokenize_ms` | `chunk_plan_ms` | `forward_eval_ms` | `padding_ratio` | `num_chunks` | `bucket_hist` |
+| --- | --- | --- | --- | --- | --- | --- |
+| W1 | TBD | TBD | TBD | TBD | 3 | TBD (PR #6) |
+| W2 | TBD | TBD | TBD | TBD | 100 | TBD (PR #6) |
+| W3 | TBD | TBD | TBD | TBD | 10 | TBD (PR #6) |
+
+### Comparison to Phase 1
+
+PR #6 fills these once all Phase 2 PRs merge:
+
+- **`padding_ratio` delta**: every workload must drop to `≤ 1.10`. W3's Phase 1 `2.316` is the headline target.
+- **`forward_eval_ms` vs `real_tokens`**: PR #6 fits `forward_eval_ms` as a linear function of `real_tokens` across W1/W2/W3 and asserts `R² ≥ 0.95` (NFR-005).
+- **`bucket_hist` distribution**: W2 expected to concentrate in bucket 0 (`[100,0,0,0]`), W1 and W3 to span 2–3 buckets.
+
+## Fixtures
+
+Phase 2 output must match the committed baseline fixtures at `tests/fixtures/phase2_baseline/w{1,2,3}.bin` (captured on the last Phase 1 commit before bucket batching, despite the directory name) within NFR-001 tolerances: `cosine_similarity ≥ 0.99999 AND max_abs_diff ≤ 1e-5`. Verified by `mlx_smoke verify-fixture` — see [`phase1_baseline.md`](./phase1_baseline.md#fixtures) for format details.
+
+## How to reproduce
+
+```sh
+# Build
+cargo build --bin mlx_smoke
+
+# Measure Phase 2 numbers (identical harness to phase1_baseline.md)
+target/debug/mlx_smoke measure-baseline 2> phase2.log
+grep "^baseline" phase2.log
+
+# Optional: re-run bit-exact check against Phase 1 fixtures
+target/debug/mlx_smoke verify-fixture
+```
+
+## Notes
+
+- Numbers TBD until PR #6 (#52 sub-phase 2E). Until then this file is a *target*, not a record — do not paste estimates.
+- `measure-baseline` warms both batched and per-document shapes once per workload before timing (see `src/bin/mlx_smoke.rs::run_measure_baseline`). Without the sequential-side warmup, `ratio = batch / sequential` is biased batch-favourably.

--- a/tests/mlx_smoke.rs
+++ b/tests/mlx_smoke.rs
@@ -8,6 +8,8 @@
 //!   — invokes `mlx_smoke verify-fixture` which compares W1/W2/W3 output
 //!   against `tests/fixtures/phase2_baseline/w{1,2,3}.bin` at Spec NFR-001
 //!   tolerances.
+//! - `smoke_measure_baseline`: shape check for `mlx_smoke measure-baseline`
+//!   output that PR #6's SLA + linearity parser will consume.
 //! - `probe_embed_smoke_binary`: embed subprocess probe contract (via `probe_embed_smoke`)
 //! - `probe_reranker_smoke_binary`: reranker subprocess probe contract (via `probe_reranker_smoke`)
 
@@ -47,6 +49,29 @@ fn smoke_verify_fixture() {
         .output()
         .expect("spawn mlx_smoke verify-fixture");
     assert_smoke_success(&output);
+}
+
+/// Guard the `baseline[wN] ...` stderr format that `mlx_smoke measure-baseline`
+/// emits, so PR #6's downstream SLA + linearity parser (R-S05, NFR-005)
+/// catches format drift here rather than in its fit computation.
+///
+/// Numbers are not asserted — that is PR #6's job. Only the shape of the
+/// output is checked: one `baseline[wN]` line per workload.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon); ~60-90s runtime
+fn smoke_measure_baseline() {
+    let output = Command::new(env!("CARGO_BIN_EXE_mlx_smoke"))
+        .arg("measure-baseline")
+        .output()
+        .expect("spawn mlx_smoke measure-baseline");
+    assert_smoke_success(&output);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for name in ["baseline[w1]", "baseline[w2]", "baseline[w3]"] {
+        assert!(
+            stderr.contains(name),
+            "measure-baseline stderr must contain {name} line (got: {stderr})"
+        );
+    }
 }
 
 /// Validate the embed subprocess probe contract end-to-end.


### PR DESCRIPTION
## 概要

Phase 2 の結果記録テンプレート (`docs/benchmarks/phase2_result.md`) を追加し、`mlx_smoke measure-baseline` 出力の shape guard integration test (`smoke_measure_baseline`) を追加する。PR #6 (2E) が実測値を埋め、SLA + 線形性 assertion を追加する前段階 (R-S02, R-S04)。

## 変更点

- **docs/benchmarks/phase2_result.md**: `phase1_baseline.md` の table 構造をミラーしたひな型。数値は `TBD (PR #6)` placeholder。intro 冒頭で "target document ... numbers are placeholders" と明示し、読者が placeholder を実測値と混同せんよう予防。
- **tests/mlx_smoke.rs**: `smoke_measure_baseline` integration test (`#[ignore]`、~85s runtime) 追加。`mlx_smoke measure-baseline` 実行して stderr に `baseline[w1/w2/w3]` 3 行が含まれることだけを assert。shape guard のみで数値は検証せん。

## 設計判断

- **数値 assert しない**: T-WLD-001〜003 (SLA) + T-MET-003 (R²) は PR #6 の仕事。この test は PR #6 の downstream parser が format drift で壊れるのを早期検知する port-guard 的役割。
- **新 binary mode 追加せず**: `measure-baseline` subcommand は PR #0 で既に W1/W2/W3 対応済。R-S02 ("smoke binary で実行可能") は既に satisfied。
- **fixture 命名の historical quirk 明示**: `tests/fixtures/phase2_baseline/` は "Phase 2 の bit-exact 検証用" やから phase2_baseline/ 命名やが中身は Phase 1 出力。この混乱を intro で明示。
- **既存 helper 流用**: `assert_smoke_success` と `Command::new(env!("CARGO_BIN_EXE_mlx_smoke"))` pattern は `smoke_full`/`smoke_verify_fixture` と同じ。

## テスト方法

- `cargo test --lib` — 210 テスト全通過 (無変更、production code なし)
- `cargo clippy -- -D warnings` & `cargo fmt --check` — クリーン
- `cargo test --test mlx_smoke smoke_measure_baseline -- --ignored` — 85.51s で通過、`baseline[w1/w2/w3]` 行確認
- codex review: 0 findings / coderabbit review: 2 major (file:// URL + fixture naming) → 両方 fix 済

## 関連

- Part of #52 (sub-phase 2D)
- Series: #55 → #56 (2A-a) → #57 (2A-b) → #58 (2B) → #59 (2C) → this PR
