### PR TITLE
embed パイプライン向け GPU プールプリミティブと Phase 3a プローブを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1896,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]

--- a/adr/0002-gpu-side-pooling-embed.md
+++ b/adr/0002-gpu-side-pooling-embed.md
@@ -21,7 +21,7 @@ Today's embed pipeline reads the full `[batch, seq, hidden]` tensor back to CPU 
 
 Three contract gaps this ADR resolves.
 
-1. Readback volume is proportional to `seq × hidden` instead of `hidden`. For W1 (`8192 × 768 × 3` chunks, plus the sequential denominator's equivalent repeats), readback dominates `forward_eval_ms = 15,620`. The pooling math only needs `[batch, hidden]` out.
+1. Readback volume is proportional to `seq × hidden` instead of `hidden`. For W1 (`8192 × 768 × 3` chunks, plus the sequential denominator's equivalent repeats), readback dominates `forward_eval_ms = 15,620`. The pooling math only needs `[batch, hidden]` out. Any post-check that triggers a synchronous `eval() + as_slice()` inside the pool function defeats this lever and is pushed to direct callers instead of the hot path.
 2. `release_inference_output(output: Array)` has a one-value contract. `src/mlx_cache.rs:26-31` documents drop-before-clear ordering at compile time by consuming the Array by value. If GPU pooling introduces a second Array (`hidden` + `pooled`), the ordering is no longer compile-time guaranteed.
 3. f32 accumulation order drifts between CPU and GPU reductions. CPU `mean_pooling` is strict left-to-right row-major accumulation. Any GPU reduction uses tree or warp-partial aggregation, which introduces per-element `~1e-6` drift that L2 normalize can amplify toward the NFR-001 `max_abs_diff ≤ 1e-5` boundary. Risk is highest at `seq_len = 8192` where 8192 terms are summed per hidden dim.
 
@@ -112,12 +112,14 @@ Positive:
 - `ModernBert::forward` remains a pure backbone. Phase 5a mutex scope work is unaffected.
 - Issue #52 AC "CPU-side pooling と GPU-side pooling の結果差分が許容範囲内" is reached.
 - NFR-001 regression detection is explicit via the probe bin. Phase 2 aspirational diagnostics continue as ongoing regression detectors.
+- `gpu_pool_and_normalize` stays readback-free. The only NaN source (fully-masked row, `0/0` on divide) is already rejected upstream by `ModernBert::forward::validate_attention_mask`; the pool function relies on that invariant instead of re-scanning its output. Direct callers that bypass `ModernBert::forward` (the Phase 3a probe bin) add their own `is_finite` guard as a defensive check.
 
 Negative:
 
 - `src/embed/pooling.rs` grows from 85 lines to roughly 165 lines while both variants coexist. Phase 3c cleanup removes the CPU variant after rewiring stabilises, but Phase 3b to 3c leaves a dead-code window.
 - Approach is conditional on mlx-rs 0.25.3 exposing reduction + broadcasting ops. If not, Phase 3 is deferred until a bindings update or an alternative (f64 intermediate, CPU-hybrid) is chosen.
 - Probe bin is additional binary target surface that must be kept green until Phase 3c deletes it.
+- FR-001a invariant is now distributed across `validate_attention_mask` (upstream rejection) and the probe bin (`is_finite` defensive guard). A regression that removes either location would leave a NaN-pathway silently open. Mitigation: T-011 is re-typed as an integration scenario on the probe bin; any replacement wiring must add an equivalent guard at the new direct-caller site.
 
 ## Migration Plan
 

--- a/adr/0002-gpu-side-pooling-embed.md
+++ b/adr/0002-gpu-side-pooling-embed.md
@@ -1,0 +1,143 @@
+# ADR 0002: GPU-side Pooling for the embed Pipeline
+
+- Status: Proposed
+- Date: 2026-04-24
+- Confidence: medium. The mlx-rs 0.25.3 Array API surface for reduction + broadcasting divide is unconfirmed, and the empirical precision margin over NFR-001 is unmeasured pre-prototype.
+
+## Context
+
+Phase 2 (length-bucket batching, PR #55-#61) reduced W3 `padding_ratio` from 2.316 to 1.165 and brought W2 and W3 into the primary SLA + padding thresholds. W1 (long-document mix, all three chunks at `seq_len ≈ 8K` resolving to bucket 3) stayed at `padding_ratio = 1.474` and batch/sequential `ratio = 1.254`. Bucket batching is a mechanical no-op for single-bucket workloads, so closing W1 needs a different lever.
+
+`docs/benchmarks/phase2_result.md` L42-47 names three attack paths for W1:
+
+- Phase 3 (this ADR). GPU-side pooling to reduce the fixed readback cost that dominates when every forward pass is 8K × 3.
+- Phase 5a. Mutex scope reduction to parallelise `tokenize` and `chunk_plan`.
+- Sub-8K chunking. Out of scope.
+
+Today's embed pipeline reads the full `[batch, seq, hidden]` tensor back to CPU after `model.forward()` and runs mask-weighted mean pooling + L2 normalize CPU-side:
+
+- `src/embed/mlx.rs::forward_sub_batch` runs `output.eval()`, then `output.as_slice()`, then `unpack_batch_output` (per-chunk slicing), then `postprocess_embedding`.
+- `src/embed/pooling.rs` implements `mean_pooling` + `l2_normalize` as sequential f32 accumulation over `seq_len × hidden_size`.
+
+Three contract gaps this ADR resolves.
+
+1. Readback volume is proportional to `seq × hidden` instead of `hidden`. For W1 (`8192 × 768 × 3` chunks, plus the sequential denominator's equivalent repeats), readback dominates `forward_eval_ms = 15,620`. The pooling math only needs `[batch, hidden]` out.
+2. `release_inference_output(output: Array)` has a one-value contract. `src/mlx_cache.rs:26-31` documents drop-before-clear ordering at compile time by consuming the Array by value. If GPU pooling introduces a second Array (`hidden` + `pooled`), the ordering is no longer compile-time guaranteed.
+3. f32 accumulation order drifts between CPU and GPU reductions. CPU `mean_pooling` is strict left-to-right row-major accumulation. Any GPU reduction uses tree or warp-partial aggregation, which introduces per-element `~1e-6` drift that L2 normalize can amplify toward the NFR-001 `max_abs_diff ≤ 1e-5` boundary. Risk is highest at `seq_len = 8192` where 8192 terms are summed per hidden dim.
+
+## Decision
+
+Introduce GPU-side pooling via a new `src/embed/pooling.rs::gpu_pool_and_normalize` function, rewire `forward_sub_batch` and `embed_query_truncated` to use it, and gate the rewiring on an empirical precision probe.
+
+The decision has three sub-decisions.
+
+### Sub-decision 1: Layer placement in embed/pooling.rs
+
+`ModernBert::forward` stays as the `[batch, seq, hidden]` backbone. The new pooling function lives in `src/embed/pooling.rs` alongside the existing CPU `mean_pooling` and `l2_normalize`.
+
+- `ModernBert` is the token-to-hidden-states backbone. Pooling is post-processing specific to the embedding use case, not every consumer of this model.
+- Phase 5a (mutex scope reduction) plans to release `tokenize` and `chunk_plan` from the `EmbedderInner` mutex. Keeping `ModernBert::forward` pure simplifies Phase 5a: the lock continues to wrap the GPU forward call, with pre-processing and post-processing running outside the lock.
+- The reranker already follows this pattern. `src/reranker/mlx.rs::forward` does on-GPU CLS pooling (`transpose_axes + index(0)`) using the same `ModernBert` backbone unchanged.
+
+### Sub-decision 2: Value-consuming signature for hidden
+
+```rust
+pub fn gpu_pool_and_normalize(
+    hidden: mlx_rs::Array,
+    mask: &mlx_rs::Array,
+) -> Result<mlx_rs::Array, Exception>
+```
+
+`hidden` is consumed by value. The pooled Array is returned for the caller to pass to `release_inference_output`.
+
+Visibility is `pub` (not `pub(super)`) so the Phase 3a precursor probe binary (`src/bin/gpu_pool_probe.rs`) can call it as a separate crate target. Internal callers (`src/embed/mlx.rs`) access the same symbol via the `pub use pooling::gpu_pool_and_normalize` re-export on `src/embed.rs`.
+
+- Preserves the compile-time drop-before-clear contract declared in `src/mlx_cache.rs:26-31`. Only one Array (the pooled result) survives past this call.
+- `mask` stays as `&Array` because the caller may hold it for other purposes (for example, in the query path) and pooling does not consume it.
+- A unit test asserts that two live Arrays from the same forward call cannot both reach `release_inference_output`. Move semantics catch this at compile time.
+
+### Sub-decision 3: Phase 3a precursor probe with 10x margin
+
+Phase 3a adds `src/bin/gpu_pool_probe.rs`, a standalone binary that forwards a single W1 chunk (`seq_len = 8192`), runs both `gpu_pool_and_normalize` and the existing `postprocess_embedding` on the same hidden-states Array, and emits `max_abs_diff` and `cosine_sim`. Phase 3b rewiring is gated on the probe reporting `max_abs_diff ≤ 1e-6`, a 10x margin over NFR-001's `1e-5`.
+
+- f32 reduction order drift is empirical, not derivable. Pre-committing to an NFR-001 margin without measurement is the same trap that Phase 2 W3 kernel-compile variance fell into.
+- If the probe fails the 10x margin, Phase 3b rewiring blocks and the approach gets re-examined (for example, mixed-precision accumulation with f64 intermediate, or a CPU-hybrid with GPU-side mask multiply + CPU sum).
+- The probe bin also serves as the mlx-rs 0.25.3 Array API surface primary-source check. `cargo build --bin gpu_pool_probe` fails fast if `sum(axis, keepdim)`, `sqrt`, or broadcasting `divide` are missing from the bindings.
+
+## Options Considered
+
+### Option A (chosen): GPU pool in embed/pooling.rs with a precursor probe
+
+Pros:
+
+- preserves `ModernBert::forward` as a pure backbone, keeping Phase 5a mutex scope work unaffected
+- readback volume drops from `O(seq × hidden)` to `O(hidden)` per batch entry
+- precision gate is empirical and fails fast before production rewiring
+
+Cons:
+
+- `src/embed/pooling.rs` grows during Phase 3b (both CPU and GPU variants live side by side until Phase 3c cleanup)
+- adds a probe bin target that exists only until Phase 3c cleanup
+
+### Option B: `ModernBert::forward_pooled` in model.rs
+
+Pros:
+
+- single call site in the embed forward path
+- backbone consumer can opt into pooled output directly
+
+Cons:
+
+- mixes backbone responsibility with post-processing
+- conflicts with Phase 5a mutex scope reduction, which expects `ModernBert::forward` to stay pure
+- reranker would end up asymmetric: CLS pooling in `src/reranker/mlx.rs`, mean pooling inside `ModernBert`
+
+### Option C: MLX compile cache for the pool graph
+
+Pros:
+
+- repeated same-shape calls amortise pool graph construction
+
+Cons:
+
+- secondary to readback shape reduction (the primary lever)
+- compile cache policy is Phase 4 scope, mixing concerns
+- adds shape-cache invalidation logic to Phase 3
+
+## Consequences
+
+Positive:
+
+- W1 `forward_eval_ms + readback_pool_ms` drops. Exact magnitude is aspirational, measured post-prototype in `phase3_result.md`.
+- `ModernBert::forward` remains a pure backbone. Phase 5a mutex scope work is unaffected.
+- Issue #52 AC "CPU-side pooling と GPU-side pooling の結果差分が許容範囲内" is reached.
+- NFR-001 regression detection is explicit via the probe bin. Phase 2 aspirational diagnostics continue as ongoing regression detectors.
+
+Negative:
+
+- `src/embed/pooling.rs` grows from 85 lines to roughly 165 lines while both variants coexist. Phase 3c cleanup removes the CPU variant after rewiring stabilises, but Phase 3b to 3c leaves a dead-code window.
+- Approach is conditional on mlx-rs 0.25.3 exposing reduction + broadcasting ops. If not, Phase 3 is deferred until a bindings update or an alternative (f64 intermediate, CPU-hybrid) is chosen.
+- Probe bin is additional binary target surface that must be kept green until Phase 3c deletes it.
+
+## Migration Plan
+
+1. Phase 3a. Add `src/bin/gpu_pool_probe.rs` and `gpu_pool_and_normalize` in `src/embed/pooling.rs`. Probe bin measures `max_abs_diff` and `cosine_sim` on W1 single chunk. Production paths unchanged.
+2. Phase 3b. If probe passes the 10x margin, rewire `forward_sub_batch` and `embed_query_truncated`. Delete `unpack_batch_output`. CPU variants in `pooling.rs` become dead code but are not yet removed.
+3. Phase 3c. Remove the CPU variants (`mean_pooling`, `l2_normalize`, `postprocess_embedding`), remove the probe bin, write `docs/benchmarks/phase3_result.md` with measured readback reduction and Phase 2 aspirational recovery status.
+
+## Reassessment Triggers
+
+- Phase 3a probe reports `max_abs_diff > 1e-6`. Approach is re-examined with f64 intermediate accumulation or CPU-hybrid fallback before Phase 3b.
+- mlx-rs 0.25.3 bindings are missing `sum(axis, keepdim)`, `sqrt`, or broadcasting `divide`. Phase 3 is deferred or the binding gap is submitted upstream.
+- Phase 5a lands first and reduces W1 ratio below 0.80 on its own. The readback attack retains its diagnostic value even if ratio is no longer the primary motivator.
+
+## References
+
+- Issue #52: `embed pipeline のスループット改善余地を計測して段階的に最適化する`
+- `docs/benchmarks/phase2_result.md` L42-47 (Phase 3 / 5a attack paths)
+- `src/embed/mlx.rs::forward_sub_batch:285-324` (rewire target)
+- `src/embed/mlx.rs::embed_query_truncated:144-189` (rewire target)
+- `src/embed/pooling.rs::postprocess_embedding:56-85` (CPU reference implementation)
+- `src/mlx_cache.rs::release_inference_output:30-44` (drop-before-clear contract)
+- `src/reranker/mlx.rs::forward:124-143` (existing on-GPU pooling pattern)
+- `tests/fixtures/phase2_baseline/w{1,2,3}.bin` (NFR-001 reference fixtures, regeneration not required because fixture format stores the final pooled vector)

--- a/adr/README.md
+++ b/adr/README.md
@@ -3,3 +3,4 @@
 | ID | Title | Status | Date |
 | --- | --- | --- | --- |
 | [0001](./0001-typed-fts-query-contract.md) | Adopt a Typed FTS Query Contract in `rurico` | Proposed | 2026-03-28 |
+| [0002](./0002-gpu-side-pooling-embed.md) | GPU-side Pooling for the embed Pipeline | Proposed | 2026-04-24 |

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -63,6 +63,30 @@ impl<K> VerifiedArtifacts<K> {
         }
     }
 
+    /// Borrow the underlying model paths.
+    ///
+    /// Scoped to cross-target probe bins (`src/bin/gpu_pool_probe.rs`) that
+    /// need to load raw files without going through the full `Embedder`.
+    /// Hidden from public docs so it does not become part of the stable
+    /// semantic-search surface. Phase 3c removes the Phase 3a probe bin and
+    /// with it the only external caller.
+    #[doc(hidden)]
+    pub fn paths(&self) -> &ModelPaths {
+        &self.paths
+    }
+
+    /// Borrow the parsed model config. See [`paths`](Self::paths) for scope.
+    #[doc(hidden)]
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Borrow the loaded tokenizer. See [`paths`](Self::paths) for scope.
+    #[doc(hidden)]
+    pub fn tokenizer(&self) -> &tokenizers::Tokenizer {
+        &self.tokenizer
+    }
+
     /// Delete the artifact files from disk.
     ///
     /// Consumes `self` so the artifacts cannot be used after deletion.

--- a/src/bin/gpu_pool_probe.rs
+++ b/src/bin/gpu_pool_probe.rs
@@ -40,8 +40,8 @@ use rurico::embed::{
 use rurico::modernbert::ModernBert;
 use rurico::sandbox;
 
-/// NFR-003 precision margin: 10x over NFR-001's `1e-5` fixture tolerance.
-const MARGIN_10X: f32 = 1e-6;
+/// NFR-003 precision threshold — 10x margin over NFR-001's `1e-5`.
+const PRECISION_THRESHOLD: f32 = 1e-6;
 
 struct ProbeReport {
     max_abs_diff: f32,
@@ -49,8 +49,8 @@ struct ProbeReport {
 }
 
 impl ProbeReport {
-    fn passes_margin(&self) -> bool {
-        self.max_abs_diff <= MARGIN_10X
+    fn is_within_threshold(&self) -> bool {
+        self.max_abs_diff <= PRECISION_THRESHOLD
     }
 }
 
@@ -63,7 +63,7 @@ fn main() {
         Ok(report) => {
             eprintln!("max_abs_diff={:.9e}", report.max_abs_diff);
             eprintln!("cosine_sim={:.9}", report.cosine_sim);
-            if report.passes_margin() {
+            if report.is_within_threshold() {
                 eprintln!("margin_10x: PASS (threshold=1e-6)");
                 process::exit(0);
             } else {
@@ -86,25 +86,25 @@ fn run(force_fail: bool) -> Result<ProbeReport, Box<dyn Error>> {
     let w1 = workload_w1();
     let text = &w1[0];
     let tokenized = tokenize_with_prefix(artifacts.tokenizer(), text, DOCUMENT_PREFIX)?;
-    if tokenized.seq_len <= MAX_SEQ_LEN {
+    if tokenized.seq_len < MAX_SEQ_LEN {
         return Err(format!(
-            "W1[0] tokenized seq_len={} ≤ MAX_SEQ_LEN={}; probe expects a long chunk",
+            "W1[0] tokenized seq_len={} < MAX_SEQ_LEN={}; probe expects a long chunk",
             tokenized.seq_len, MAX_SEQ_LEN
         )
         .into());
     }
 
     let seq_len = MAX_SEQ_LEN;
-    let ids: Vec<u32> = tokenized.input_ids[..seq_len].to_vec();
+    let ids = &tokenized.input_ids[..seq_len];
     let mask: Vec<u32> = vec![1; seq_len];
 
     let seq_i32 = i32::try_from(seq_len)?;
-    let hidden = model.forward(&ids, &mask, 1, seq_i32)?;
+    let hidden = model.forward(ids, &mask, 1, seq_i32)?;
     hidden.eval()?;
 
-    // CPU reference first: snapshot the flat hidden buffer before the GPU
-    // path consumes `hidden`. The GPU path is value-consuming by design
-    // (NFR-005 / ADR 0002 sub-decision 2), so this ordering is mandatory.
+    // CPU reference first: `as_slice()` snapshots the flat hidden buffer
+    // before `gpu_pool_and_normalize` consumes `hidden` by value (NFR-005 /
+    // ADR 0002 sub-decision 2). This ordering is mandatory.
     let hidden_flat: &[f32] = hidden.as_slice();
     let mut cpu_pooled = postprocess_embedding(hidden_flat, seq_len, &mask)?;
     if force_fail && let Some(v) = cpu_pooled.first_mut() {
@@ -113,8 +113,21 @@ fn run(force_fail: bool) -> Result<ProbeReport, Box<dyn Error>> {
 
     let mask_arr = Array::from_slice(&mask, &[1, seq_i32]);
     let gpu_pooled = gpu_pool_and_normalize(hidden, &mask_arr)?;
+    // Materialize the lazy graph explicitly. `as_slice()` would otherwise
+    // call `eval().unwrap()` internally, turning an MLX failure into a
+    // panic (exit 101) and bypassing the documented setup-error exit (2).
     gpu_pooled.eval()?;
     let gpu_flat: &[f32] = gpu_pooled.as_slice();
+
+    // `gpu_pool_and_normalize` is intentionally readback-free on the hot
+    // path (ADR 0002 primary lever). As a direct caller bypassing
+    // `ModernBert::forward`'s `validate_attention_mask`, the probe bin adds
+    // a defensive `is_finite` guard here.
+    if !gpu_flat.iter().all(|v| v.is_finite()) {
+        return Err("gpu pool produced non-finite output; \
+                    upstream validate_attention_mask invariant violated"
+            .into());
+    }
 
     if gpu_flat.len() != cpu_pooled.len() {
         return Err(format!(
@@ -125,21 +138,15 @@ fn run(force_fail: bool) -> Result<ProbeReport, Box<dyn Error>> {
         .into());
     }
 
-    let max_abs_diff = gpu_flat
+    // Both vectors are L2-normalized, so `cosine_sim` reduces to the dot
+    // product. Force-fail perturbation breaks CPU unit-norm, but the probe
+    // gate reports on `max_abs_diff` — `cosine_sim` is diagnostic only.
+    let (max_abs_diff, cosine_sim) = gpu_flat
         .iter()
         .zip(cpu_pooled.iter())
-        .map(|(a, b)| (a - b).abs())
-        .fold(0.0f32, f32::max);
-
-    // Both vectors are L2-normalized, so cosine similarity reduces to the
-    // dot product. The force-fail perturbation breaks unit-norm on the CPU
-    // side, but the probe gate reports on `max_abs_diff` — `cosine_sim` is
-    // a diagnostic aid, not the threshold.
-    let cosine_sim: f32 = gpu_flat
-        .iter()
-        .zip(cpu_pooled.iter())
-        .map(|(a, b)| a * b)
-        .sum();
+        .fold((0.0f32, 0.0f32), |(m, s), (a, b)| {
+            (m.max((a - b).abs()), s + a * b)
+        });
 
     Ok(ProbeReport {
         max_abs_diff,

--- a/src/bin/gpu_pool_probe.rs
+++ b/src/bin/gpu_pool_probe.rs
@@ -1,0 +1,148 @@
+//! Phase 3a precursor probe bin (FR-004 / FR-004a / NFR-003).
+//!
+//! Loads the cached `cl-nagoya/ruri-v3-310m` model, tokenizes the first W1
+//! long document with `DOCUMENT_PREFIX`, takes the first `MAX_SEQ_LEN` tokens
+//! (`seq_len = 8192`), and runs one forward pass. The resulting
+//! `[1, 8192, 768]` hidden-states tensor is fed to both
+//! [`gpu_pool_and_normalize`] and the CPU reference [`postprocess_embedding`]
+//! using the same input, so any divergence is reduction-order drift rather
+//! than input drift.
+//!
+//! On stderr the probe emits `max_abs_diff=<f32>`, `cosine_sim=<f32>`, and a
+//! `margin_10x: PASS|FAIL (threshold=1e-6)` banner. Exit code is `0` on
+//! `max_abs_diff ≤ 1e-6`, `1` on the margin violation, and `2` on setup
+//! failure (missing cache, tokenize error, etc.). These three exit classes
+//! let integration tests in `tests/gpu_pool_probe.rs` distinguish expected
+//! margin failure from environmental failure.
+//!
+//! # Flags
+//!
+//! - `--force-fail`: perturbs the CPU reference vector by `+1e-3` on its
+//!   first element so the `margin_10x: FAIL` branch can be exercised without
+//!   injecting reduction-order drift into the real backend. Used by T-013.
+//!
+//! # Requires
+//!
+//! - `cl-nagoya/ruri-v3-310m` downloaded and cached under the local HF Hub
+//!   cache (run `rurico` or `mlx_smoke` once to populate it).
+//! - Unsandboxed MLX runtime (Apple Silicon). The `exit_if_seatbelt` guard
+//!   early-returns `SEATBELT_SKIP_EXIT` inside the Codex sandbox.
+
+use std::env;
+use std::error::Error;
+use std::process;
+
+use mlx_rs::Array;
+use rurico::embed::{
+    self, DOCUMENT_PREFIX, MAX_SEQ_LEN, cached_artifacts, gpu_pool_and_normalize,
+    postprocess_embedding, tokenize_with_prefix, workloads::workload_w1,
+};
+use rurico::modernbert::ModernBert;
+use rurico::sandbox;
+
+/// NFR-003 precision margin: 10x over NFR-001's `1e-5` fixture tolerance.
+const MARGIN_10X: f32 = 1e-6;
+
+struct ProbeReport {
+    max_abs_diff: f32,
+    cosine_sim: f32,
+}
+
+impl ProbeReport {
+    fn passes_margin(&self) -> bool {
+        self.max_abs_diff <= MARGIN_10X
+    }
+}
+
+fn main() {
+    sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
+
+    let force_fail = env::args().any(|a| a == "--force-fail");
+
+    match run(force_fail) {
+        Ok(report) => {
+            eprintln!("max_abs_diff={:.9e}", report.max_abs_diff);
+            eprintln!("cosine_sim={:.9}", report.cosine_sim);
+            if report.passes_margin() {
+                eprintln!("margin_10x: PASS (threshold=1e-6)");
+                process::exit(0);
+            } else {
+                eprintln!("margin_10x: FAIL (threshold=1e-6)");
+                process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("gpu_pool_probe: setup error: {e}");
+            process::exit(2);
+        }
+    }
+}
+
+fn run(force_fail: bool) -> Result<ProbeReport, Box<dyn Error>> {
+    let artifacts = cached_artifacts(embed::ModelId::default())?
+        .ok_or("ruri-v3-310m not cached; download the embed model before running the probe")?;
+    let mut model = ModernBert::load(&artifacts.paths().model, artifacts.config())?;
+
+    let w1 = workload_w1();
+    let text = &w1[0];
+    let tokenized = tokenize_with_prefix(artifacts.tokenizer(), text, DOCUMENT_PREFIX)?;
+    if tokenized.seq_len <= MAX_SEQ_LEN {
+        return Err(format!(
+            "W1[0] tokenized seq_len={} ≤ MAX_SEQ_LEN={}; probe expects a long chunk",
+            tokenized.seq_len, MAX_SEQ_LEN
+        )
+        .into());
+    }
+
+    let seq_len = MAX_SEQ_LEN;
+    let ids: Vec<u32> = tokenized.input_ids[..seq_len].to_vec();
+    let mask: Vec<u32> = vec![1; seq_len];
+
+    let seq_i32 = i32::try_from(seq_len)?;
+    let hidden = model.forward(&ids, &mask, 1, seq_i32)?;
+    hidden.eval()?;
+
+    // CPU reference first: snapshot the flat hidden buffer before the GPU
+    // path consumes `hidden`. The GPU path is value-consuming by design
+    // (NFR-005 / ADR 0002 sub-decision 2), so this ordering is mandatory.
+    let hidden_flat: &[f32] = hidden.as_slice();
+    let mut cpu_pooled = postprocess_embedding(hidden_flat, seq_len, &mask)?;
+    if force_fail && let Some(v) = cpu_pooled.first_mut() {
+        *v += 1e-3;
+    }
+
+    let mask_arr = Array::from_slice(&mask, &[1, seq_i32]);
+    let gpu_pooled = gpu_pool_and_normalize(hidden, &mask_arr)?;
+    gpu_pooled.eval()?;
+    let gpu_flat: &[f32] = gpu_pooled.as_slice();
+
+    if gpu_flat.len() != cpu_pooled.len() {
+        return Err(format!(
+            "gpu_flat.len()={} != cpu_pooled.len()={}",
+            gpu_flat.len(),
+            cpu_pooled.len()
+        )
+        .into());
+    }
+
+    let max_abs_diff = gpu_flat
+        .iter()
+        .zip(cpu_pooled.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0f32, f32::max);
+
+    // Both vectors are L2-normalized, so cosine similarity reduces to the
+    // dot product. The force-fail perturbation breaks unit-norm on the CPU
+    // side, but the probe gate reports on `max_abs_diff` — `cosine_sim` is
+    // a diagnostic aid, not the threshold.
+    let cosine_sim: f32 = gpu_flat
+        .iter()
+        .zip(cpu_pooled.iter())
+        .map(|(a, b)| a * b)
+        .sum();
+
+    Ok(ProbeReport {
+        max_abs_diff,
+        cosine_sim,
+    })
+}

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -29,7 +29,11 @@ pub use crate::artifacts::{ArtifactError, EmbedKind, VerifiedArtifacts};
 pub use crate::model_probe::{ProbeStatus, handle_probe_if_needed};
 pub use embedder::Embedder;
 pub use metrics::BatchMetrics;
-pub(crate) use pooling::postprocess_embedding;
+pub use pooling::gpu_pool_and_normalize;
+// Re-exported for the Phase 3a precursor probe bin (`src/bin/gpu_pool_probe.rs`).
+// Hidden from docs — the CPU reference path is removed in Phase 3c.
+#[doc(hidden)]
+pub use pooling::postprocess_embedding;
 pub(crate) use probe::probe_env_to_paths;
 
 use crate::artifacts::verify_as_embed;

--- a/src/embed/pooling.rs
+++ b/src/embed/pooling.rs
@@ -1,4 +1,4 @@
-use mlx_rs::{Array, Dtype, error::Exception};
+use mlx_rs::{Array, Dtype, error::Exception, ops::maximum};
 
 use super::EmbedError;
 
@@ -103,27 +103,26 @@ pub fn postprocess_embedding(
     Ok(pooled)
 }
 
-/// GPU-side mask-weighted mean pool + L2 unit-norm. Consumes `hidden` by value
-/// to preserve the drop-before-clear ordering in
-/// `src/mlx_cache.rs::release_inference_output` (ADR 0002 sub-decision 2, FR-005).
+/// GPU-side mask-weighted mean pool + L2 unit-norm. Mask is cast to
+/// `Float32` internally (FR-006). `hidden` is consumed by value to preserve
+/// the drop-before-clear ordering in
+/// `src/mlx_cache.rs::release_inference_output`.
 ///
-/// The mask is cast to `Float32` internally (FR-006). A fully-masked row
-/// produces a `0/0` divide, so the pooled output is post-checked with
-/// `is_finite` and `Err(Exception)` is returned on NaN (FR-001a). Production
-/// callers go through `ModernBert::forward`'s `validate_attention_mask`, which
-/// already rejects fully-masked rows; this guard defends direct callers such
-/// as the Phase 3a precursor probe bin.
+/// No post-check on the pooled output: production callers go through
+/// `ModernBert::forward::validate_attention_mask`, which rejects all-zero
+/// rows — the only NaN source (`0/0` on a fully-masked row). Keeping the
+/// function readback-free is the primary lever of ADR 0002 (`O(hidden)` per
+/// batch entry instead of `O(seq × hidden)`); an internal `eval() +
+/// as_slice() + is_finite scan` would defeat that on every forward. Direct
+/// callers that bypass `ModernBert::forward` (the Phase 3a probe bin) add
+/// their own `is_finite` check — see `src/bin/gpu_pool_probe.rs`.
 ///
 /// # Errors
 ///
-/// Returns an MLX [`Exception`] if any tensor operation fails or the pooled
-/// output contains non-finite values.
-//
-// `hidden` is intentionally taken by value to enforce the drop-before-clear
-// contract in `src/mlx_cache.rs::release_inference_output` at compile time —
-// callers cannot hold it live alongside the pooled result. `clippy` cannot
-// see this cross-function ownership intent, so suppress the lint here. See
-// ADR 0002 sub-decision 2 and NFR-005 for rationale.
+/// Returns an MLX [`Exception`] if any tensor operation fails.
+// See ADR 0002 sub-decision 2 / NFR-005: `hidden` by-value enforces
+// drop-before-clear at compile time. `clippy` can't see that cross-function
+// intent, so suppress the lint here.
 #[allow(clippy::needless_pass_by_value)]
 pub fn gpu_pool_and_normalize(hidden: Array, mask: &Array) -> Result<Array, Exception> {
     let shape = mask.shape();
@@ -140,17 +139,13 @@ pub fn gpu_pool_and_normalize(hidden: Array, mask: &Array) -> Result<Array, Exce
     let pooled = sum_hidden.divide(&mask_sum)?;
     let norm_sq = pooled.multiply(&pooled)?.sum_axes(&[-1], true)?;
     let norm = norm_sq.sqrt()?;
-    let normalized = pooled.divide(&norm)?;
-
-    normalized.eval()?;
-    let flat: &[f32] = normalized.as_slice();
-    if flat.iter().any(|v| !v.is_finite()) {
-        return Err(Exception::custom(
-            "gpu_pool_and_normalize: non-finite output (likely fully-masked row)",
-        ));
-    }
-
-    Ok(normalized)
+    // CPU `l2_normalize` leaves a zero-norm vector unchanged. Match that on
+    // GPU by clamping the norm to `f32::MIN_POSITIVE` before division: a
+    // zero pooled row still divides to zeros (0 / 1e-38 = 0), and any real
+    // norm ≥ MIN_POSITIVE passes through unchanged. Readback-free.
+    let eps = Array::from_slice(&[f32::MIN_POSITIVE], &[1]);
+    let safe_norm = maximum(&norm, &eps)?;
+    pooled.divide(&safe_norm)
 }
 
 /// `t_NNN_` prefix maps to Spec test scenarios in
@@ -195,28 +190,6 @@ mod tests {
             let total = (batch * seq * hidden) as usize;
             let data: Vec<f32> = (0..total).map(|i| (i as f32) * 0.01).collect();
             Array::from_slice(&data, &[batch, seq, hidden])
-        }
-
-        /// CPU oracle mirroring `postprocess_embedding` row-major. `hidden_f32`
-        /// is the same buffer used to construct the GPU Array.
-        fn cpu_reference_batch(
-            hidden_f32: &[f32],
-            mask_u32: &[u32],
-            batch: usize,
-            seq: usize,
-            hidden: usize,
-        ) -> Vec<Vec<f32>> {
-            let stride = seq * hidden;
-            let mut rows = Vec::with_capacity(batch);
-            for b in 0..batch {
-                let slice = &hidden_f32[b * stride..(b + 1) * stride];
-                let mask = &mask_u32[b * seq..(b + 1) * seq];
-                rows.push(
-                    postprocess_embedding(slice, seq, mask)
-                        .expect("cpu reference post-process must succeed"),
-                );
-            }
-            rows
         }
 
         fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
@@ -270,23 +243,21 @@ mod tests {
         #[serial]
         fn t_002_gpu_vs_cpu_reference_within_tolerance() {
             require_unsandboxed_mlx_runtime();
-            let batch = 1usize;
-            let seq = 5usize;
-            let hidden = 4usize;
-            let data: Vec<f32> = (0..batch * seq * hidden)
-                .map(|i| (i as f32) * 0.01)
-                .collect();
+            let seq: i32 = 5;
+            let hidden: i32 = 4;
+            let total = (seq * hidden) as usize;
+            let data: Vec<f32> = (0..total).map(|i| (i as f32) * 0.01).collect();
             let mask_vec: Vec<u32> = vec![1, 1, 1, 1, 0];
 
-            let hidden_arr = Array::from_slice(&data, &[batch as i32, seq as i32, hidden as i32]);
-            let mask_arr = Array::from_slice(&mask_vec, &[batch as i32, seq as i32]);
+            let hidden_arr = Array::from_slice(&data, &[1, seq, hidden]);
+            let mask_arr = Array::from_slice(&mask_vec, &[1, seq]);
 
             let pooled = gpu_pool_and_normalize(hidden_arr, &mask_arr).expect("pool ok");
             pooled.eval().expect("eval pool");
             let gpu_flat: &[f32] = pooled.as_slice();
 
-            let cpu = cpu_reference_batch(&data, &mask_vec, batch, seq, hidden);
-            let cpu_flat: Vec<f32> = cpu.into_iter().flatten().collect();
+            let cpu_flat = postprocess_embedding(&data, seq as usize, &mask_vec)
+                .expect("cpu reference post-process must succeed");
 
             assert_eq!(
                 gpu_flat.len(),
@@ -380,30 +351,35 @@ mod tests {
 
         // T-011 / FR-001a / AC-3
         //
-        // [T-011] Contract test on the pool function alone. In production,
-        // `validate_attention_mask` in `src/modernbert/model.rs` rejects
-        // fully-masked rows upstream, so this path is unreachable via
-        // `ModernBert::forward`. The pool function itself must still guard
-        // against an all-zero row and return an MLX `Exception`, so a direct
-        // caller cannot silently emit NaN.
+        // [T-011] Upstream-guarantee regression signal. `gpu_pool_and_normalize`
+        // intentionally has no internal all-zero-mask guard so the hot path
+        // stays readback-free (ADR 0002 primary lever). Production callers go
+        // through `ModernBert::forward::validate_attention_mask`, which rejects
+        // fully-masked rows; direct callers (the Phase 3a probe bin) add a
+        // defensive `is_finite` check.
         //
-        // IMPORTANT: The Phase 2 CPU reference `postprocess_embedding` returns
-        // zeros on all-zero mask (no divide-by-zero guard). Phase 3a must
-        // tighten the contract: `gpu_pool_and_normalize` explicitly validates
-        // the mask OR post-checks `is_finite` and converts NaN → `Err`.
+        // This test feeds an all-zero mask row directly and asserts the
+        // output contains NaN. If someone re-adds an in-function guard that
+        // converts this to `Err` or a zero vector, the test fails, forcing
+        // a revisit of ADR 0002 sub-decision 2 before the readback tax
+        // silently returns to the Phase 3b production path.
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_011_all_zero_mask_row_returns_err() {
+        fn t_011_all_zero_mask_propagates_nan_without_internal_guard() {
             require_unsandboxed_mlx_runtime();
             let hidden = make_hidden(2, 3, 4);
-            // Row 0 valid, row 1 fully masked.
             let mask = Array::from_slice(&[1u32, 1, 0, 0, 0, 0], &[2, 3]);
 
-            let result = gpu_pool_and_normalize(hidden, &mask);
+            let pooled = gpu_pool_and_normalize(hidden, &mask).expect("pool ok");
+            pooled.eval().expect("eval pool");
+            let flat: &[f32] = pooled.as_slice();
+
             assert!(
-                result.is_err(),
-                "[T-011] all-zero mask row must return Err(Exception), got Ok"
+                flat.iter().any(|v| v.is_nan()),
+                "[T-011] all-zero mask row must propagate NaN (no internal \
+                 guard — upstream validate_attention_mask is the contract); \
+                 got all-finite: {flat:?}"
             );
         }
     }

--- a/src/embed/pooling.rs
+++ b/src/embed/pooling.rs
@@ -1,3 +1,5 @@
+use mlx_rs::{Array, Dtype, error::Exception};
+
 use super::EmbedError;
 
 /// Compute mean pooling over hidden states, weighted by attention mask.
@@ -53,7 +55,24 @@ pub(crate) fn l2_normalize(v: &mut [f32]) {
     }
 }
 
-pub(crate) fn postprocess_embedding(
+/// Phase 2 CPU-side post-processing: mask-weighted mean pool plus L2 unit-norm.
+///
+/// Reference implementation for the Phase 3a precision probe
+/// (`src/bin/gpu_pool_probe.rs`). Phase 3c removes this function once the
+/// GPU pool has stabilised — hidden from public docs via
+/// `#[doc(hidden)] pub use` on [`embed`](crate::embed).
+///
+/// `flat` is a row-major `[seq_len × hidden_size]` buffer and
+/// `attention_mask.len() >= seq_len`.
+///
+/// # Errors
+///
+/// Returns [`EmbedError::EmptySequence`] when `seq_len == 0`, and
+/// [`EmbedError::inference`](EmbedError) when the flat buffer length or
+/// mask length is inconsistent with `seq_len`. Returns
+/// [`EmbedError::NonFiniteOutput`] if the pooled vector contains NaN or
+/// infinity.
+pub fn postprocess_embedding(
     flat: &[f32],
     seq_len: usize,
     attention_mask: &[u32],
@@ -82,4 +101,310 @@ pub(crate) fn postprocess_embedding(
         return Err(EmbedError::NonFiniteOutput);
     }
     Ok(pooled)
+}
+
+/// GPU-side mask-weighted mean pool + L2 unit-norm. Consumes `hidden` by value
+/// to preserve the drop-before-clear ordering in
+/// `src/mlx_cache.rs::release_inference_output` (ADR 0002 sub-decision 2, FR-005).
+///
+/// The mask is cast to `Float32` internally (FR-006). A fully-masked row
+/// produces a `0/0` divide, so the pooled output is post-checked with
+/// `is_finite` and `Err(Exception)` is returned on NaN (FR-001a). Production
+/// callers go through `ModernBert::forward`'s `validate_attention_mask`, which
+/// already rejects fully-masked rows; this guard defends direct callers such
+/// as the Phase 3a precursor probe bin.
+///
+/// # Errors
+///
+/// Returns an MLX [`Exception`] if any tensor operation fails or the pooled
+/// output contains non-finite values.
+//
+// `hidden` is intentionally taken by value to enforce the drop-before-clear
+// contract in `src/mlx_cache.rs::release_inference_output` at compile time —
+// callers cannot hold it live alongside the pooled result. `clippy` cannot
+// see this cross-function ownership intent, so suppress the lint here. See
+// ADR 0002 sub-decision 2 and NFR-005 for rationale.
+#[allow(clippy::needless_pass_by_value)]
+pub fn gpu_pool_and_normalize(hidden: Array, mask: &Array) -> Result<Array, Exception> {
+    let shape = mask.shape();
+    let batch = shape[0];
+    let seq = shape[1];
+
+    let mask_f32 = mask.as_dtype(Dtype::Float32)?;
+    let mask_expanded = mask_f32.reshape(&[batch, seq, 1])?;
+
+    let masked = hidden.multiply(&mask_expanded)?;
+    let sum_hidden = masked.sum_axes(&[1], false)?;
+    let mask_sum = mask_f32.sum_axes(&[1], true)?;
+
+    let pooled = sum_hidden.divide(&mask_sum)?;
+    let norm_sq = pooled.multiply(&pooled)?.sum_axes(&[-1], true)?;
+    let norm = norm_sq.sqrt()?;
+    let normalized = pooled.divide(&norm)?;
+
+    normalized.eval()?;
+    let flat: &[f32] = normalized.as_slice();
+    if flat.iter().any(|v| !v.is_finite()) {
+        return Err(Exception::custom(
+            "gpu_pool_and_normalize: non-finite output (likely fully-masked row)",
+        ));
+    }
+
+    Ok(normalized)
+}
+
+/// `t_NNN_` prefix maps to Spec test scenarios in
+/// `.claude/workspace/planning/2026-04-24-phase3-gpu-pooling/spec.md`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mlx_rs::Array;
+    use mlx_rs::error::Exception;
+
+    // T-004 / FR-005 / AC-3
+    //
+    // Pure compile-time contract check: `gpu_pool_and_normalize` must consume
+    // `hidden` by value so the drop-before-clear contract in
+    // `src/mlx_cache.rs::release_inference_output` keeps its compile-time
+    // guarantee. If someone relaxes the signature to `&Array`, the fn-pointer
+    // coercion below fails to typecheck and this test refuses to compile —
+    // which is the intended regression signal for AC-3.
+    #[test]
+    fn t_004_gpu_pool_signature_consumes_hidden_by_value() {
+        let _coerce: fn(Array, &Array) -> Result<Array, Exception> = gpu_pool_and_normalize;
+    }
+
+    /// MLX runtime tests — construct `mlx_rs::Array` and call
+    /// `gpu_pool_and_normalize`. Gated behind `test-mlx` so the default
+    /// `cargo test` (including CI seatbelt) stays green.
+    ///
+    /// Run with `cargo test --features test-mlx -- --ignored` outside the
+    /// Codex seatbelt. Mirrors the pattern in
+    /// `src/modernbert/model.rs::mlx_runtime_tests`.
+    #[cfg(feature = "test-mlx")]
+    mod mlx_runtime_tests {
+        use serial_test::serial;
+
+        use super::*;
+        use crate::sandbox::require_unsandboxed_mlx_runtime;
+
+        /// Build a `[batch, seq, hidden]` f32 Array filled deterministically
+        /// from a row-major iteration counter so a CPU reference can recompute
+        /// the expected values without MLX.
+        fn make_hidden(batch: i32, seq: i32, hidden: i32) -> Array {
+            let total = (batch * seq * hidden) as usize;
+            let data: Vec<f32> = (0..total).map(|i| (i as f32) * 0.01).collect();
+            Array::from_slice(&data, &[batch, seq, hidden])
+        }
+
+        /// CPU oracle mirroring `postprocess_embedding` row-major. `hidden_f32`
+        /// is the same buffer used to construct the GPU Array.
+        fn cpu_reference_batch(
+            hidden_f32: &[f32],
+            mask_u32: &[u32],
+            batch: usize,
+            seq: usize,
+            hidden: usize,
+        ) -> Vec<Vec<f32>> {
+            let stride = seq * hidden;
+            let mut rows = Vec::with_capacity(batch);
+            for b in 0..batch {
+                let slice = &hidden_f32[b * stride..(b + 1) * stride];
+                let mask = &mask_u32[b * seq..(b + 1) * seq];
+                rows.push(
+                    postprocess_embedding(slice, seq, mask)
+                        .expect("cpu reference post-process must succeed"),
+                );
+            }
+            rows
+        }
+
+        fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+            a.iter()
+                .zip(b)
+                .map(|(x, y)| (x - y).abs())
+                .fold(0.0f32, f32::max)
+        }
+
+        // T-001 / FR-001 / AC-3
+        //
+        // [T-001] Small known-shape pool: batch=2, seq=4, hidden=3 with mask
+        // `[[1,1,0,0],[1,1,1,0]]`. Output must be shape [2, 3] and every row
+        // must be unit-norm within `1e-6`.
+        #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
+        #[serial]
+        fn t_001_small_shape_pool_yields_unit_norm_rows() {
+            require_unsandboxed_mlx_runtime();
+            let hidden = make_hidden(2, 4, 3);
+            let mask = Array::from_slice(&[1u32, 1, 0, 0, 1, 1, 1, 0], &[2, 4]);
+
+            let pooled = gpu_pool_and_normalize(hidden, &mask).expect("pool ok");
+            pooled.eval().expect("eval pool");
+
+            assert_eq!(
+                pooled.shape(),
+                &[2, 3],
+                "[T-001] output shape must be [2, 3]"
+            );
+
+            let data: &[f32] = pooled.as_slice();
+            assert_eq!(data.len(), 6, "[T-001] flat length must be batch*hidden");
+            for row in 0..2usize {
+                let r = &data[row * 3..(row + 1) * 3];
+                let norm_sq: f32 = r.iter().map(|v| v * v).sum();
+                assert!(
+                    (norm_sq - 1.0).abs() <= 1e-6,
+                    "[T-001] row {row} L2 norm^2 must be 1.0 ± 1e-6, got {norm_sq} (row={r:?})"
+                );
+            }
+        }
+
+        // T-002 / FR-001 / AC-3
+        //
+        // [T-002] GPU vs CPU reference parity on `[1, 5, 4]`. The same flat
+        // buffer feeds both paths so any `max_abs_diff > 1e-6` is reduction
+        // order drift, not input drift.
+        #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
+        #[serial]
+        fn t_002_gpu_vs_cpu_reference_within_tolerance() {
+            require_unsandboxed_mlx_runtime();
+            let batch = 1usize;
+            let seq = 5usize;
+            let hidden = 4usize;
+            let data: Vec<f32> = (0..batch * seq * hidden)
+                .map(|i| (i as f32) * 0.01)
+                .collect();
+            let mask_vec: Vec<u32> = vec![1, 1, 1, 1, 0];
+
+            let hidden_arr = Array::from_slice(&data, &[batch as i32, seq as i32, hidden as i32]);
+            let mask_arr = Array::from_slice(&mask_vec, &[batch as i32, seq as i32]);
+
+            let pooled = gpu_pool_and_normalize(hidden_arr, &mask_arr).expect("pool ok");
+            pooled.eval().expect("eval pool");
+            let gpu_flat: &[f32] = pooled.as_slice();
+
+            let cpu = cpu_reference_batch(&data, &mask_vec, batch, seq, hidden);
+            let cpu_flat: Vec<f32> = cpu.into_iter().flatten().collect();
+
+            assert_eq!(
+                gpu_flat.len(),
+                cpu_flat.len(),
+                "[T-002] GPU and CPU flat lengths must match"
+            );
+            let diff = max_abs_diff(gpu_flat, &cpu_flat);
+            assert!(
+                diff <= 1e-6,
+                "[T-002] max_abs_diff must be ≤ 1e-6, got {diff} (gpu={gpu_flat:?} cpu={cpu_flat:?})"
+            );
+        }
+
+        // T-003 / FR-001 / AC-3
+        //
+        // [T-003] Large W1-class shape `[1, 8192, 768]`. Output shape must be
+        // `[1, 768]` and every value finite.
+        #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
+        #[serial]
+        fn t_003_large_w1_shape_produces_finite_output() {
+            require_unsandboxed_mlx_runtime();
+            let batch = 1i32;
+            let seq = 8192i32;
+            let hidden = 768i32;
+            let total = (batch * seq * hidden) as usize;
+            // Seed-based reproducible synthetic input (LCG). Values in
+            // roughly `[-1.0, 1.0]` so mask-weighted mean stays in-range.
+            let data: Vec<f32> = {
+                let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+                (0..total)
+                    .map(|_| {
+                        state = state
+                            .wrapping_mul(6364136223846793005)
+                            .wrapping_add(1442695040888963407);
+                        let u = ((state >> 33) as u32) as f32 / (u32::MAX as f32);
+                        u * 2.0 - 1.0
+                    })
+                    .collect()
+            };
+            let mask: Vec<u32> = vec![1u32; (batch * seq) as usize];
+
+            let hidden_arr = Array::from_slice(&data, &[batch, seq, hidden]);
+            let mask_arr = Array::from_slice(&mask, &[batch, seq]);
+
+            let pooled = gpu_pool_and_normalize(hidden_arr, &mask_arr).expect("pool ok");
+            pooled.eval().expect("eval pool");
+
+            assert_eq!(
+                pooled.shape(),
+                &[batch, hidden],
+                "[T-003] output shape must be [1, 768]"
+            );
+            let flat: &[f32] = pooled.as_slice();
+            assert_eq!(flat.len(), 768, "[T-003] flat len must be hidden_size");
+            assert!(
+                flat.iter().all(|v| v.is_finite()),
+                "[T-003] all output values must be finite"
+            );
+            // Spot-check unit norm so the test fails if L2 normalize is skipped.
+            let norm_sq: f32 = flat.iter().map(|v| v * v).sum();
+            assert!(
+                (norm_sq - 1.0).abs() <= 1e-5,
+                "[T-003] pooled row must be unit-norm (norm^2={norm_sq})"
+            );
+        }
+
+        // T-005 / FR-006 / AC-3
+        //
+        // [T-005] `u32` mask with values in `{0, 1}` must flow through the
+        // internal `as_dtype(Float32)` cast without a dtype panic.
+        #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
+        #[serial]
+        fn t_005_u32_mask_cast_to_f32_succeeds() {
+            require_unsandboxed_mlx_runtime();
+            let hidden = make_hidden(1, 3, 2);
+            let mask = Array::from_slice(&[1u32, 0, 1], &[1, 3]);
+
+            let pooled = gpu_pool_and_normalize(hidden, &mask).expect("pool ok");
+            pooled.eval().expect("eval pool");
+
+            assert_eq!(pooled.shape(), &[1, 2], "[T-005] shape must be [1, 2]");
+            let flat: &[f32] = pooled.as_slice();
+            assert_eq!(flat.len(), 2, "[T-005] flat len must be batch*hidden");
+            assert!(
+                flat.iter().all(|v| v.is_finite()),
+                "[T-005] output must be finite (got {flat:?})"
+            );
+        }
+
+        // T-011 / FR-001a / AC-3
+        //
+        // [T-011] Contract test on the pool function alone. In production,
+        // `validate_attention_mask` in `src/modernbert/model.rs` rejects
+        // fully-masked rows upstream, so this path is unreachable via
+        // `ModernBert::forward`. The pool function itself must still guard
+        // against an all-zero row and return an MLX `Exception`, so a direct
+        // caller cannot silently emit NaN.
+        //
+        // IMPORTANT: The Phase 2 CPU reference `postprocess_embedding` returns
+        // zeros on all-zero mask (no divide-by-zero guard). Phase 3a must
+        // tighten the contract: `gpu_pool_and_normalize` explicitly validates
+        // the mask OR post-checks `is_finite` and converts NaN → `Err`.
+        #[test]
+        #[ignore = "requires unsandboxed MLX runtime"]
+        #[serial]
+        fn t_011_all_zero_mask_row_returns_err() {
+            require_unsandboxed_mlx_runtime();
+            let hidden = make_hidden(2, 3, 4);
+            // Row 0 valid, row 1 fully masked.
+            let mask = Array::from_slice(&[1u32, 1, 0, 0, 0, 0], &[2, 3]);
+
+            let result = gpu_pool_and_normalize(hidden, &mask);
+            assert!(
+                result.is_err(),
+                "[T-011] all-zero mask row must return Err(Exception), got Ok"
+            );
+        }
+    }
 }

--- a/tests/gpu_pool_probe.rs
+++ b/tests/gpu_pool_probe.rs
@@ -1,0 +1,93 @@
+//! Integration tests for `src/bin/gpu_pool_probe.rs` (Phase 3a).
+//!
+//! Spawns the probe subprocess and asserts on stderr banners and exit code.
+//! Mirrors the pattern in `tests/mlx_smoke.rs` (subprocess isolation so an
+//! MLX SIGABRT cannot kill the test runner).
+//!
+//! All tests are `#[ignore]` because they require the ruri-v3-310m model
+//! cached locally and an MLX-capable runtime (Apple Silicon, unsandboxed).
+
+use std::process::{Command, Output};
+
+use rurico::sandbox::SEATBELT_SKIP_EXIT;
+
+fn run_probe(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_gpu_pool_probe"))
+        .args(args)
+        .output()
+        .expect("spawn gpu_pool_probe")
+}
+
+fn skip_if_seatbelt(output: &Output) -> bool {
+    output.status.code() == Some(SEATBELT_SKIP_EXIT)
+}
+
+// T-008 / FR-004 / AC-4
+//
+// [T-008] On a real W1 single-chunk input (seq_len = 8192), the probe must
+// complete successfully and emit the three banner fields on stderr. The
+// implementation is expected to pass the 10x margin on real weights; if the
+// gate actually fails, Phase 3b is blocked per ADR 0002 sub-decision 3.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon) unsandboxed
+fn t_008_probe_emits_max_abs_diff_cosine_sim_and_margin_banner() {
+    let output = run_probe(&[]);
+    if skip_if_seatbelt(&output) {
+        return;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "[T-008] probe must exit 0 on passing margin; got status={:?}, stderr={}",
+        output.status,
+        stderr
+    );
+    assert!(
+        stderr.contains("max_abs_diff="),
+        "[T-008] stderr must contain `max_abs_diff=` banner; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("cosine_sim="),
+        "[T-008] stderr must contain `cosine_sim=` banner; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("margin_10x: PASS"),
+        "[T-008] stderr must contain `margin_10x: PASS` on real-weight W1 \
+         single chunk; got: {stderr}"
+    );
+}
+
+// T-013 / FR-004a / AC-4
+//
+// [T-013] When the probe is run with `--force-fail`, the CPU reference is
+// deliberately offset so the reported `max_abs_diff` exceeds the 10x margin.
+// Exit code must be non-zero and stderr must contain `margin_10x: FAIL`.
+// `--force-fail` is a synthetic perturbation path, not a Scope Cut Candidate
+// — the 10x margin is designed to absorb honest f32 reduction order drift,
+// so injecting drift into the real backend would be unreliable.
+#[test]
+#[ignore] // requires ruri-v3-310m cached + MLX (Apple Silicon) unsandboxed
+fn t_013_probe_exits_nonzero_and_emits_fail_banner_on_margin_violation() {
+    let output = run_probe(&["--force-fail"]);
+    if skip_if_seatbelt(&output) {
+        return;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "[T-013] probe must exit non-zero on margin violation; got status={:?}, stderr={}",
+        output.status,
+        stderr
+    );
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "[T-013] exit code must be ≠ 0 on margin violation"
+    );
+    assert!(
+        stderr.contains("margin_10x: FAIL"),
+        "[T-013] stderr must contain `margin_10x: FAIL` banner; got: {stderr}"
+    );
+}


### PR DESCRIPTION
## 概要

Issue #52（embed パイプライン スループット）の Phase 3a。**精度ゲートであり、速度改善ではない。** プロダクションパスは変更なし。速度向上は Phase 3b で届く。

AC-4 実測（Apple Silicon、ruri-v3-310m、W1[0]、seq_len=8192）：`max_abs_diff = 5.066e-7`、`cosine_sim = 0.99999988`、`margin_10x: PASS`（閾値 `1e-6`）、exit 0。NFR-003 threshold の約 50% の余裕。Phase 3b はこれにより unblocked。

## 設計意図：NaN 責任の分散

`gpu_pool_and_normalize` はホットパスでリードバックを行わない（ADR 0002 主レバー：`O(hidden)` per batch entry、`O(seq × hidden)` でない）。そのため関数内に all-zero-mask ガードを置かない。プロダクション呼び出し元は `ModernBert::forward::validate_attention_mask` が完全マスク行を上流で排除する。上流ガードをバイパスするプローブ bin は自前で `is_finite` 防御チェックを持つ。

ゼロノルムの CPU/GPU パリティは `maximum(norm, f32::MIN_POSITIVE)` クランプで保持する。ゼロプール行は `0 / 1e-38 = 0` になり、CPU `l2_normalize` の「ゼロノルムベクトルをそのまま残す」セマンティクスと一致し、ホストラウンドトリップなし。

## スコープ

**IN**：GPU プールプリミティブ、プレカーサプローブ bin (`src/bin/gpu_pool_probe.rs`)、`VerifiedArtifacts` アクセサメソッド、ADR 0002、テスト T-004/T-008/T-011/T-013。

**NOT IN**：`forward_sub_batch` の切り替え（Phase 3b）、CPU プール削除（Phase 3c）、`phase3_result.md`（Phase 3c）。

## レビュアーフォーカス

| ファイル | 確認ポイント |
| --- | --- |
| `src/embed/pooling.rs::gpu_pool_and_normalize` | リードバックフリーの数式、`maximum` クランプ根拠、`#[allow(clippy::needless_pass_by_value)]`（ADR 0002 sub-decision 2 による） |
| `src/bin/gpu_pool_probe.rs` | プローブフロー、`is_finite` ガード、`--force-fail` セマンティクス、exit コード分類（0/1/2） |
| `adr/0002-gpu-side-pooling-embed.md` | Consequences セクション（分散責任の説明） |
| `src/artifacts.rs` | アクセサメソッド（Phase 3c で削除予定。CodeRabbit 0 findings） |

## リスク

AC-4 の再実行コストは非ゼロ（ruri-v3-310m ロード + 8K forward 1 回）だが、Phase 3b ゲートチェック時のみ必要。MLX-rs 0.25.3 のバインディング仮定（reduction・broadcasting・`maximum`）はプローブ成功実行で確認済み。`maximum(NaN, x)` の MLX セマンティクスは PASS パスでは未テストだが、T-011 ランタイムテスト（デフォルト ignore）が将来のリグレッション信号として存在する。

## テスト計画

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` グリーン
- [x] `cargo test --lib` — 219 passed / 0 failed / 3 ignored（MLX ランタイムテスト）
- [x] `cargo test --test gpu_pool_probe` — T-008、T-013 コンパイル、両方 `#[ignore]`（unsandboxed MLX が必要）
- [x] `cargo build --bin gpu_pool_probe` グリーン
- [x] AC-4 実測：Apple Silicon で `./target/debug/gpu_pool_probe` が `margin_10x: PASS` を報告

Refs: #52
