### PR TITLE
feat(retrieval): Phase 3アグリゲータ戦略の実装 (Issue #67)

### DIFF
--- a/adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -175,15 +175,15 @@ Negative:
 
 ## Migration Plan
 
-This ADR ships in a docs-only PR. No source code changes in this PR.
-
-1. **Phase 2 (this ADR)**: commit `adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md`, append the row to `adr/README.md`. No changes to `src/`.
-2. **Phase 3a** (Issue #67 prerequisite, may bundle into #67 first PR): rename `src/eval/pipeline.rs` → `src/retrieval.rs`. Move the `Hit`/`QueryResult`/`PipelineConfig`/`PipelineError` types and `evaluate` function. Drop `#[cfg(feature = "eval-harness")]` from items in the new module; keep eval-only fixture/baseline/metrics modules behind the feature. Update `src/lib.rs` and `src/bin/eval_harness.rs` to use the new module path. Tests T-011 (and any smoke tests touching `eval::pipeline`) repoint imports.
-3. **Phase 3b** (Issue #67): introduce `Aggregator` trait at the position fixed in Stage 3, with the identity default. Add at least one non-identity strategy (max-chunk-score is the simplest baseline) and re-run the eval baseline.
-4. **Phase 4** (Issue #68): expand Stage 2 with `MergeConfig`/`MergeStrategy`. Tune weights against the eval harness, commit a new `baseline.json`.
-5. **Phase 5** (Issue #69): insert query normalization at Stage 1 entry. Default off; opt-in via config to preserve current behaviour.
-6. **Phase 6** (Issue #70): add `CandidateSource::PrefixEnsemble` variants and the embedding-side fan-out logic.
-7. **Cross-repo follow-ups**: file individual issues against `recall`, `sae`, `yomu` after the first `rurico` bump that exposes `src/retrieval.rs`. Each downstream adopts at its own pace; `rurico` does not change `recall`/`sae`/`yomu` directly (cross-repo issue rule, ADR 0001 migration pattern).
+1. **Phase 2 (this ADR)**: commit `adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md`, append the row to `adr/README.md`. No changes to `src/`. **Done 2026-04-26 (PR #74).**
+2. **Phase 3** (Issue #67, **implemented 2026-04-26**): introduce `MergedHit` and the `Aggregator` trait at the position fixed in Stage 3, plus four impls (`IdentityAggregator`, `MaxChunkAggregator`, `DedupeAggregator`, `TopKAverageAggregator`). New surface lives in `src/retrieval.rs` with no feature gate. `eval/pipeline.rs::evaluate` takes an `&impl Aggregator` parameter; the harness dispatches by `aggregation=identity|max-chunk|dedupe|topk-average` argv. `BaselineSnapshot` gains `aggregation: String` (serde-default `"identity"` so pre-Phase-3 files round-trip).
+   - **Pipeline-shape finding**: `rrf_merge` (`src/storage/search.rs:154`) fuses on `doc_id` via `HashMap`, so its output is already unique. Combined with one-chunk-per-`EvalDocument` indexing, every non-identity aggregator is **structurally identical** to identity on the current eval baseline. Strategy correctness is validated via synthetic multi-hit unit tests in `src/retrieval.rs`; non-vacuous baseline evaluation arrives once chunk-level retrieval lands (item 7 below).
+   - **Deferred from this ADR's wording**: full `eval/pipeline.rs` → `src/retrieval.rs` rename. The Aggregator surface is what Phase 3+ needs; the reference composition stays in `eval/pipeline.rs` until a downstream consumer needs to share more of the wiring.
+3. **Phase 4** (Issue #68): expand Stage 2 with `MergeConfig`/`MergeStrategy`. Tune weights against the eval harness, commit a new `baseline.json`.
+4. **Phase 5** (Issue #69): insert query normalization at Stage 1 entry. Default off; opt-in via config to preserve current behaviour.
+5. **Phase 6** (Issue #70): add `CandidateSource::PrefixEnsemble` variants and the embedding-side fan-out logic.
+6. **Cross-repo follow-ups**: file individual issues against `recall`, `sae`, `yomu` after the first `rurico` bump that exposes `src/retrieval.rs`. Each downstream adopts at its own pace; `rurico` does not change `recall`/`sae`/`yomu` directly (cross-repo issue rule, ADR 0001 migration pattern).
+7. **Chunk-level retrieval follow-up** (separate issue, prerequisite for non-vacuous aggregation evaluation): extend `ChunkedEmbedding` with `chunk_id` metadata, switch the reference pipeline to chunk-level indexing, add the parent-child helper, and capture per-strategy baselines that reflect actual ranking changes. Touches `recall`/`sae`/`yomu` schema, so it ships under its own issue rather than #67.
 
 ## Reassessment Triggers
 

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -123,7 +123,7 @@ const RURI_V3_310M_REVISION: &str = "pinned-via-rurico-embed-cache";
 /// [`build_one_metric`]; aliased to silence `clippy::type_complexity`.
 ///
 /// Accepts borrowed `&[&str]` of ranked doc ids — callers project from
-/// `Hit.doc_id: String` without cloning each id per metric per query.
+/// `MergedHit.doc_id: String` without cloning each id per metric per query.
 type MetricFn = fn(&[&str], &HashMap<String, u8>, usize) -> f64;
 
 /// Closed set of Stage 3 aggregation kinds. Anchors `aggregation=` argv
@@ -138,15 +138,16 @@ enum AggregationKind {
 }
 
 impl AggregationKind {
-    /// Stable label written to `BaselineSnapshot.aggregation`. The
-    /// `TopKAverage` discriminator drops `k` so the field round-trips against
-    /// the canonical name in [`VALID_AGGREGATION_KINDS`].
-    const fn name(self) -> &'static str {
+    /// Stable label written to `BaselineSnapshot.aggregation`. `TopKAverage`
+    /// encodes `k` as `"topk-average:K"` so a baseline captured with a
+    /// non-default `k` round-trips through [`Self::from_name`] without
+    /// silently falling back to [`DEFAULT_TOPK_AVERAGE_K`] at verify time.
+    fn name(self) -> String {
         match self {
-            Self::Identity => "identity",
-            Self::MaxChunk => "max-chunk",
-            Self::Dedupe => "dedupe",
-            Self::TopKAverage(_) => "topk-average",
+            Self::Identity => "identity".to_owned(),
+            Self::MaxChunk => "max-chunk".to_owned(),
+            Self::Dedupe => "dedupe".to_owned(),
+            Self::TopKAverage(k) => format!("topk-average:{k}"),
         }
     }
 
@@ -178,17 +179,24 @@ impl AggregationKind {
     }
 
     /// Resolve `BaselineSnapshot.aggregation` back to a dispatchable kind for
-    /// `verify-baseline`. `topk-average` uses [`DEFAULT_TOPK_AVERAGE_K`] —
-    /// future work that varies `k` per-baseline can extend the schema.
+    /// `verify-baseline`. Recognises both the encoded `"topk-average:K"` form
+    /// (post-fix) and the legacy bare `"topk-average"` form (pre-fix
+    /// baselines fall back to [`DEFAULT_TOPK_AVERAGE_K`]).
     fn from_name(name: &str) -> Result<Self, String> {
         match name {
             "identity" => Ok(Self::Identity),
             "max-chunk" => Ok(Self::MaxChunk),
             "dedupe" => Ok(Self::Dedupe),
             "topk-average" => Ok(Self::TopKAverage(DEFAULT_TOPK_AVERAGE_K)),
-            other => Err(format!(
-                "unknown aggregation in baseline: {other:?}; expected one of {VALID_AGGREGATION_KINDS:?}"
-            )),
+            other => match other.strip_prefix("topk-average:") {
+                Some(k_str) => k_str
+                    .parse::<usize>()
+                    .map(Self::TopKAverage)
+                    .map_err(|e| format!("topk-average:K parse error in baseline: {e}")),
+                None => Err(format!(
+                    "unknown aggregation in baseline: {other:?}; expected one of {VALID_AGGREGATION_KINDS:?}"
+                )),
+            },
         }
     }
 }
@@ -507,7 +515,7 @@ fn run_capture_baseline_with<E: Embed, R: Rerank>(
         model_revision: RURI_V3_310M_REVISION.to_owned(),
         mlx_rs_version: MLX_RS_VERSION.to_owned(),
         fixture_hash,
-        aggregation: aggregation.name().to_owned(),
+        aggregation: aggregation.name(),
         global,
         per_category,
         latency_p50_ms,
@@ -991,4 +999,65 @@ fn hash_fixture_dir(fixture_dir: &Path) -> Result<String, String> {
         }
     }
     Ok(format!("fnv1a64:{hash:016x}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-067-007: aggregation_kind_topk_average_roundtrips_through_name
+    //
+    // Codex P2 / CodeRabbit minor (PR #75): a non-default `topk_k=` passed at
+    // capture time used to be silently downgraded to DEFAULT_TOPK_AVERAGE_K
+    // by `from_name` at verify time. Encode `k` in the serialised name and
+    // round-trip to keep the strategy bit-identical across capture/verify.
+    #[test]
+    fn aggregation_kind_topk_average_roundtrips_through_name() {
+        for k in [1, 3, 5, 100] {
+            let original = AggregationKind::TopKAverage(k);
+            let name = original.name();
+            assert_eq!(
+                name,
+                format!("topk-average:{k}"),
+                "TopKAverage({k}) must encode k in name"
+            );
+            let parsed =
+                AggregationKind::from_name(&name).expect("encoded topk-average must parse back");
+            assert_eq!(
+                parsed, original,
+                "round-trip lost k for TopKAverage({k}): {parsed:?}"
+            );
+        }
+    }
+
+    // T-067-008: aggregation_kind_legacy_topk_average_falls_back_to_default
+    //
+    // Pre-fix baselines wrote bare "topk-average" without `k`. Verify-baseline
+    // must continue to parse those, falling back to DEFAULT_TOPK_AVERAGE_K so
+    // operators with committed snapshots aren't forced to recapture.
+    #[test]
+    fn aggregation_kind_legacy_topk_average_falls_back_to_default() {
+        let parsed = AggregationKind::from_name("topk-average")
+            .expect("legacy bare topk-average must still parse");
+        assert_eq!(parsed, AggregationKind::TopKAverage(DEFAULT_TOPK_AVERAGE_K));
+    }
+
+    // T-067-009: aggregation_kind_simple_variants_roundtrip
+    //
+    // Identity / MaxChunk / Dedupe carry no `k` payload, but they share the
+    // round-trip contract — `name()` → `from_name()` must yield the original
+    // variant.
+    #[test]
+    fn aggregation_kind_simple_variants_roundtrip() {
+        for original in [
+            AggregationKind::Identity,
+            AggregationKind::MaxChunk,
+            AggregationKind::Dedupe,
+        ] {
+            let name = original.name();
+            let parsed =
+                AggregationKind::from_name(&name).expect("simple variant name must round-trip");
+            assert_eq!(parsed, original, "round-trip mismatch for {original:?}");
+        }
+    }
 }

--- a/src/bin/eval_harness.rs
+++ b/src/bin/eval_harness.rs
@@ -41,8 +41,13 @@ use rurico::eval::fixture::{
     EvalDocument, EvalQuery, load_documents, load_known_answers, load_queries,
 };
 use rurico::eval::metrics::{MetricResult, bootstrap_ci, mrr_at_k, ndcg_at_k, recall_at_k};
-use rurico::eval::pipeline::{PipelineConfig, QueryResult, evaluate as run_pipeline};
+use rurico::eval::pipeline::{
+    PipelineConfig, PipelineError, QueryResult, evaluate as run_pipeline,
+};
 use rurico::reranker::Rerank;
+use rurico::retrieval::{
+    DedupeAggregator, IdentityAggregator, MaxChunkAggregator, TopKAverageAggregator,
+};
 use rurico::sandbox::exit_if_seatbelt;
 use rurico::{embed, model_probe, reranker};
 
@@ -88,6 +93,16 @@ const BOOTSTRAP_SEED: u64 = 42;
 /// argv validation in `run_evaluate` and the dispatch in `load_fixture_for_kind`.
 const VALID_EVALUATE_KINDS: &[&str] = &["full", "shuffled", "identity", "reverse", "single_doc"];
 
+/// Closed set of Stage 3 aggregation kinds accepted by `aggregation=...`.
+/// Anchors argv validation and round-tripping with the `aggregation` field on
+/// [`BaselineSnapshot`] (Issue #67 / Phase 3).
+const VALID_AGGREGATION_KINDS: &[&str] = &["identity", "max-chunk", "dedupe", "topk-average"];
+
+/// Default `k` for the `topk-average` strategy when no `topk_k=` override is
+/// supplied. `k = 3` matches the issue body's "top-k average over the top
+/// chunks per document" framing without needing a flag for first capture.
+const DEFAULT_TOPK_AVERAGE_K: usize = 3;
+
 /// Exit code for a metric regression detected by `verify-baseline`. Reserved
 /// for *expected* failure modes — the gate fired because numbers moved.
 const EXIT_REGRESSION: u8 = 1;
@@ -110,6 +125,126 @@ const RURI_V3_310M_REVISION: &str = "pinned-via-rurico-embed-cache";
 /// Accepts borrowed `&[&str]` of ranked doc ids — callers project from
 /// `Hit.doc_id: String` without cloning each id per metric per query.
 type MetricFn = fn(&[&str], &HashMap<String, u8>, usize) -> f64;
+
+/// Closed set of Stage 3 aggregation kinds. Anchors `aggregation=` argv
+/// validation, the JSON `aggregation` field on [`BaselineSnapshot`], and
+/// [`run_verify_baseline`]'s reverse lookup of which strategy to dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AggregationKind {
+    Identity,
+    MaxChunk,
+    Dedupe,
+    TopKAverage(usize),
+}
+
+impl AggregationKind {
+    /// Stable label written to `BaselineSnapshot.aggregation`. The
+    /// `TopKAverage` discriminator drops `k` so the field round-trips against
+    /// the canonical name in [`VALID_AGGREGATION_KINDS`].
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Identity => "identity",
+            Self::MaxChunk => "max-chunk",
+            Self::Dedupe => "dedupe",
+            Self::TopKAverage(_) => "topk-average",
+        }
+    }
+
+    /// Parse `aggregation=<kind>` (and optional `topk_k=<n>`) from argv `kvs`.
+    /// Returns `Self::Identity` when the key is absent so callers that don't
+    /// pass the flag preserve the pre-Phase-3 behaviour.
+    fn from_kvs(kvs: &HashMap<String, String>) -> Result<Self, String> {
+        let raw = kvs
+            .get("aggregation")
+            .map(String::as_str)
+            .unwrap_or("identity");
+        match raw {
+            "identity" => Ok(Self::Identity),
+            "max-chunk" => Ok(Self::MaxChunk),
+            "dedupe" => Ok(Self::Dedupe),
+            "topk-average" => {
+                let k = match kvs.get("topk_k") {
+                    Some(v) => v
+                        .parse::<usize>()
+                        .map_err(|e| format!("topk_k= parse error: {e}"))?,
+                    None => DEFAULT_TOPK_AVERAGE_K,
+                };
+                Ok(Self::TopKAverage(k))
+            }
+            other => Err(format!(
+                "unknown aggregation: {other:?}; expected one of {VALID_AGGREGATION_KINDS:?}"
+            )),
+        }
+    }
+
+    /// Resolve `BaselineSnapshot.aggregation` back to a dispatchable kind for
+    /// `verify-baseline`. `topk-average` uses [`DEFAULT_TOPK_AVERAGE_K`] —
+    /// future work that varies `k` per-baseline can extend the schema.
+    fn from_name(name: &str) -> Result<Self, String> {
+        match name {
+            "identity" => Ok(Self::Identity),
+            "max-chunk" => Ok(Self::MaxChunk),
+            "dedupe" => Ok(Self::Dedupe),
+            "topk-average" => Ok(Self::TopKAverage(DEFAULT_TOPK_AVERAGE_K)),
+            other => Err(format!(
+                "unknown aggregation in baseline: {other:?}; expected one of {VALID_AGGREGATION_KINDS:?}"
+            )),
+        }
+    }
+}
+
+/// Run [`run_pipeline`] with the concrete aggregator selected by `aggregation`.
+///
+/// Centralises the trait-object-vs-generic dispatch so the four mode handlers
+/// (`evaluate`, `capture-baseline`, `capture-reverse-baseline`,
+/// `verify-baseline`) share the same fan-out.
+fn dispatch_pipeline<E, R>(
+    corpus: &[EvalDocument],
+    queries: &[EvalQuery],
+    embedder: &E,
+    reranker: Option<&R>,
+    aggregation: AggregationKind,
+    config: &PipelineConfig,
+) -> Result<Vec<QueryResult>, PipelineError>
+where
+    E: Embed,
+    R: Rerank,
+{
+    match aggregation {
+        AggregationKind::Identity => run_pipeline(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &IdentityAggregator,
+            config,
+        ),
+        AggregationKind::MaxChunk => run_pipeline(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &MaxChunkAggregator,
+            config,
+        ),
+        AggregationKind::Dedupe => run_pipeline(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &DedupeAggregator,
+            config,
+        ),
+        AggregationKind::TopKAverage(k) => run_pipeline(
+            corpus,
+            queries,
+            embedder,
+            reranker,
+            &TopKAverageAggregator::new(k),
+            config,
+        ),
+    }
+}
 
 /// Closed set of metrics the harness emits in `BaselineSnapshot.global` and
 /// verifies via `verify-baseline`.
@@ -216,14 +351,22 @@ fn main() -> ExitCode {
     }
 }
 
-/// `evaluate kind=...` — run the reference pipeline against the chosen
-/// fixture slice and print metric JSON to stdout.
+/// `evaluate kind=... aggregation=...` — run the reference pipeline against
+/// the chosen fixture slice with the chosen aggregation strategy and print
+/// metric JSON to stdout.
 fn run_evaluate(kvs: &HashMap<String, String>) -> ExitCode {
     let kind = kvs.get("kind").map_or("full", String::as_str);
     if !VALID_EVALUATE_KINDS.contains(&kind) {
         eprintln!("evaluate: unknown kind {kind:?}; expected one of {VALID_EVALUATE_KINDS:?}");
         return ExitCode::from(EXIT_USAGE);
     }
+    let aggregation = match AggregationKind::from_kvs(kvs) {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("evaluate: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
     let ctx = match production_context() {
         Ok(c) => c,
         Err(msg) => {
@@ -232,10 +375,14 @@ fn run_evaluate(kvs: &HashMap<String, String>) -> ExitCode {
         }
     };
     log_run_context(&ctx, "evaluate", Some(kind), None);
-    run_evaluate_with(&ctx, kind)
+    run_evaluate_with(&ctx, kind, aggregation)
 }
 
-fn run_evaluate_with<E: Embed, R: Rerank>(ctx: &EvalContext<E, R>, kind: &str) -> ExitCode {
+fn run_evaluate_with<E: Embed, R: Rerank>(
+    ctx: &EvalContext<E, R>,
+    kind: &str,
+    aggregation: AggregationKind,
+) -> ExitCode {
     let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, kind) {
         Ok(v) => v,
         Err(msg) => {
@@ -244,11 +391,12 @@ fn run_evaluate_with<E: Embed, R: Rerank>(ctx: &EvalContext<E, R>, kind: &str) -
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let mut results = match run_pipeline(
+    let mut results = match dispatch_pipeline(
         &corpus,
         &queries,
         &ctx.embedder,
         Some(&ctx.reranker),
+        aggregation,
         &config,
     ) {
         Ok(r) => r,
@@ -280,8 +428,8 @@ fn run_evaluate_with<E: Embed, R: Rerank>(ctx: &EvalContext<E, R>, kind: &str) -
     }
 }
 
-/// `capture-baseline output=<path>` — run full evaluation + bootstrap CI and
-/// write `BaselineSnapshot` to `output=`.
+/// `capture-baseline output=<path> [aggregation=<kind>]` — run full evaluation
+/// + bootstrap CI and write `BaselineSnapshot` to `output=`.
 fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
     let Some(output_path_raw) = kvs.get("output") else {
         eprintln!("capture-baseline: output= argument required");
@@ -289,6 +437,13 @@ fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
     };
     let output_path = match validate_output_path(output_path_raw) {
         Ok(p) => p,
+        Err(msg) => {
+            eprintln!("capture-baseline: {msg}");
+            return ExitCode::from(EXIT_USAGE);
+        }
+    };
+    let aggregation = match AggregationKind::from_kvs(kvs) {
+        Ok(a) => a,
         Err(msg) => {
             eprintln!("capture-baseline: {msg}");
             return ExitCode::from(EXIT_USAGE);
@@ -302,12 +457,13 @@ fn run_capture_baseline(kvs: &HashMap<String, String>) -> ExitCode {
         }
     };
     log_run_context(&ctx, "capture-baseline", None, Some(&output_path));
-    run_capture_baseline_with(&ctx, &output_path)
+    run_capture_baseline_with(&ctx, &output_path, aggregation)
 }
 
 fn run_capture_baseline_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     output_path: &Path,
+    aggregation: AggregationKind,
 ) -> ExitCode {
     let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, "full") {
         Ok(v) => v,
@@ -324,11 +480,12 @@ fn run_capture_baseline_with<E: Embed, R: Rerank>(
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let results = match run_pipeline(
+    let results = match dispatch_pipeline(
         &corpus,
         &queries,
         &ctx.embedder,
         Some(&ctx.reranker),
+        aggregation,
         &config,
     ) {
         Ok(r) => r,
@@ -350,6 +507,7 @@ fn run_capture_baseline_with<E: Embed, R: Rerank>(
         model_revision: RURI_V3_310M_REVISION.to_owned(),
         mlx_rs_version: MLX_RS_VERSION.to_owned(),
         fixture_hash,
+        aggregation: aggregation.name().to_owned(),
         global,
         per_category,
         latency_p50_ms,
@@ -401,11 +559,15 @@ fn run_capture_reverse_baseline_with<E: Embed, R: Rerank>(
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let mut results = match run_pipeline(
+    // Reverse baseline measures the nDCG lower bound under a flipped ranking;
+    // aggregation choice is irrelevant once `reverse_each_ranking` runs, so
+    // pin to `Identity` to keep the lower-bound contract independent of #67.
+    let mut results = match dispatch_pipeline(
         &corpus,
         &queries,
         &ctx.embedder,
         Some(&ctx.reranker),
+        AggregationKind::Identity,
         &config,
     ) {
         Ok(r) => r,
@@ -508,6 +670,13 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
     ctx: &EvalContext<E, R>,
     committed: &BaselineSnapshot,
 ) -> ExitCode {
+    let aggregation = match AggregationKind::from_name(&committed.aggregation) {
+        Ok(a) => a,
+        Err(msg) => {
+            eprintln!("verify-baseline: {msg}");
+            return ExitCode::from(EXIT_INFRA);
+        }
+    };
     let (corpus, queries) = match load_fixture_for_kind(&ctx.fixture_dir, "full") {
         Ok(v) => v,
         Err(msg) => {
@@ -516,11 +685,12 @@ fn run_verify_baseline_with<E: Embed, R: Rerank>(
         }
     };
     let config = PipelineConfig { k: PIPELINE_K };
-    let results = match run_pipeline(
+    let results = match dispatch_pipeline(
         &corpus,
         &queries,
         &ctx.embedder,
         Some(&ctx.reranker),
+        aggregation,
         &config,
     ) {
         Ok(r) => r,

--- a/src/eval/baseline.rs
+++ b/src/eval/baseline.rs
@@ -75,6 +75,13 @@ pub struct BaselineSnapshot {
     pub mlx_rs_version: String,
     /// Content hash over `documents.jsonl + queries.jsonl + known_answers.jsonl`.
     pub fixture_hash: String,
+    /// Stage 3 aggregation strategy used for capture (Issue #67 / Phase 3).
+    ///
+    /// Pre-Phase-3 baselines lack this field; `serde(default)` resolves it to
+    /// `"identity"` so the existing committed `baseline.json` round-trips.
+    /// `verify-baseline` reads it back to dispatch the same aggregator.
+    #[serde(default = "default_aggregation_kind")]
+    pub aggregation: String,
     /// Global metric results (regression gate per BR-001).
     pub global: Vec<MetricResult>,
     /// Per-category metric breakdown for exploratory inspection.
@@ -83,6 +90,10 @@ pub struct BaselineSnapshot {
     pub latency_p50_ms: f64,
     /// 95th percentile per-query latency in milliseconds.
     pub latency_p95_ms: f64,
+}
+
+fn default_aggregation_kind() -> String {
+    "identity".to_owned()
 }
 
 /// Errors surfaced when writing a [`BaselineSnapshot`].
@@ -260,6 +271,7 @@ mod tests {
             model_revision: "rev".to_owned(),
             mlx_rs_version: "0.0.0".to_owned(),
             fixture_hash: "fnv1a64:0".to_owned(),
+            aggregation: default_aggregation_kind(),
             global: vec![],
             per_category: BTreeMap::new(),
             latency_p50_ms: 0.0,

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -40,22 +40,18 @@ const RRF_CANDIDATE_MULTIPLIER: usize = 3;
 /// (mrr / ndcg_at_10 unchanged versus a 10,000-combo cap).
 const MAX_COMBOS: usize = 100;
 
-/// Single ranked hit from the pipeline.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Hit {
-    /// Document identifier (matches `EvalDocument::id`).
-    pub doc_id: String,
-    /// Aggregated relevance score after RRF merge and optional rerank.
-    pub score: f64,
-}
-
 /// One query's pipeline output: ordered hits + wall-clock latency.
+///
+/// `ranked_hits` reuses [`MergedHit`] — the same type passed across the Stage
+/// 3 boundary — so the rerank tail no longer round-trips through a separate
+/// `Hit` shape. Downstream callers should still treat the slice as sorted by
+/// descending `score`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResult {
     /// Identifier of the input [`EvalQuery`].
     pub query_id: String,
-    /// Hits sorted by descending [`Hit::score`].
-    pub ranked_hits: Vec<Hit>,
+    /// Hits sorted by descending [`MergedHit::score`].
+    pub ranked_hits: Vec<MergedHit>,
     /// Wall-clock latency for this single query in milliseconds.
     pub latency_ms: u64,
 }
@@ -225,7 +221,7 @@ fn run_single_query<E, R, A>(
     aggregator: &A,
     corpus_index: &HashMap<&str, &str>,
     config: &PipelineConfig,
-) -> Result<Vec<Hit>, PipelineError>
+) -> Result<Vec<MergedHit>, PipelineError>
 where
     E: Embed,
     R: Rerank,
@@ -240,22 +236,17 @@ where
         .into_iter()
         .map(|(doc_id, score)| MergedHit { doc_id, score })
         .collect();
-    let aggregated = aggregator.aggregate(&merged_hits);
-    let mut after_aggregation: Vec<(String, f64)> = aggregated
-        .into_iter()
-        .map(|h| (h.doc_id, h.score))
-        .collect();
-    after_aggregation.truncate(config.k);
+    // Aggregator::aggregate guarantees score-descending output (see trait
+    // doc), so truncate-then-rerank does not silently drop higher-scoring
+    // hits.
+    let mut aggregated = aggregator.aggregate(&merged_hits);
+    aggregated.truncate(config.k);
 
     if let Some(reranker) = reranker {
-        after_aggregation =
-            apply_reranker(reranker, &query.text, &after_aggregation, corpus_index)?;
+        aggregated = apply_reranker(reranker, &query.text, aggregated, corpus_index)?;
     }
 
-    Ok(after_aggregation
-        .into_iter()
-        .map(|(doc_id, score)| Hit { doc_id, score })
-        .collect())
+    Ok(aggregated)
 }
 
 /// FTS5 retrieval. Empty / unsanitisable queries return an empty hit list
@@ -416,27 +407,34 @@ fn retrieve_vec<E: Embed>(
 
 /// Rescore `merged` via `reranker.rerank(query, doc_bodies)`.
 ///
-/// Builds a parallel `(doc_id, body)` slice from `merged` filtered by
-/// `corpus_index` membership, then feeds the body slice to the reranker. The
-/// reranker's returned `index` maps back to the same filtered slice — so a
-/// missing-from-corpus entry never causes a misalignment between
-/// reranker output and merged identity. Rerank score (`f32`) widens
-/// to `f64` to keep the merged list type consistent.
+/// Consumes `merged` and yields a fresh `Vec<MergedHit>` with rerank scores
+/// in place of RRF scores. Filters by `corpus_index` membership before
+/// scoring, so the reranker's returned `index` aligns with the same filtered
+/// slice and no missing-from-corpus entry can misalign rerank output with
+/// merged identity. Rerank score (`f32`) widens to `f64` to keep the merged
+/// list type consistent.
 fn apply_reranker<R: Rerank>(
     reranker: &R,
     query: &str,
-    merged: &[(String, f64)],
+    merged: Vec<MergedHit>,
     corpus_index: &HashMap<&str, &str>,
-) -> Result<Vec<(String, f64)>, PipelineError> {
-    let (resolved_ids, bodies): (Vec<&String>, Vec<&str>) = merged
-        .iter()
-        .filter_map(|(id, _)| corpus_index.get(id.as_str()).map(|body| (id, *body)))
+) -> Result<Vec<MergedHit>, PipelineError> {
+    let (resolved_ids, bodies): (Vec<String>, Vec<&str>) = merged
+        .into_iter()
+        .filter_map(|h| {
+            corpus_index
+                .get(h.doc_id.as_str())
+                .map(|body| (h.doc_id, *body))
+        })
         .unzip();
     let ranked_results = reranker.rerank(query, &bodies)?;
     let mut reranked = Vec::with_capacity(ranked_results.len());
     for r in ranked_results {
         if let Some(doc_id) = resolved_ids.get(r.index) {
-            reranked.push(((*doc_id).clone(), f64::from(r.score)));
+            reranked.push(MergedHit {
+                doc_id: doc_id.clone(),
+                score: f64::from(r.score),
+            });
         }
     }
     Ok(reranked)

--- a/src/eval/pipeline.rs
+++ b/src/eval/pipeline.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use crate::embed::{EMBEDDING_DIMS, Embed, EmbedError};
 use crate::eval::fixture::{EvalDocument, EvalQuery};
 use crate::reranker::{Rerank, RerankerError};
+use crate::retrieval::{Aggregator, MergedHit};
 use crate::storage::{
     MatchFtsQuery, SanitizeError, ensure_sqlite_vec, f32_as_bytes, prepare_match_query, rrf_merge,
 };
@@ -115,16 +116,18 @@ pub enum PipelineError {
 /// See [`PipelineError`] variants. Sqlite, embed, rerank, and sanitize errors
 /// each surface their respective source via `#[from]`; sqlite-vec load
 /// failure surfaces as [`PipelineError::SqliteVec`].
-pub fn evaluate<E, R>(
+pub fn evaluate<E, R, A>(
     corpus: &[EvalDocument],
     queries: &[EvalQuery],
     embedder: &E,
     reranker: Option<&R>,
+    aggregator: &A,
     config: &PipelineConfig,
 ) -> Result<Vec<QueryResult>, PipelineError>
 where
     E: Embed,
     R: Rerank,
+    A: Aggregator,
 {
     ensure_sqlite_vec().map_err(PipelineError::SqliteVec)?;
     let conn = Connection::open_in_memory()?;
@@ -142,8 +145,15 @@ where
     let mut results = Vec::with_capacity(queries.len());
     for query in queries {
         let started = Instant::now();
-        let ranked_hits =
-            run_single_query(&conn, query, embedder, reranker, &corpus_index, config)?;
+        let ranked_hits = run_single_query(
+            &conn,
+            query,
+            embedder,
+            reranker,
+            aggregator,
+            &corpus_index,
+            config,
+        )?;
         let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
         results.push(QueryResult {
             query_id: query.id.clone(),
@@ -205,31 +215,44 @@ fn index_corpus<E: Embed>(
     Ok(())
 }
 
-/// Drive one `EvalQuery` through FTS + vec retrieval, RRF merge, and (when
-/// supplied) reranker rescoring.
-fn run_single_query<E, R>(
+/// Drive one `EvalQuery` through FTS + vec retrieval, RRF merge, Stage 3
+/// aggregation, and (when supplied) reranker rescoring.
+fn run_single_query<E, R, A>(
     conn: &Connection,
     query: &EvalQuery,
     embedder: &E,
     reranker: Option<&R>,
+    aggregator: &A,
     corpus_index: &HashMap<&str, &str>,
     config: &PipelineConfig,
 ) -> Result<Vec<Hit>, PipelineError>
 where
     E: Embed,
     R: Rerank,
+    A: Aggregator,
 {
     let candidate_limit = config.k * RRF_CANDIDATE_MULTIPLIER;
     let fts_hits = retrieve_fts(conn, &query.text, candidate_limit)?;
     let vec_hits = retrieve_vec(conn, embedder, &query.text, candidate_limit)?;
-    let mut merged = rrf_merge(&fts_hits, &vec_hits);
-    merged.truncate(config.k);
+    let merged = rrf_merge(&fts_hits, &vec_hits);
+
+    let merged_hits: Vec<MergedHit> = merged
+        .into_iter()
+        .map(|(doc_id, score)| MergedHit { doc_id, score })
+        .collect();
+    let aggregated = aggregator.aggregate(&merged_hits);
+    let mut after_aggregation: Vec<(String, f64)> = aggregated
+        .into_iter()
+        .map(|h| (h.doc_id, h.score))
+        .collect();
+    after_aggregation.truncate(config.k);
 
     if let Some(reranker) = reranker {
-        merged = apply_reranker(reranker, &query.text, &merged, corpus_index)?;
+        after_aggregation =
+            apply_reranker(reranker, &query.text, &after_aggregation, corpus_index)?;
     }
 
-    Ok(merged
+    Ok(after_aggregation
         .into_iter()
         .map(|(doc_id, score)| Hit { doc_id, score })
         .collect())
@@ -427,6 +450,7 @@ mod tests {
     use crate::embed::MockEmbedder;
     use crate::eval::fixture::{EvalDocument, EvalQuery};
     use crate::reranker::MockReranker;
+    use crate::retrieval::IdentityAggregator;
 
     /// Build an [`EvalDocument`] with stub title / source. The body carries
     /// the surface text the FTS5 + vec wiring will see.
@@ -472,9 +496,10 @@ mod tests {
         let queries = vec![make_query("q1", "alpha retrieval", "d1")];
         let embedder = MockEmbedder::default();
         let reranker: Option<&MockReranker> = None;
+        let aggregator = IdentityAggregator;
         let config = PipelineConfig { k: 5 };
 
-        let result = evaluate(&corpus, &queries, &embedder, reranker, &config)
+        let result = evaluate(&corpus, &queries, &embedder, reranker, &aggregator, &config)
             .expect("pipeline must succeed with MockEmbedder + no reranker");
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod model_probe;
 pub mod modernbert;
 /// Cross-encoder reranker for query-document relevance scoring.
 pub mod reranker;
+/// Retrieval pipeline contract: Stage 3 [`Aggregator`](retrieval::Aggregator) hook (ADR 0004, Issue #67).
+pub mod retrieval;
 /// Codex seatbelt sandbox detection for MLX runtime gating.
 ///
 /// Internal support API used by smoke binaries and integration tests. Exposed

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1,0 +1,274 @@
+//! Retrieval pipeline contract (ADR 0004, Issue #67 / Phase 3).
+//!
+//! Plug-in points frozen by ADR 0004:
+//! - Stage 3 aggregation: [`Aggregator`] trait between merge and rerank.
+//!   Default impl is [`IdentityAggregator`].
+//!
+//! Concrete strategies ([`MaxChunkAggregator`], [`DedupeAggregator`],
+//! [`TopKAverageAggregator`]) live alongside the trait; downstream crates can
+//! also supply their own `impl Aggregator` for domain-specific dedupers.
+//!
+//! ## Pipeline shape note
+//!
+//! `rrf_merge` (`src/storage/search.rs`) fuses ranks via a `HashMap` keyed by
+//! `doc_id`, so its output already carries unique identifiers. With the
+//! current pipeline that indexes one chunk per `EvalDocument`, every
+//! non-identity aggregator therefore behaves as identity on the eval baseline.
+//! Strategy correctness is validated via synthetic multi-hit unit tests;
+//! non-vacuous evaluation arrives once chunk-level retrieval lands (parent-
+//! child / `chunk_id` follow-up).
+
+use std::collections::HashMap;
+
+/// Single candidate after Stage 2 (RRF merge) — input/output for [`Aggregator`].
+///
+/// Score sign is "higher is better" (post-RRF fused score). Stage 3 may
+/// rewrite, drop, or re-order entries; the resulting `Vec` becomes the input
+/// to Stage 4 (rerank).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MergedHit {
+    /// Document or chunk identifier carried through Stage 1+2.
+    pub doc_id: String,
+    /// Aggregated relevance score (RRF score).
+    pub score: f64,
+}
+
+/// Stage 3 hook: aggregate / dedupe / re-order [`MergedHit`]s before Stage 4.
+///
+/// ADR 0004 fixes the position (between Stage 2 merge and Stage 4 rerank) and
+/// the surface; this trait is the only stable extension point. Granularity
+/// (chunk vs document) and ordering guarantees are strategy-specific —
+/// implementations document their own contract.
+pub trait Aggregator {
+    /// Aggregate `hits` into the form Stage 4 expects.
+    ///
+    /// Output ordering should be score-descending unless the strategy
+    /// explicitly preserves rank order. Output length may be ≤ input length
+    /// (dedupe / max-chunk collapse duplicates).
+    fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit>;
+}
+
+/// Identity aggregator — returns the input unchanged.
+///
+/// Default for the reference pipeline composition; preserves the pre-Phase-3
+/// behaviour where each `EvalDocument` produces exactly one hit.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct IdentityAggregator;
+
+impl Aggregator for IdentityAggregator {
+    fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit> {
+        hits.to_vec()
+    }
+}
+
+/// Same-document max-score aggregator — keeps the maximum score per `doc_id`,
+/// then re-orders by score descending (ties broken by `doc_id` ascending).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MaxChunkAggregator;
+
+impl Aggregator for MaxChunkAggregator {
+    fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit> {
+        let mut best: HashMap<&str, f64> = HashMap::new();
+        for hit in hits {
+            let entry = best.entry(hit.doc_id.as_str()).or_insert(f64::MIN);
+            if hit.score > *entry {
+                *entry = hit.score;
+            }
+        }
+        let mut output: Vec<MergedHit> = best
+            .into_iter()
+            .map(|(id, score)| MergedHit {
+                doc_id: id.to_owned(),
+                score,
+            })
+            .collect();
+        output.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_id.cmp(&b.doc_id))
+        });
+        output
+    }
+}
+
+/// First-occurrence dedupe aggregator — preserves the rank-order of the first
+/// hit per `doc_id`, drops subsequent duplicates.
+///
+/// Unlike [`MaxChunkAggregator`] this keeps the first hit's score (typically
+/// the higher rank from RRF), making it a structural dedupe rather than a
+/// score-aware collapse.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DedupeAggregator;
+
+impl Aggregator for DedupeAggregator {
+    fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit> {
+        let mut seen: HashMap<&str, ()> = HashMap::new();
+        let mut output = Vec::with_capacity(hits.len());
+        for hit in hits {
+            if seen.insert(hit.doc_id.as_str(), ()).is_none() {
+                output.push(hit.clone());
+            }
+        }
+        output
+    }
+}
+
+/// Top-k average aggregator — for each `doc_id`, averages its highest `k`
+/// scores. Output is sorted by aggregate score descending.
+#[derive(Debug, Clone, Copy)]
+pub struct TopKAverageAggregator {
+    /// Number of top-scoring hits per `doc_id` to include in the average. A
+    /// `doc_id` with fewer than `k` hits averages over all of them. `k = 0`
+    /// returns an empty output.
+    pub k: usize,
+}
+
+impl TopKAverageAggregator {
+    /// Construct with the given top-k cutoff.
+    pub fn new(k: usize) -> Self {
+        Self { k }
+    }
+}
+
+impl Aggregator for TopKAverageAggregator {
+    fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit> {
+        if self.k == 0 {
+            return Vec::new();
+        }
+        let mut buckets: HashMap<&str, Vec<f64>> = HashMap::new();
+        for hit in hits {
+            buckets
+                .entry(hit.doc_id.as_str())
+                .or_default()
+                .push(hit.score);
+        }
+        let mut output: Vec<MergedHit> = buckets
+            .into_iter()
+            .map(|(id, mut scores)| {
+                scores.sort_by(|a, b| b.total_cmp(a));
+                scores.truncate(self.k);
+                #[allow(clippy::cast_precision_loss)]
+                let mean = scores.iter().sum::<f64>() / scores.len() as f64;
+                MergedHit {
+                    doc_id: id.to_owned(),
+                    score: mean,
+                }
+            })
+            .collect();
+        output.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_id.cmp(&b.doc_id))
+        });
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hit(id: &str, score: f64) -> MergedHit {
+        MergedHit {
+            doc_id: id.to_owned(),
+            score,
+        }
+    }
+
+    // T-067-001: identity_returns_input_unchanged
+    #[test]
+    fn identity_returns_input_unchanged() {
+        let aggregator = IdentityAggregator;
+        let input = vec![hit("d1", 0.9), hit("d2", 0.7), hit("d1", 0.5)];
+        let output = aggregator.aggregate(&input);
+        assert_eq!(output, input, "Identity must preserve input verbatim");
+    }
+
+    // T-067-002: max_chunk_collapses_duplicates_to_max_score
+    #[test]
+    fn max_chunk_collapses_duplicates_to_max_score() {
+        let aggregator = MaxChunkAggregator;
+        let input = vec![
+            hit("d1", 0.5),
+            hit("d2", 0.7),
+            hit("d1", 0.9),
+            hit("d3", 0.6),
+        ];
+        let output = aggregator.aggregate(&input);
+        assert_eq!(
+            output,
+            vec![hit("d1", 0.9), hit("d2", 0.7), hit("d3", 0.6)],
+            "MaxChunk should keep d1=0.9 (max) and sort by score desc"
+        );
+    }
+
+    // T-067-003: dedupe_keeps_first_occurrence_per_doc_id
+    #[test]
+    fn dedupe_keeps_first_occurrence_per_doc_id() {
+        let aggregator = DedupeAggregator;
+        let input = vec![
+            hit("d1", 0.9),
+            hit("d2", 0.7),
+            hit("d1", 0.5),
+            hit("d3", 0.6),
+            hit("d2", 0.4),
+        ];
+        let output = aggregator.aggregate(&input);
+        assert_eq!(
+            output,
+            vec![hit("d1", 0.9), hit("d2", 0.7), hit("d3", 0.6)],
+            "Dedupe should keep input rank-order and drop later duplicates"
+        );
+    }
+
+    // T-067-004: topk_average_averages_top_k_per_doc_id
+    //
+    // Uses IEEE-754-exact dyadic fractions (1.0, 0.5, 0.25, 0.125) so the
+    // observed averages compare bit-equal to the expected values.
+    #[test]
+    fn topk_average_averages_top_k_per_doc_id() {
+        let aggregator = TopKAverageAggregator::new(2);
+        let input = vec![
+            hit("d1", 1.0),
+            hit("d1", 0.5),
+            hit("d1", 0.25),
+            hit("d2", 0.5),
+            hit("d2", 0.25),
+            hit("d3", 0.125),
+        ];
+        let output = aggregator.aggregate(&input);
+        // d1 top-2 = (1.0 + 0.5) / 2  = 0.75
+        // d2 top-2 = (0.5 + 0.25) / 2 = 0.375
+        // d3 top-1 = 0.125            = 0.125
+        assert_eq!(
+            output,
+            vec![hit("d1", 0.75), hit("d2", 0.375), hit("d3", 0.125)],
+            "TopK avg should take top-k scores per doc_id and sort by mean desc"
+        );
+    }
+
+    // T-067-005: topk_average_with_zero_k_returns_empty
+    #[test]
+    fn topk_average_with_zero_k_returns_empty() {
+        let aggregator = TopKAverageAggregator::new(0);
+        let input = vec![hit("d1", 0.9), hit("d2", 0.7)];
+        let output = aggregator.aggregate(&input);
+        assert!(output.is_empty(), "k=0 should return empty");
+    }
+
+    // T-067-006: max_chunk_handles_unique_input_unchanged_in_descending_order
+    //
+    // Documents the structural-identity fact called out in the module doc:
+    // when input doc_ids are already unique (current pipeline shape), the
+    // observable difference between MaxChunk and Identity is only the sort.
+    #[test]
+    fn max_chunk_unique_input_only_resorts() {
+        let aggregator = MaxChunkAggregator;
+        let input = vec![hit("d1", 0.9), hit("d2", 0.7), hit("d3", 0.5)];
+        let output = aggregator.aggregate(&input);
+        assert_eq!(
+            output, input,
+            "MaxChunk on already-unique input must equal input"
+        );
+    }
+}

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -20,12 +20,16 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 /// Single candidate after Stage 2 (RRF merge) — input/output for [`Aggregator`].
 ///
 /// Score sign is "higher is better" (post-RRF fused score). Stage 3 may
 /// rewrite, drop, or re-order entries; the resulting `Vec` becomes the input
-/// to Stage 4 (rerank).
-#[derive(Debug, Clone, PartialEq)]
+/// to Stage 4 (rerank). Also serves as the public ranked-hit type returned
+/// from `eval::pipeline::QueryResult` — Serialize/Deserialize keep the
+/// pipeline output JSON shape unchanged across the merge boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MergedHit {
     /// Document or chunk identifier carried through Stage 1+2.
     pub doc_id: String,
@@ -37,21 +41,25 @@ pub struct MergedHit {
 ///
 /// ADR 0004 fixes the position (between Stage 2 merge and Stage 4 rerank) and
 /// the surface; this trait is the only stable extension point. Granularity
-/// (chunk vs document) and ordering guarantees are strategy-specific —
-/// implementations document their own contract.
+/// (chunk vs document) is strategy-specific — implementations document their
+/// own dedupe / collapse contract.
 pub trait Aggregator {
     /// Aggregate `hits` into the form Stage 4 expects.
     ///
-    /// Output ordering should be score-descending unless the strategy
-    /// explicitly preserves rank order. Output length may be ≤ input length
-    /// (dedupe / max-chunk collapse duplicates).
+    /// **Output MUST be sorted by `score` descending** (with deterministic
+    /// tiebreaking by `doc_id` when scores are equal). The pipeline truncates
+    /// the result to `config.k` after this call, so non-sorted output would
+    /// silently drop higher-scoring hits. Output length may be ≤ input
+    /// length (dedupe / max-chunk collapse duplicates).
     fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit>;
 }
 
 /// Identity aggregator — returns the input unchanged.
 ///
 /// Default for the reference pipeline composition; preserves the pre-Phase-3
-/// behaviour where each `EvalDocument` produces exactly one hit.
+/// behaviour where each `EvalDocument` produces exactly one hit. The sort
+/// invariant is upheld by pass-through because Stage 2 RRF merge already
+/// emits score-descending output.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct IdentityAggregator;
 
@@ -96,7 +104,9 @@ impl Aggregator for MaxChunkAggregator {
 ///
 /// Unlike [`MaxChunkAggregator`] this keeps the first hit's score (typically
 /// the higher rank from RRF), making it a structural dedupe rather than a
-/// score-aware collapse.
+/// score-aware collapse. The sort invariant is upheld because Stage 2 RRF
+/// merge already emits score-descending output and dedupe drops later
+/// duplicates without re-ordering.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DedupeAggregator;
 
@@ -256,7 +266,7 @@ mod tests {
         assert!(output.is_empty(), "k=0 should return empty");
     }
 
-    // T-067-006: max_chunk_handles_unique_input_unchanged_in_descending_order
+    // T-067-006: max_chunk_unique_input_only_resorts
     //
     // Documents the structural-identity fact called out in the module doc:
     // when input doc_ids are already unique (current pipeline shape), the

--- a/tests/fixtures/eval/baseline.json
+++ b/tests/fixtures/eval/baseline.json
@@ -7,6 +7,7 @@
   "model_revision": "pinned-via-rurico-embed-cache",
   "mlx_rs_version": "0.25",
   "fixture_hash": "fnv1a64:187f5bea7336300c",
+  "aggregation": "identity",
   "global": [
     {
       "name": "recall@5",


### PR DESCRIPTION
## 概要

Retrieval/Rerank パイプラインコントラクト (ADR 0004) の Phase 3 集約ステージを実装。Aggregator トレイトと4つの戦略を追加し、eval_harness に `--aggregation` フラグサポートを統合。

### コミット構成

1. `9342c5e` feat(retrieval): Phase 3 集約トレイト/戦略の初期実装
2. `02afd74` fix(eval): sort contract 強制 + Hit 型統一（polish）

### 変更内容

- **src/retrieval.rs** (NEW): Aggregator トレイト + 4つの戦略
  - `IdentityAggregator`: パススルー（ベースライン）
  - `MaxChunkAggregator`: 重複を最高スコアに集約
  - `DedupeAggregator`: doc_id ごとに最初の出現を保持
  - `TopKAverageAggregator`: doc_id ごとに top-K を平均化
  - 9個の単体テスト（戦略 6 + TopKAverage round-trip 3）

- **src/lib.rs**: モジュールエクスポート + ADR 0004 参照

- **src/eval/pipeline.rs**: 集約ディスパッチの追加。重複していた `Hit` 型を削除し、`MergedHit` に統一。`run_single_query` の三度の round-trip 変換を排除。

- **src/bin/eval_harness.rs**: `--aggregation` フラグパース、`dispatch_pipeline<E, R>` ジェネリックディスパッチャ実装。`AggregationKind::name()` を `String` に変更し、TopKAverage の `k` を `topk-average:K` 形式で永続化（legacy fallback 対応）。

- **src/eval/baseline.rs**: BaselineSnapshot に `aggregation` フィールド追加（serde default = "identity"）

- **tests/fixtures/eval/baseline.json**: テストフィクスチャに aggregation フィールド

- **adr/0004-..._contract-for-rurico.md**: Migration Plan を Phase 3 完了、構造的同一性の知見で更新

### 設計メモ

**構造的同一性の知見**: 現在の単一チャンク/ドキュメント インデックスでは、すべての戦略がフィクスチャ上で動作的に同一（rrf_merge の HashMap は doc_id の一意性を保証）。単体テストは合成的マルチチャンク入力で正確性を検証；ベースライン比較は「差分なし（予期通り）」パスを文書化。

**型統一**: Stage 2 (RRF merge) と Stage 3 (Aggregator) の境界で `MergedHit { doc_id: String, score: f64 }` 型を共有。Phase 3 polish で `Hit` 重複型を削除し、パイプライン全体を `MergedHit` で統一。

**Sort contract 強制**: `Aggregator::aggregate` の出力ソート要件を `should` から `MUST` に強化。truncate 直前にコメントで Aggregator 契約を参照し、silent data loss を防止。`IdentityAggregator` / `DedupeAggregator` の doc に sort 不変条件の根拠を明記。

**TopKAverage k 永続化**: シリアライズ名を `topk-average:K` 形式にエンコードし、`k` パラメータの round-trip を保証。`:K` サフィックスがない旧形式は `DEFAULT_TOPK_AVERAGE_K` にフォールバック（後方互換）。

**後方互換性**: BaselineSnapshot.aggregation はデシリアライズ時に "identity" がデフォルト、Phase 3 前フィクスチャとの互換性を維持。

### 検証

✅ 244 テスト成功（lib 233 + bin 3 + eval 8）
✅ Aggregator 9 単体テスト（戦略 6 + TopKAverage round-trip 3）
✅ Clippy クリーン
✅ フォーマット クリーン

### レビューフォーカス

- `src/retrieval.rs`: Aggregator トレイトの sort contract（"MUST" 文言）と各 impl の不変条件
- `src/bin/eval_harness.rs`: `topk-average:K` エンコーディングの parse/format 対称性とフォールバック
- `src/eval/pipeline.rs`: `Hit` → `MergedHit` 統一による round-trip 削減

### 次のステップ

- ベンチマーク: 集約オーバーヘッド検証
- Issue #72: チャンクレベル Retrieval フォローアップ
- 完全なパイプライン.rs 型リネームは後回し

### 参考資料

- ADR 0004: Retrieval/Rerank パイプラインコントラクト
- Issue #67: Phase 3 集約
- Closes #67