### PR TITLE
docs(adr): ADR 0004 item 7 を Issue #76 にリンク

### DIFF
--- a/adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -183,7 +183,7 @@ Negative:
 4. **Phase 5** (Issue #69): insert query normalization at Stage 1 entry. Default off; opt-in via config to preserve current behaviour.
 5. **Phase 6** (Issue #70): add `CandidateSource::PrefixEnsemble` variants and the embedding-side fan-out logic.
 6. **Cross-repo follow-ups**: file individual issues against `recall`, `sae`, `yomu` after the first `rurico` bump that exposes `src/retrieval.rs`. Each downstream adopts at its own pace; `rurico` does not change `recall`/`sae`/`yomu` directly (cross-repo issue rule, ADR 0001 migration pattern).
-7. **Chunk-level retrieval follow-up** (separate issue, prerequisite for non-vacuous aggregation evaluation): extend `ChunkedEmbedding` with `chunk_id` metadata, switch the reference pipeline to chunk-level indexing, add the parent-child helper, and capture per-strategy baselines that reflect actual ranking changes. Touches `recall`/`sae`/`yomu` schema, so it ships under its own issue rather than #67.
+7. **Chunk-level retrieval follow-up** (Issue #76, prerequisite for non-vacuous aggregation evaluation): extend `ChunkedEmbedding` with `chunk_id` metadata, switch the reference pipeline to chunk-level indexing, add the parent-child helper, and capture per-strategy baselines that reflect actual ranking changes. Touches `recall`/`sae`/`yomu` schema, so it ships under its own issue rather than #67.
 
 ## Reassessment Triggers
 


### PR DESCRIPTION
## 概要

ADR 0004 Migration Plan item 7（chunk-level retrieval follow-up）が "separate issue" の placeholder のままだったので、起票済みの Issue #76 への参照に置き換える。

## 背景

PR #75 (Phase 3 #67) のマージで Aggregator trait + 4 戦略は完了したが、ADR 0004 で予告されていた chunk-level retrieval follow-up は別 issue 扱いとされていた。Phase 3 完了を機に Issue #76 を起票し、その番号を ADR にリンクする。

## 変更内容

`adr/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md` の Migration Plan item 7:

- Before: `Chunk-level retrieval follow-up (separate issue, ...)`
- After:  `Chunk-level retrieval follow-up (Issue #76, ...)`

## 影響範囲

- ドキュメントのみ。コード／テスト変更なし
- ADR の決定内容（pipeline contract）は不変
- supersede 手続きは不要（Migration Plan の参照リンク補完のみ）

## 検証

- ADR 内のリンクが Issue #76 を指す
- `cargo` 系コマンド影響なし

## 参考

- Issue #76: chunk-level retrieval の最小実装 (ADR 0004 item 7)
- ADR 0004: Retrieval/Rerank パイプラインコントラクト
- PR #75: Phase 3 aggregation 実装（直前のマージ）