### PR TITLE
chore(deps): rand 0.10 + rand_chacha 0.10 へ bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +263,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -708,6 +728,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -807,7 +828,7 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1648,8 +1669,19 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1659,7 +1691,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1670,6 +1712,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1826,8 +1874,8 @@ dependencies = [
  "hf-hub",
  "log",
  "mlx-rs",
- "rand",
- "rand_chacha",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rurico-ffi",
  "rusqlite",
  "serde",
@@ -2352,7 +2400,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ bytemuck = "1"
 hf-hub = "0.5"
 log = "0.4"
 mlx-rs = "0.25"
-rand = "0.9"
-rand_chacha = "0.9"
+rand = "0.10"
+rand_chacha = "0.10"
 rusqlite = { version = "0.39", features = ["bundled"] }
 rurico-ffi = { path = "crates/rurico-ffi" }
 serde = { version = "1", features = ["derive"] }

--- a/src/eval/metrics.rs
+++ b/src/eval/metrics.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## 概要

`rand` 0.9 → 0.10、`rand_chacha` 0.9 → 0.10 への bump。`rand` 0.10 migration guide が "[`rand_chacha`] is likely to be discontinued in the future" と明記しているため、サプライチェーン延命目的で先回り。

### 変更内容

- `Cargo.toml`: `rand = "0.10"`、`rand_chacha = "0.10"`
- `src/eval/metrics.rs`: `Rng` trait が `RngExt` に rename されたため import 1 行修正 (`use rand::{Rng, SeedableRng}` → `use rand::{RngExt, SeedableRng}`)。`random_range` のメソッド呼び出し本体は変更不要
- `src/bin/eval_harness.rs`: `SliceRandom::shuffle` の API は 0.10 でもそのまま、変更不要

### bit-equal 保証

`ChaCha{8,12,20}Rng` の output は 0.9 → 0.10 で reproducibility 維持と公式 migration guide が明記:

> The `ChaCha{8,12,20}Rng` types are a direct replacement for the like-named `rand_chacha` types; **these maintain reproducibility of output and have a similar API**.

よって bootstrap CI 用の seed 固定 reproducibility (NFR-002) を保ち、`tests/fixtures/eval/baseline.json` の regenerate は不要。実機 verify は T-007 (`bootstrap_ci_is_bit_identical_for_same_seed`) で seed 固定再現性を確認済み。

### 「精度向上」は無い

事前に `rand` 0.10 changelog を確認した結果、0.10 では reproducibility-breaking 変更も統計品質改善も入っていない (`gen_range` の Lemire's method 化は 0.9 で完了済み)。今回の bump は将来の `rand_chacha` 廃止に備える整備で、検索品質スコアには影響しない。

## テスト計画

- [x] `cargo build --features eval-harness` PASS
- [x] `cargo test --workspace --features eval-harness` 277 + 7 + 8 passed / 0 failed
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` PASS
- [x] `cargo fmt -- --check` PASS
- [ ] (任意・実機) MLX 環境で `eval_harness verify-baseline baseline=tests/fixtures/eval/baseline.json` が pass することを確認 (移行ガイドの output reproducibility 保証の実機 verify)