### PR TITLE
embedder / reranker degraded パスに tracing::warn 規律を入れる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1257,15 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1398,6 +1413,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1878,7 +1902,6 @@ version = "0.2.0"
 dependencies = [
  "bytemuck",
  "hf-hub",
- "log",
  "mlx-rs",
  "rand 0.10.1",
  "rand_chacha 0.10.0",
@@ -1890,6 +1913,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokenizers",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
  "unicode-normalization",
 ]
 
@@ -2124,6 +2150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2364,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2561,7 +2605,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2571,6 +2627,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2698,6 +2805,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,22 @@ exclude = [".claude/", ".yomu/", "workspace/"]
 [features]
 test-mlx = []
 test-support = []
+# Gate the `mlx_smoke` binary and its integration test behind a feature so
+# `tracing-subscriber` does not enter downstream library users' dependency
+# graph. Enable with `cargo build/run/test --features smoke`.
+smoke = ["dep:tracing-subscriber"]
+
+[[bin]]
+name = "mlx_smoke"
+required-features = ["smoke"]
+
+[[test]]
+name = "mlx_smoke"
+required-features = ["smoke"]
 
 [dependencies]
 bytemuck = "1"
 hf-hub = "0.5"
-log = "0.4"
 mlx-rs = "0.25"
 rand = "0.10"
 rand_chacha = "0.10"
@@ -29,11 +40,14 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 unicode-normalization = "0.1"
 
 [dev-dependencies]
 serial_test = "3"
 tempfile = "3"
+tracing-test = "0.2"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ stmt.execute(rusqlite::params![f32_as_bytes(&vector)])?;
 
 ### ログ出力
 
-内部の警告は `log` crate経由で出力される。`env_logger::init()` 等でloggerを初期化すると観測できる。
+内部の警告は `tracing` crate 経由で `warn` レベルで出力される。`tracing_subscriber` を初期化し、`RUST_LOG=rurico=warn` または EnvFilter に `rurico=warn` directive を含めることで観測できる（amici を使う CLI は `amici::logging::init_subscriber` 経由で自動的に観測される）。
 
 ### テストサポート（downstream 向け）
 

--- a/docs/decisions/0007-library-logging-boundary.md
+++ b/docs/decisions/0007-library-logging-boundary.md
@@ -1,0 +1,118 @@
+# ADR 0007: Library Logging Boundary — `rurico` Emits Internal Recovery Warns, CLI Emits Caller Boundary Warns
+
+- Status: Accepted
+- Date: 2026-04-30
+- Confidence: high. The boundary is observable from the existing call graph: `yomu/src/query.rs:487-493` already warns on `embed_query` failures (caller boundary); `rurico::embed::Embedder::forward` callers are the only consumers that decide whether a typed error becomes `degraded=true`, so a `rurico`-side warn at that point would duplicate. The internal-recovery sites (`split_pooled` non-finite output, `mlx_cache` lock poisoning, probe subprocess timeout, etc.) are decisions `rurico` makes that the caller cannot see, so a `rurico`-side warn is the only place where the diagnostic information exists.
+
+## Context
+
+Issue [#89](https://github.com/thkt/rurico/issues/89) surfaced that operators of downstream CLIs (`yomu`, `sae`, `recall`) cannot diagnose why `degraded=true` is returned, because `rurico`'s `log::warn!` calls are silently dropped: downstream initialises `tracing_subscriber::fmt()` without `LogTracer`, so events from the `log` crate never reach the subscriber, and the EnvFilter (`yomu=warn` / `sae=info` / `recall=warn`) excludes the `rurico` target even after the `log → tracing` migration.
+
+Once `rurico` migrates to `tracing` and downstream filters include `rurico=warn` (handled in `amici#36`, `yomu#149`, `sae#85`), the question becomes: at *which* sites should `rurico` emit `warn!`? Two failure modes need to be avoided:
+
+1. **Silent drop (the original problem)** — internal recovery decisions invisible to the caller, so `degraded=true` cannot be triaged.
+2. **Duplicate warn (the new risk)** — if `rurico` warns at every typed-error return site, callers that already warn at *their* boundary (e.g. `yomu/src/query.rs:487-493`) emit two log lines for one event, forcing operators to deduplicate.
+
+The boundary that distinguishes the two is whether `rurico` is making an internal recovery decision the caller cannot observe.
+
+## Decision
+
+`rurico` warns when it makes an internal recovery decision; the caller (CLI) warns at its boundary when it converts a typed error into a degraded mode.
+
+| Site type | Owner of `tracing::warn!` | Example |
+|---|---|---|
+| Internal recovery (rurico decides to truncate, recover from poison, give up after retries, reject corrupt output) | `rurico` | `embed/mlx.rs::split_pooled` rejecting non-finite output; `mlx_cache.rs` recovering from lock poisoning; `model_probe.rs` timing out and killing subprocess |
+| Caller boundary (caller converts typed error into `degraded=true` / `DegradedReason::*` / fallback path) | CLI (yomu / sae / recall) | `yomu/src/query.rs:487-493` warning when `embed_query` fails before falling back to text search; `yomu/src/tools.rs:525-535` (yomu#131) warning when `embed_query` failure becomes `DegradedReason::ProbeFailed` |
+
+Concrete classification for `rurico` 0.2.x:
+
+### `rurico` warns (internal recovery)
+
+- `embed.rs::truncate_for_query` — query exceeds `max_seq_len`, truncating
+- `embed/metrics.rs::PhaseMetrics::log` — per-call debug summary (debug, not warn)
+- `embed/mlx.rs::shrink_chunk_to_fit` — chunk cannot fit after adaptive shrink
+- `embed/mlx.rs::split_pooled` — `BufferShapeMismatch` (corrupt readback) and `NonFiniteOutput` (kernel overflow / corrupt weights)
+- `mlx_cache.rs::clear_inference_cache` — lock poison recovery, FFI cache-clear non-zero exit
+- `modernbert/model.rs::forward` — `seq_len` exceeds `max_seq_len`, defense-in-depth truncation
+- `model_probe.rs::wait_with_timeout` / `collect_pipe` — probe subprocess timeout, drain failure, channel disconnect
+- `reranker/mlx.rs::truncate_pair` — pair exceeds `max_seq_len`, truncating
+- `reranker/mlx.rs::score_batch` — output shape mismatch, non-finite scores
+
+### `rurico` does not warn (caller boundary or noise)
+
+- `embed/mlx.rs:178,352` `forward(...).map_err(EmbedError::inference)?` — caller (`yomu/src/query.rs:487-493`) already warns; `rurico` warn would duplicate.
+- `EmbedInitError::backend` — init-time failure surfacing as binary error; the binary's error handler prints it.
+- `artifacts.rs::WrongModelKind` / `MissingFile` / `InvalidConfig` / `InvalidTokenizer` — caller decides whether the absence is fatal or fallback (`DegradedReason::ProbeFailed` in yomu#131); caller responsibility.
+- `model_probe.rs::ProbeError::*` returned from `probe_via_subprocess` — caller decides whether the probe failure becomes `degraded=true`; caller responsibility.
+
+### Field discipline
+
+`tracing::warn!(error = %e, "<context>")` when wrapping an `Error` value. Otherwise, name structured fields after the relevant local (snake_case); prefer `expected` / `actual` for shape mismatches and a `*_secs` suffix for durations.
+
+## Options Considered
+
+### Option A (chosen): Sharp library/CLI boundary by recovery semantics
+
+Pros:
+
+- Each warn line maps to exactly one event. Operators can grep without deduplication.
+- Compatible with the existing degraded-reason machinery in CLIs (`amici::model::embedder::DegradedReason`); rurico does not replicate the reason mapping, so the abstraction stays one-directional.
+- The classification is decidable per call site by asking "does the caller know?" — internal recovery is invisible to the caller; typed errors are visible.
+
+Cons:
+
+- Requires reviewers to remember the boundary on new code. Mitigated by this ADR being the explicit reference and by the `rurico=warn` directive in `amici::logging::init_subscriber` (amici#36) making the boundary observable in tests.
+
+### Option B: `rurico` warns at every typed-error return site
+
+Pros:
+
+- Mechanical rule: any `?`/`map_err` over an internal error gets a warn.
+
+Cons:
+
+- Duplicate warns at every caller that already wraps the error (`yomu/src/query.rs:487-493`, future `sae` / `recall` callers). Operators see N+1 lines per event.
+- "Library is too noisy" leads operators to filter `rurico=error` (or worse, suppress `rurico` entirely), defeating the point of the migration.
+- Conflates init-time failures (which the binary's error handler already surfaces) with runtime degradation.
+
+### Option C: `rurico` never warns; CLIs must reconstruct context from typed errors
+
+Pros:
+
+- Minimal coupling between rurico and CLIs — rurico is "pure".
+
+Cons:
+
+- The original silent-drop problem returns: internal recovery decisions (e.g. lock poison recovery, probe timeout kill, non-finite output rejection) are not exposed via the typed error chain. The decision is invisible.
+- Forces every CLI to instrument the same internal recovery sites (e.g. wrap every `embed_query` call with telemetry that re-derives "the kernel produced a non-finite output"). High duplication in CLI code.
+- The N+1 `yomu/sae/recall` problem from issue #89 reasserts: each downstream re-implements the diagnostic.
+
+## Consequences
+
+Positive:
+
+- The `rurico` warn surface is documented and bounded. New rurico contributors can decide warn placement without re-deriving the boundary.
+- Downstream filter directives (`amici::logging::init_subscriber` adds `rurico=warn` per amici#36) collect exactly the diagnostic events a `degraded=true` operator needs, without per-call-site instrumentation.
+- yomu#131's caller-boundary warns and rurico#89's internal-recovery warns compose without duplication.
+
+Negative:
+
+- The boundary requires judgement on borderline cases (e.g. `EmbedError::Inference` returned from a tokenizer encoding error in `plan_long_document`: is the tokenizer error caller-observable? In this codebase yes, so `rurico` does not warn). Reviewers must apply the rule.
+- `tracing` becomes a public-API-shape concern for `rurico`: removing or renaming a structured field is a downstream-grep-breaking change. Mitigated by the structured-field naming convention listed under Decision §Field discipline.
+- `rurico` Cargo.toml gains a `tracing` runtime dependency and a `tracing-subscriber` dependency for the `mlx_smoke` binary. The library code itself never initialises a subscriber (LANG.md compliance); only the smoke binary does.
+
+## Reassessment Triggers
+
+- A new caller pattern emerges where typed errors do *not* propagate to a place the caller can warn (e.g. async runtime that drops errors). The boundary may need to shift toward Option B for that subsystem only.
+- Downstream `tracing` filtering at `rurico=warn` produces audibly noisy logs in production (more than ~1 line per `degraded=true` event). The internal-recovery surface is too broad and needs trimming, or the field discipline needs tightening (e.g. spans instead of repeated warns).
+- A future `rurico-eval` or other consumer crate sits between `rurico` and the CLIs. The boundary applies recursively: the consumer crate becomes a "caller" relative to `rurico` and an "internal" relative to its CLI; each level applies the same rule.
+
+## References
+
+- Issue [thkt/rurico#89](https://github.com/thkt/rurico/issues/89) — originating issue with full Fix-site classification (A/B/C/D scope)
+- Issue [thkt/yomu#131](https://github.com/thkt/yomu/issues/131) — caller-boundary warns in yomu (RC-001 — SIL-001/002/008 + OPS-001)
+- Issue [thkt/amici#36](https://github.com/thkt/amici/issues/36) — `init_subscriber` adds `rurico=warn` directive
+- Issue [thkt/yomu#149](https://github.com/thkt/yomu/issues/149) — yomu migrates to `amici::logging::init_subscriber`
+- Issue [thkt/sae#85](https://github.com/thkt/sae/issues/85) — sae migrates to `amici::logging::init_subscriber`
+- LANG.md `Logging` section — `tracing` over `log`, structured fields, no subscriber init in library code
+- ADR 0006 — eval-harness migration to `amici` (similar boundary concern: who owns what)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,3 +8,4 @@
 | [0004](./0004-retrieval-and-rerank-pipeline-contract-for-rurico.md) | Retrieval and Rerank Pipeline Contract for `rurico` | Accepted | 2026-04-26 |
 | [0005](./0005-prefix-ensemble-experiment-not-adopted.md) | Phase 6 Prefix-Ensemble Experiment — Not Adopted | Accepted | 2026-04-27 |
 | [0006](./0006-eval-harness-migration-to-amici.md) | Migrate Search-Quality Evaluation Harness from `rurico` to `amici` | Accepted | 2026-04-27 |
+| [0007](./0007-library-logging-boundary.md) | Library Logging Boundary — `rurico` Emits Internal Recovery Warns, CLI Emits Caller Boundary Warns | Accepted | 2026-04-30 |

--- a/justfile
+++ b/justfile
@@ -32,15 +32,15 @@ chunk-test:
 
 # Capture embed fixture → tests/fixtures/embed/{w1,w2,w3}.bin
 embed-capture:
-    cargo run --bin mlx_smoke --release -- capture-fixture
+    cargo run --bin mlx_smoke --features smoke --release -- capture-fixture
 
 # Measure embed speed / padding / R² baseline (stderr diagnostics)
 embed-baseline:
-    cargo run --bin mlx_smoke --release -- measure-baseline
+    cargo run --bin mlx_smoke --features smoke --release -- measure-baseline
 
 # Verify embed fixture parity (cosine_min ≥ 0.99999, max_abs_diff ≤ 1e-5)
 embed-verify:
-    cargo run --bin mlx_smoke --release -- verify-fixture
+    cargo run --bin mlx_smoke --features smoke --release -- verify-fixture
 
 # === Probe smoke (subprocess probe contract) ===
 

--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -25,7 +25,7 @@
 
 use std::env;
 use std::fs::{self, File};
-use std::io::{BufReader, BufWriter};
+use std::io::{BufReader, BufWriter, stderr};
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -38,39 +38,23 @@ use rurico::embed::{
 use rurico::model_probe;
 use rurico::sandbox;
 
-/// Minimal `log` crate subscriber that writes every record to stderr.
+/// Minimal `tracing` subscriber that writes every record to stderr.
 ///
 /// Kept inside the smoke binary so that debug logs emitted by the library are
-/// visible when this binary runs, without forcing a logging backend on
-/// library consumers.
-struct StderrLogger;
-
-impl log::Log for StderrLogger {
-    fn enabled(&self, _: &log::Metadata) -> bool {
-        true
-    }
-    fn log(&self, record: &log::Record) {
-        if self.enabled(record.metadata()) {
-            eprintln!(
-                "[{}] {}: {}",
-                record.level(),
-                record.target(),
-                record.args()
-            );
-        }
-    }
-    fn flush(&self) {}
-}
-
-static LOGGER: StderrLogger = StderrLogger;
-
-fn init_logger() {
-    let _ = log::set_logger(&LOGGER);
-    log::set_max_level(log::LevelFilter::Debug);
+/// visible when this binary runs, without forcing a subscriber on library
+/// consumers.
+fn init_tracing_subscriber() {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug")),
+        )
+        .try_init();
 }
 
 fn main() {
-    init_logger();
+    init_tracing_subscriber();
 
     // Also acts as a probe subprocess when probe env vars are set.
     model_probe::handle_probe_if_needed();

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -197,7 +197,7 @@ pub(crate) fn truncate_for_query(
 ) -> (Vec<u32>, Vec<u32>, usize) {
     let orig_len = input_ids.len();
     if truncate_with_eos(&mut input_ids, &mut attention_mask, max_len) {
-        log::warn!("query exceeds max_seq_len ({orig_len} > {max_len}), truncating");
+        tracing::warn!(orig_len, max_len, "query exceeds max_seq_len, truncating");
     }
     let len = input_ids.len();
     (input_ids, attention_mask, len)

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -1,6 +1,6 @@
 //! Phase timing and batch shape counters for the embed pipeline.
 //!
-//! One `log::debug!` line per `embed_*` call so that bottlenecks can be read
+//! One `tracing::debug!` line per `embed_*` call so that bottlenecks can be read
 //! from a run log without extra infrastructure.
 //!
 //! [`PhaseMetrics`] is the internal accumulator, `pub(super)` so only the
@@ -125,9 +125,7 @@ impl PhaseMetrics {
 
     /// Emit one structured debug line summarising this call.
     pub(super) fn log(&self) {
-        if log::log_enabled!(log::Level::Debug) {
-            log::debug!("{}", self.format_log());
-        }
+        tracing::debug!("{}", self.format_log());
     }
 }
 

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -475,6 +475,10 @@ pub(super) fn shrink_chunk_to_fit(
     let byte_start = offsets[start].0;
     loop {
         if *end <= start {
+            tracing::warn!(
+                start_token = start,
+                "chunk cannot fit within MAX_SEQ_LEN after adaptive shrink"
+            );
             return Err(EmbedError::inference(format!(
                 "chunk at token {start} cannot fit within \
                  MAX_SEQ_LEN after adaptive shrink"
@@ -553,12 +557,24 @@ pub(super) fn split_pooled(
 ) -> Result<Vec<Vec<f32>>, EmbedError> {
     let expected = batch_size.saturating_mul(hidden_size);
     if flat.len() != expected {
+        tracing::warn!(
+            expected,
+            actual = flat.len(),
+            batch_size,
+            hidden_size,
+            "split_pooled: buffer shape mismatch"
+        );
         return Err(EmbedError::BufferShapeMismatch {
             expected,
             actual: flat.len(),
         });
     }
     if !flat.iter().all(|v| v.is_finite()) {
+        tracing::warn!(
+            batch_size,
+            hidden_size,
+            "split_pooled: non-finite output detected (NaN or Inf in pooled buffer)"
+        );
         return Err(EmbedError::NonFiniteOutput);
     }
     if batch_size == 0 {
@@ -578,6 +594,7 @@ mod tests {
     use std::sync::{Mutex, PoisonError};
 
     use mlx_rs::Array;
+    use tracing_test::traced_test;
 
     use super::super::EmbedError;
     use super::{
@@ -971,5 +988,30 @@ mod tests {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
+    }
+
+    // T-012: emits warn so operators can diagnose corrupt readback (see ADR 0007).
+    #[traced_test]
+    #[test]
+    fn t_012_split_pooled_emits_warn_on_buffer_shape_mismatch() {
+        let flat: Vec<f32> = vec![0.0; 7]; // expected 8
+        let _ = split_pooled(&flat, 2, 4);
+        assert!(
+            logs_contain("split_pooled: buffer shape mismatch"),
+            "warn must be emitted on shape mismatch"
+        );
+    }
+
+    // T-015: emits warn so operators can distinguish kernel overflow / corrupt
+    // weights from upstream input errors (see ADR 0007).
+    #[traced_test]
+    #[test]
+    fn t_015_split_pooled_emits_warn_on_non_finite_output() {
+        let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
+        let _ = split_pooled(&flat, 1, 4);
+        assert!(
+            logs_contain("split_pooled: non-finite output"),
+            "warn must be emitted on non-finite output"
+        );
     }
 }

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -48,16 +48,16 @@ pub(crate) fn release_inference_output(output: mlx_rs::Array) {
 /// to preserve the drop-before-clear ordering.
 pub(crate) fn clear_inference_cache() {
     let _guard = MLX_CACHE_LOCK.lock().unwrap_or_else(|e| {
-        log::warn!("MLX cache lock was poisoned; recovering");
+        tracing::warn!("MLX cache lock was poisoned; recovering");
         e.into_inner()
     });
     let code = rurico_ffi::mlx_clear_cache();
     if code != 0 {
-        log::warn!("mlx_clear_cache failed (code: {code})");
+        tracing::warn!(code, "mlx_clear_cache failed");
     }
     let code = rurico_ffi::mlx_compile_clear_cache();
     if code != 0 {
-        log::warn!("mlx_detail_compile_clear_cache failed (code: {code})");
+        tracing::warn!(code, "mlx_detail_compile_clear_cache failed");
     }
 }
 

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -220,7 +220,7 @@ where
         thread::spawn(move || {
             let mut buf = Vec::new();
             if let Err(e) = stream.read_to_end(&mut buf) {
-                log::warn!("probe: failed to drain child {label}: {e}");
+                tracing::warn!(label, error = %e, "probe: failed to drain child");
             }
             let _ = tx.send(buf);
         });
@@ -243,14 +243,15 @@ fn collect_pipe(recv: Option<Receiver<Vec<u8>>>, label: &str) -> Vec<u8> {
     match rx.recv_timeout(COLLECT_PIPE_TIMEOUT) {
         Ok(buf) => buf,
         Err(RecvTimeoutError::Timeout) => {
-            log::warn!(
-                "probe: child {label} drain timed out after {}s; reader thread will leak",
-                COLLECT_PIPE_TIMEOUT.as_secs()
+            tracing::warn!(
+                label,
+                timeout_secs = COLLECT_PIPE_TIMEOUT.as_secs(),
+                "probe: child drain timed out; reader thread will leak"
             );
             Vec::new()
         }
         Err(RecvTimeoutError::Disconnected) => {
-            log::warn!("probe: child {label} reader thread dropped channel");
+            tracing::warn!(label, "probe: child reader thread dropped channel");
             Vec::new()
         }
     }
@@ -294,9 +295,9 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<Output, Pro
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
-                    log::warn!(
-                        "probe subprocess timed out after {}s, killing",
-                        timeout.as_secs()
+                    tracing::warn!(
+                        timeout_secs = timeout.as_secs(),
+                        "probe subprocess timed out, killing"
                     );
                     let _ = child.kill();
                     let status = child.wait().map_err(|e| {

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -282,7 +282,7 @@ impl ModernBert {
     ///
     /// When `seq_len` exceeds `config.max_position_embeddings`, the input is
     /// truncated as a defense-in-depth fallback; `Ok` is returned with a shorter
-    /// output tensor and a `log::warn!` warning is emitted.
+    /// output tensor and a `tracing::warn!` warning is emitted.
     ///
     /// Exception messages are backend-generated and should be treated as opaque.
     pub fn forward(
@@ -317,9 +317,10 @@ impl ModernBert {
         let max_seq = i32::try_from(self.max_seq_len).expect("bounded by model config");
         if seq_len > max_seq {
             // Defense-in-depth: truncate oversize inputs, validating only the effective prefix.
-            log::warn!(
-                "model.forward: seq_len ({seq_len}) exceeds max_seq_len ({max_seq}), \
-                 truncating as defense-in-depth fallback"
+            tracing::warn!(
+                seq_len,
+                max_seq,
+                "model.forward: seq_len exceeds max_seq_len, truncating as defense-in-depth fallback"
             );
             let bs = batch_size as usize;
             let old_len = seq_len as usize;

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -63,12 +63,21 @@ impl RerankerInner {
             let flat: &[f32] = output.as_slice();
             let flat_len = flat.len();
             if flat_len != batch_size {
+                tracing::warn!(
+                    expected = batch_size,
+                    actual = flat_len,
+                    "score_batch: output shape mismatch"
+                );
                 return Err(RerankerError::inference(format!(
                     "score_batch: expected {batch_size} scores, got {flat_len}"
                 )));
             }
             let scores: Vec<f32> = flat.iter().map(|&logit| sigmoid(logit)).collect();
             if scores.iter().any(|v| !v.is_finite()) {
+                tracing::warn!(
+                    batch_size,
+                    "score_batch: non-finite output detected (NaN or Inf in reranker scores)"
+                );
                 return Err(RerankerError::NonFiniteOutput);
             }
             Ok(scores)
@@ -156,7 +165,12 @@ pub(super) fn truncate_pair(
 ) {
     let orig_len = ids.len();
     if truncate_with_eos(ids, mask, max_len) {
-        log::warn!("pair {pair_idx} exceeds max_seq_len ({orig_len} > {max_len}), truncating");
+        tracing::warn!(
+            pair_idx,
+            orig_len,
+            max_len,
+            "pair exceeds max_seq_len, truncating"
+        );
     }
 }
 


### PR DESCRIPTION
## What & Why

`degraded=true` を返した時に operator が原因を診断できない問題（rurico の `log::warn!` が下流の `tracing_subscriber` に届かず silent drop）を解消するため、`log` → `tracing` 移行 + 内部 recovery 経路 5 箇所への warn 追加 + ADR で boundary 文書化。

## Changes

- **`log` → `tracing` 移行 (9 箇所)**: 既存の `log::warn!` / `log::debug!` を `tracing` に置換、structured field 化（`embed.rs` query truncation, `model_probe.rs` drain/timeout/channel × 4, `mlx_cache.rs` lock poison/clear × 3, `modernbert/model.rs` defense-in-depth fallback, `reranker/mlx.rs` pair truncation, `embed/metrics.rs` debug summary）。
- **内部 recovery 経路に新規 `tracing::warn!` 追加 (5 箇所)**: caller boundary で warn できない rurico 内部判断箇所に warn を仕込んだ（`embed/mlx.rs::shrink_chunk_to_fit` chunk shrink failure / `embed/mlx.rs::split_pooled` BufferShapeMismatch / NonFiniteOutput / `reranker/mlx.rs::score_batch` shape mismatch / NonFiniteOutput）。
- **`tracing-test` capture テスト 2 件**: MLX-free な `split_pooled` の warn capture を T-012 / T-015 ファミリーに編入。
- **`mlx_smoke` binary を `smoke` feature で gate**: `tracing-subscriber` を library users の dep graph から除外（matchers / regex-automata / sharded-slab / nu-ansi-term / thread_local 等を default deps から確認除外済）。
- **ADR 0007**: `rurico = 内部 recovery warn` / `CLI = caller boundary warn` の boundary を文書化。
- **README ログ出力 セクション update**: `env_logger::init()` 案内 → `tracing` + `RUST_LOG=rurico=warn` 案内に変更。

## Scope

- **Not included**: 下流 (yomu/sae/recall/amici) 側の filter directive 追加は別 issue で対応 (amici#36 / yomu#149 / sae#85)。recall は既に `amici::logging::init_subscriber` 使用済なので amici#36 が merge されれば自動で恩恵を受ける。
- **やらない (caller 責務 = duplicate 回避)**: `embed/mlx.rs:178,352` `forward(...).map_err(EmbedError::inference)?` (yomu/query.rs:487-493 で既に warn 済)、`EmbedInitError::backend` (binary error handler)、`artifacts.rs::WrongModelKind` (caller が DegradedReason 変換、yomu#131)、`model_probe.rs::ProbeError::*` 返却時 warn (caller 責務)。

## Design Decisions

- **`smoke` feature gate を採用**: `tracing-subscriber` を unconditional に `[dependencies]` に置くと downstream の dep graph が膨らむ (matchers/regex-automata/sharded-slab/nu-ansi-term/thread_local 5 crates)。`[dev-dependencies]` 移動は cargo の `[[bin]]` 制約で build break するため不採用。`smoke = ["dep:tracing-subscriber"]` + `[[bin]]/[[test]] required-features` が唯一の clean な解。
- **既存 `t_012_*` / `t_015_*` test family に編入**: 新規 tracing test を独立命名にせず、spec scenario 連番で既存 family に統合（reviewer-readability 指摘を反映）。
- **`tracing::enabled!` guard 削除 (`embed/metrics.rs`)**: `tracing::debug!` macro は callsite enabled check 後に format するため `log::log_enabled!` 相当のガードは冗長。pre-migration の名残を整理。

## How to Test

1. `cargo build --workspace --tests` (default features) → pass
2. `cargo build --workspace --all-features --tests` → pass
3. `cargo test --workspace --all-features` → pass (新規 tracing-test 2 件含む)
4. `cargo clippy --workspace --all-targets --all-features -- -D warnings` → pass
5. `cargo tree -e normal --no-default-features` で `tracing-subscriber|matchers|sharded-slab|nu-ansi-term` を grep → 空 (default deps から exclude 確認)
6. `RUST_LOG=rurico=warn cargo run --bin mlx_smoke --features smoke --release -- verify-fixture` → mlx_smoke が tracing 経由で warn を出すことを観測 (model 必要)

## Related

- Closes #89
- Companion downstream issues: amici#36, yomu#149, sae#85
- 関連: yomu#131 (caller 側 RC-001)
