### PR TITLE
pre-commit hook と Development docs を追加（yomu #148 横展開）

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# rurico pre-commit hook: enforce fmt + clippy --all-targets before commit.
+#
+# Install (one-time per clone):
+#   git config --local core.hooksPath .githooks
+#
+# Skip for one commit:
+#   git commit --no-verify
+
+set -e
+
+# Only run when Rust / config / CI files are staged (covers add, modify, delete, rename).
+if git diff --cached --name-only | grep -qE '\.rs$|Cargo\.(toml|lock)$|\.github/'; then
+    echo "▶ pre-commit: cargo fmt --all -- --check"
+    cargo fmt --all -- --check
+
+    echo "▶ pre-commit: cargo clippy --workspace --all-targets --all-features -- -D warnings"
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+    echo "✔ pre-commit checks passed"
+fi

--- a/README.md
+++ b/README.md
@@ -352,6 +352,26 @@ let v = embedder.embed_query("テスト")?;
 assert_eq!(v.len(), 768);
 ```
 
+## Development
+
+### Setup
+
+Run once after cloning:
+
+```sh
+git config --local core.hooksPath .githooks
+```
+
+This installs a pre-commit hook that runs `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` before each commit. Violations abort the commit. To skip for one commit: `git commit --no-verify`.
+
+### Common commands
+
+```sh
+cargo test --workspace                                                  # all tests
+cargo clippy --workspace --all-targets --all-features -- -D warnings    # lint (matches CI)
+cargo fmt --all -- --check                                              # format check
+```
+
 ## テスト
 
 ```sh


### PR DESCRIPTION
## 概要

開発者が main 直前まで `cargo fmt` / `cargo clippy --workspace --all-targets --all-features` の違反に気づけない gap を埋める。yomu PR #148 の雛形を rurico の workspace 構成に合わせて横展開し、ローカルでの早期検出（pre-commit hook）と Development docs を整備する。

## 変更

- `.githooks/pre-commit`: staged に `*.rs` / `Cargo.{toml,lock}` / `.github/` がある時だけ `cargo fmt --all -- --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` を実行（yomu hook を `--workspace` / `--all` 化）
- `README.md`: `## Development` セクション追加（hooksPath setup + Common commands）。既存 `## テスト` の前に挿入

## 範囲

- **含まない**: main branch protection の設定。`gh api -X PUT repos/thkt/rurico/branches/main/protection` は本 PR merge 後に別アクションで実施し、issue #90 はそこで close する

## 設計判断

- **`--workspace` / `--all` を明示**: rurico は workspace 構成。yomu の単 crate 版 hook をそのまま使うと一部 crate が抜けるため、CI workflow (`.github/workflows/ci.yml`) の Clippy step と完全一致させた
- **grep ガードで軽量化**: docs / 設定のみの commit では fmt / clippy をスキップ。rurico は MLX 関連で cargo build が重く、毎 commit 走らせると体験が悪い。`.github/` は workflow 変更時にも fmt / clippy を効かせる目的で含めた
- **`## Development` を `## テスト` の前に新設**: `## テスト` には MLX runtime / amici 評価ハーネスといった rurico 固有文脈が詰まっており、Development に統合すると一般的な開発フローと固有テスト戦略が混ざる。yomu の構成に合わせて分離した

## 動作確認

1. `git config --local core.hooksPath .githooks`
2. 任意の `.rs` ファイルを編集して `git add` → `git commit -m "test"`
3. `▶ pre-commit: cargo fmt --all -- --check` と `▶ pre-commit: cargo clippy --workspace --all-targets --all-features -- -D warnings` のログが出て、違反があれば commit が中断されることを確認
4. README のみの commit では hook が skip されることを確認（`*.rs` / `Cargo.*` / `.github/` 以外なので）

## 関連

- refs #90
- 雛形: thkt/yomu#148
