### PR TITLE
fix(readme): 使用例の git rev="main" を再現性のある参照に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Apple Silicon (MLX) 上で日本語テキストのembedding・reranking・類似
 
 ```toml
 [dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "main" }
+rurico = { git = "https://github.com/thkt/rurico", tag = "v0.2.0" }
 ```
+
+`tag` は [Cargo.toml の `version`](Cargo.toml) と同期する。新しい release を取り込む場合は [tag 一覧](https://github.com/thkt/rurico/tags) から最新 tag を確認して上書きする。
 
 MLXの初期化失敗はプロセスをabortする可能性がある。`probe` でモデルのロード可否を子プロセスで検証してからEmbedderを作成する。
 


### PR DESCRIPTION
## What & Why

`rev = "main"` はブランチ追従なので main 更新のたび downstream (yomu/sae/recall/amici) が implicit に新コミットを引き込み、build reproducibility が失われる。`tag = "v0.2.0"` に切り替え、Cargo.toml の version と同期した固定参照にする。

## Changes

- `README.md:35` の `rev = "main"` を `tag = "v0.2.0"` に変更
- 新 release 取込み時の手順（[tag 一覧](https://github.com/thkt/rurico/tags) で最新 tag を確認）を README に追記

## Design Decisions

- 案B（tag pin）採用。Issue 本文では案A（SHA pin）を推奨していたが、`v0.2.0` tag が GitHub に push 済（commit `b30d50d`）で `Cargo.toml` の `version = "0.2.0"` と整合していたため、人間可読性の高い tag pin を選択
- 案C（rev=main 維持 + 注意書き）は却下：警告を追記しても downstream の慣行は変わらない

## How to Test

1. GitHub PR の Files changed タブで `README.md` の差分を確認
2. `[dependencies]` ブロックが `tag = "v0.2.0"` になっていることを確認
3. README の [tag 一覧](https://github.com/thkt/rurico/tags) リンクが動作し、`v0.2.0` が表示されることを確認

## Related

- Closes #96
