### PR TITLE
refactor(mlx-cache): cache 戦略統合と test isolation の改善

### DIFF
--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -10,17 +10,8 @@ use super::{
     truncate_for_query,
 };
 use crate::mlx_cache::{clear_inference_cache, release_inference_output};
-use crate::model_io::pad_sequences;
+use crate::model_io::{BUCKET_BOUNDS, assign_bucket, pad_sequences};
 use crate::modernbert::ModernBert;
-
-/// Length-bucket upper bounds. A chunk with `len` tokens lands in the first
-/// bucket whose `BUCKET_BOUNDS[i] >= len`. Final bucket equals [`MAX_SEQ_LEN`]
-/// so every valid chunk (post-shrink) resolves to some bucket.
-///
-/// Bucketing keeps padding waste bounded by the bucket ceiling rather than the
-/// global max chunk length, so a short chunk batched with a long one pays
-/// at most the bucket's padding cost (Spec R-M01, AC-4, NFR-003).
-pub(super) const BUCKET_BOUNDS: [usize; 4] = [128, 512, 2048, MAX_SEQ_LEN];
 
 /// Per-chunk metadata carried through bucket forward so the flat output can be
 /// restored to the original position after bucket passes reorder by length.
@@ -43,19 +34,6 @@ impl IndexedChunk {
     fn doc_order_key(&self) -> (usize, usize) {
         (self.doc_idx, self.chunk_in_doc)
     }
-}
-
-/// Assign `len` to a bucket via the first `BUCKET_BOUNDS[i] >= len`.
-///
-/// # Panics
-///
-/// Panics if `len > MAX_SEQ_LEN`. Callers must ensure chunks have already
-/// been shrunk to fit (via `shrink_chunk_to_fit`).
-pub(super) fn assign_bucket(len: usize) -> usize {
-    BUCKET_BOUNDS
-        .iter()
-        .position(|&max| len <= max)
-        .expect("chunk len exceeds MAX_SEQ_LEN; shrink_chunk_to_fit must run first")
 }
 
 /// Partition indexed chunks into the four length buckets.
@@ -164,21 +142,25 @@ impl EmbedderInner {
 
         let t_tok = Instant::now();
         let tok = tokenize_with_prefix(&self.tokenizer, text, prefix)?;
-        let (input_ids, attention_mask, seq_len) =
+        let (mut input_ids, mut attention_mask, seq_len) =
             truncate_for_query(tok.input_ids, tok.attention_mask, MAX_SEQ_LEN);
         metrics.tokenize = t_tok.elapsed();
 
-        let seq_len_i32 = i32::try_from(seq_len).expect("seq_len fits in i32");
+        let bucket_idx = assign_bucket(seq_len);
+        let bucket_len = BUCKET_BOUNDS[bucket_idx];
+        input_ids.resize(bucket_len, 0);
+        attention_mask.resize(bucket_len, 0);
+        let bucket_len_i32 = i32::try_from(bucket_len).expect("BUCKET_BOUNDS fits in i32");
         let hidden_size = self.embedding_dims;
 
         let t_forward = Instant::now();
         let output = self
             .model
-            .forward(&input_ids, &attention_mask, 1, seq_len_i32)
+            .forward(&input_ids, &attention_mask, 1, bucket_len_i32)
             .map_err(EmbedError::inference)?;
 
         let outcome: Result<(mlx_rs::Array, Vec<f32>), EmbedError> = (|| {
-            let pooled = pool_output(output, &attention_mask, 1, seq_len_i32)?;
+            let pooled = pool_output(output, &attention_mask, 1, bucket_len_i32)?;
             metrics.forward_eval = t_forward.elapsed();
 
             let t_readback = Instant::now();
@@ -205,14 +187,14 @@ impl EmbedderInner {
             }
         };
 
-        // Query tokenization produces no padding (truncate, not pad), so every
-        // mask entry is non-zero — real_tokens equals seq_len.
+        // Query has `seq_len` real tokens followed by `bucket_len - seq_len`
+        // zero-padding tokens added for bucket alignment.
         metrics.real_tokens = seq_len;
-        metrics.padded_tokens = seq_len;
+        metrics.padded_tokens = bucket_len;
         metrics.num_chunks = 1;
         metrics.batch_size = 1;
-        metrics.max_seq_len = seq_len;
-        metrics.bucket_hist[assign_bucket(seq_len)] = 1;
+        metrics.max_seq_len = bucket_len;
+        metrics.bucket_hist[bucket_idx] = 1;
         metrics.log();
 
         result
@@ -286,7 +268,7 @@ impl EmbedderInner {
             // bucket_max boundary, matching the pre-bucketing OOM guarantee.
             let sub_batch_size = (TOKEN_BUDGET / BUCKET_BOUNDS[bucket_idx]).max(1);
             for sub_batch in bucket.chunks(sub_batch_size) {
-                self.forward_sub_batch(sub_batch, &mut out, &mut metrics)?;
+                self.forward_sub_batch(sub_batch, bucket_idx, &mut out, &mut metrics)?;
             }
         }
 
@@ -331,11 +313,13 @@ impl EmbedderInner {
     fn forward_sub_batch(
         &mut self,
         sub_batch: &[IndexedChunk],
+        bucket_idx: usize,
         out: &mut [Option<Vec<f32>>],
         metrics: &mut PhaseMetrics,
     ) -> Result<(), EmbedError> {
         let sub_tokens: Vec<Vec<u32>> = sub_batch.iter().map(|c| c.tokens.clone()).collect();
-        let (input_ids, attention_mask, batch_size, max_len) = pad_sequences(&sub_tokens, None);
+        let (input_ids, attention_mask, batch_size, max_len) =
+            pad_sequences(&sub_tokens, None, Some(BUCKET_BOUNDS[bucket_idx]));
         metrics.real_tokens += sub_tokens.iter().map(Vec::len).sum::<usize>();
         metrics.padded_tokens += batch_size * max_len;
         metrics.batch_size = metrics.batch_size.max(batch_size);
@@ -598,9 +582,9 @@ mod tests {
 
     use super::super::EmbedError;
     use super::{
-        BUCKET_BOUNDS, IndexedChunk, assign_bucket, build_indexed_chunks, distribute_into_buckets,
-        pool_output, split_pooled,
+        IndexedChunk, build_indexed_chunks, distribute_into_buckets, pool_output, split_pooled,
     };
+    use crate::model_io::{BUCKET_BOUNDS, assign_bucket};
 
     #[test]
     fn poison_recovery_pattern_works() {

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -15,6 +15,30 @@ pub(crate) const EOS_TOKEN_ID: u32 = 2;
 /// Maximum sequence length for ruri-v3 models (max_position_embeddings).
 pub const MAX_SEQ_LEN: usize = 8192;
 
+/// Length-bucket upper bounds shared by embed and reranker forward paths.
+///
+/// All `model.forward(..., seq_len)` callers (chunk encoder, query encoder,
+/// reranker pair scorer) round their actual `seq_len` up to one of these four
+/// values. This keeps the per-`seq_len` mask cache inside [`ModernBert`] bounded
+/// to four entries and turns the global MLX compile cache into a fixed working
+/// set of four kernels per model rather than one per observed length.
+///
+/// [`ModernBert`]: crate::modernbert::ModernBert
+pub(crate) const BUCKET_BOUNDS: [usize; 4] = [128, 512, 2048, MAX_SEQ_LEN];
+
+/// Assign `len` to the smallest bucket index `i` with `BUCKET_BOUNDS[i] >= len`.
+///
+/// # Panics
+///
+/// Panics if `len > MAX_SEQ_LEN`. Callers must truncate or shrink the sequence
+/// before bucket assignment.
+pub(crate) fn assign_bucket(len: usize) -> usize {
+    BUCKET_BOUNDS
+        .iter()
+        .position(|&max| len <= max)
+        .expect("len exceeds MAX_SEQ_LEN; truncate before bucketing")
+}
+
 /// Truncate `ids` and `mask` to `max_len` in place, replacing the last token with EOS.
 ///
 /// Returns `true` if truncation was performed. A `max_len` of 0 is a no-op.
@@ -177,7 +201,10 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
 
 /// Pad variable-length token sequences into contiguous flat arrays for batched inference.
 ///
-/// Zero-pads shorter sequences to `max_len` (the longest sequence in the batch).
+/// Zero-pads shorter sequences to `max_len`. When `target_len` is `None`,
+/// `max_len` equals the longest sequence in the batch; when `Some(t)`,
+/// `max_len = max(t, longest)`. Callers pass `Some(BUCKET_BOUNDS[i])` to keep
+/// `model.forward` shapes aligned to the four bucket ceilings.
 /// When `masks` is `None`, generates an identity mask (1 for each token, 0 for padding).
 ///
 /// Returns `(flat_ids, flat_mask, batch_size, max_len)`.
@@ -188,6 +215,7 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
 pub(crate) fn pad_sequences(
     ids: &[Vec<u32>],
     masks: Option<&[Vec<u32>]>,
+    target_len: Option<usize>,
 ) -> (Vec<u32>, Vec<u32>, usize, usize) {
     debug_assert!(
         masks.is_none_or(|m| m.len() == ids.len()),
@@ -197,7 +225,8 @@ pub(crate) fn pad_sequences(
     );
 
     let batch_size = ids.len();
-    let max_len = ids.iter().map(Vec::len).max().unwrap_or(0);
+    let actual_max = ids.iter().map(Vec::len).max().unwrap_or(0);
+    let max_len = target_len.map_or(actual_max, |t| t.max(actual_max));
 
     let mut flat_ids = vec![0u32; batch_size * max_len];
     let mut flat_mask = vec![0u32; batch_size * max_len];
@@ -262,7 +291,7 @@ mod tests {
     #[test]
     fn pad_sequences_no_masks_generates_identity() {
         let ids = vec![vec![1, 2, 3], vec![4, 5]];
-        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None);
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None, None);
         assert_eq!(batch, 2);
         assert_eq!(max_len, 3);
         assert_eq!(flat_ids, vec![1, 2, 3, 4, 5, 0]);
@@ -273,7 +302,7 @@ mod tests {
     fn pad_sequences_with_masks_copies_mask() {
         let ids = vec![vec![10, 20], vec![30]];
         let masks = vec![vec![1, 1], vec![1]];
-        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, Some(&masks));
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, Some(&masks), None);
         assert_eq!(batch, 2);
         assert_eq!(max_len, 2);
         assert_eq!(flat_ids, vec![10, 20, 30, 0]);
@@ -283,7 +312,7 @@ mod tests {
     #[test]
     fn pad_sequences_empty_input() {
         let ids: Vec<Vec<u32>> = vec![];
-        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None);
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None, None);
         assert_eq!(batch, 0);
         assert_eq!(max_len, 0);
         assert!(flat_ids.is_empty());
@@ -293,7 +322,7 @@ mod tests {
     #[test]
     fn pad_sequences_single_sequence() {
         let ids = vec![vec![1, 2, 3, 4]];
-        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None);
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None, None);
         assert_eq!(batch, 1);
         assert_eq!(max_len, 4);
         assert_eq!(flat_ids, vec![1, 2, 3, 4]);

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -328,4 +328,27 @@ mod tests {
         assert_eq!(flat_ids, vec![1, 2, 3, 4]);
         assert_eq!(flat_mask, vec![1, 1, 1, 1]);
     }
+
+    #[test]
+    fn pad_sequences_target_len_extends_when_larger_than_actual_max() {
+        let ids = vec![vec![1, 2], vec![3]];
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None, Some(5));
+        assert_eq!(batch, 2);
+        assert_eq!(max_len, 5, "target_len 5 > actual_max 2 should extend to 5");
+        assert_eq!(flat_ids, vec![1, 2, 0, 0, 0, 3, 0, 0, 0, 0]);
+        assert_eq!(flat_mask, vec![1, 1, 0, 0, 0, 1, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn pad_sequences_target_len_keeps_actual_max_when_smaller() {
+        let ids = vec![vec![1, 2, 3, 4], vec![5, 6]];
+        let (flat_ids, flat_mask, batch, max_len) = pad_sequences(&ids, None, Some(2));
+        assert_eq!(batch, 2);
+        assert_eq!(
+            max_len, 4,
+            "target_len 2 < actual_max 4 must not truncate; actual_max wins"
+        );
+        assert_eq!(flat_ids, vec![1, 2, 3, 4, 5, 6, 0, 0]);
+        assert_eq!(flat_mask, vec![1, 1, 1, 1, 1, 1, 0, 0]);
+    }
 }

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -203,8 +203,12 @@ pub struct ModernBert {
     final_norm: nn::LayerNorm,
     local_attention_half: usize,
     max_seq_len: usize,
-    /// Per-seq-len cache. Bucket batching uses up to 4 unique seq_len values,
-    /// so this map is bounded by the bucket count and never evicts within a run.
+    /// Per-seq-len cache keyed on the four [`BUCKET_BOUNDS`] ceilings. Every
+    /// `forward()` caller (chunk encoder, query encoder, reranker pair scorer)
+    /// rounds its actual `seq_len` up to a bucket bound before calling, so this
+    /// map holds at most four entries for the lifetime of the model.
+    ///
+    /// [`BUCKET_BOUNDS`]: crate::model_io::BUCKET_BOUNDS
     local_mask_cache: HashMap<i32, Array>,
 }
 

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use mlx_rs::{
@@ -202,8 +203,9 @@ pub struct ModernBert {
     final_norm: nn::LayerNorm,
     local_attention_half: usize,
     max_seq_len: usize,
-    /// Single-entry cache keyed on `seq_len`. Rebuilds when `seq_len` changes.
-    local_mask_cache: Option<(i32, Array)>,
+    /// Per-seq-len cache. Bucket batching uses up to 4 unique seq_len values,
+    /// so this map is bounded by the bucket count and never evicts within a run.
+    local_mask_cache: HashMap<i32, Array>,
 }
 
 impl ModernBert {
@@ -242,7 +244,7 @@ impl ModernBert {
             final_norm,
             local_attention_half: config.local_attention / 2,
             max_seq_len: config.max_position_embeddings,
-            local_mask_cache: None,
+            local_mask_cache: HashMap::new(),
         })
     }
 
@@ -355,15 +357,13 @@ impl ModernBert {
         xs = self.embeddings.norm.forward(&xs)?;
 
         let global_mask = prepare_4d_attention_mask(&mask, batch_size, seq_len)?;
-        let local_mask = match &self.local_mask_cache {
-            Some((cached_len, cached)) if *cached_len == seq_len => cached.clone(),
-            _ => {
-                let half =
-                    i32::try_from(self.local_attention_half).expect("bounded by model config");
-                let m = get_local_attention_mask(seq_len, half)?;
-                self.local_mask_cache = Some((seq_len, m.clone()));
-                m
-            }
+        let local_mask = if let Some(cached) = self.local_mask_cache.get(&seq_len) {
+            cached.clone()
+        } else {
+            let half = i32::try_from(self.local_attention_half).expect("bounded by model config");
+            let m = get_local_attention_mask(seq_len, half)?;
+            self.local_mask_cache.insert(seq_len, m.clone());
+            m
         };
 
         for layer in &mut self.layers {

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -1,6 +1,8 @@
 use super::{Artifacts, RerankerError, RerankerInitError};
 use crate::mlx_cache::release_inference_output;
-use crate::model_io::{MAX_SEQ_LEN, pad_sequences, truncate_with_eos};
+use crate::model_io::{
+    BUCKET_BOUNDS, MAX_SEQ_LEN, assign_bucket, pad_sequences, truncate_with_eos,
+};
 use crate::modernbert::{Config, ModernBert, layer_norm_eps_f32};
 
 use mlx_rs::{
@@ -49,7 +51,10 @@ impl RerankerInner {
             all_masks.push(mask);
         }
 
-        let (flat_ids, flat_mask, batch_size, max_len) = pad_sequences(&all_ids, Some(&all_masks));
+        let raw_max = all_ids.iter().map(Vec::len).max().unwrap_or(0);
+        let bucket_idx = assign_bucket(raw_max);
+        let (flat_ids, flat_mask, batch_size, max_len) =
+            pad_sequences(&all_ids, Some(&all_masks), Some(BUCKET_BOUNDS[bucket_idx]));
 
         let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
         let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,7 +30,12 @@ pub fn ensure_sqlite_vec() -> Result<(), String> {
     static INIT: OnceLock<Result<(), i32>> = OnceLock::new();
     let init_result = INIT.get_or_init(|| {
         let rc = rurico_ffi::sqlite_vec_register();
-        if rc == 0 { Ok(()) } else { Err(rc) }
+        if rc == 0 {
+            Ok(())
+        } else {
+            tracing::error!(rc, "sqlite-vec auto-extension registration failed");
+            Err(rc)
+        }
     });
     if let Err(rc) = init_result {
         return Err(format!(


### PR DESCRIPTION
## What & Why

`local_mask_cache` の single-entry 設計が bucket batching の 4 種類 seq_len に追従できず、bucket 切替で必ず eviction → forward 毎に最大 256MB の Array アロケーションが走っていた。HashMap に切り替えて全 4 entry を keep する。あわせて、3 forward caller (`embed_query_truncated`, `forward_sub_batch`, reranker `score_batch`) が actual seq_len を直接 cache key に使っていたため、long-lived encoder で entry が無限蓄積するリスクを構造的に塞ぐ (`BUCKET_BOUNDS` round-up)。`ensure_sqlite_vec` 失敗時に `tracing::error!` を 1 行追加して observability を補完。

## Changes

- `local_mask_cache: Option<(i32, Array)>` → `HashMap<i32, Array>` (`src/modernbert/model.rs`)
- `BUCKET_BOUNDS` / `assign_bucket` を `embed::mlx` から `model_io` に格上げして reranker からも共有
- `pad_sequences` に `target_len: Option<usize>` 引数追加 (`src/model_io.rs`)
- 3 forward caller で `BUCKET_BOUNDS[i]` まで round-up してから forward (`src/embed/mlx.rs`, `src/reranker/mlx.rs`)
- `ensure_sqlite_vec` failure に `tracing::error!(rc, ...)` emit (`src/storage.rs`)
- `pad_sequences` の `target_len` Some 分岐 2 test 追加 (`src/model_io.rs`)

## Design Decisions

- **HashMap (multi-entry) + structural round-up を採用**: tactical な LRU bound も検討したが、本来の design intent (bucket batching で seq_len は 4 値に固定) を実現する structural fix の方が production correctness と performance 両立する。`embed_query_truncated` / `forward_sub_batch` / reranker `score_batch` が actual seq_len を渡してた点が真の bug
- **`pad_sequences` に optional `target_len`**: caller 側で手動 resize するより API 集約が綺麗。`max_len = max(target, actual_max)` で under-pad しない安全性を保つ
- **`ensure_sqlite_vec` の error emit は 1 行のみ**: failure は `OnceLock` で永続化される一過性 event なので、初回のみ emit すれば十分

## How to Test

1. `cargo test --workspace --features test-support,test-mlx` 全 pass (260 既存 + 2 新規 = 262 tests)
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
3. `cargo fmt --check` clean
4. `pad_sequences_target_len_*` 2 test で Some 分岐 (extend / actual_max-wins) を pin 確認

## Related

- Closes #101
- `/polish` review で Codex P1 として指摘された unbounded cache を structural round-up で resolve
- downstream 追従: amici / yomu / recall / sae 全リポで rev bump（API 影響なし）
