### PR TITLE
refactor(model_probe): モジュール配置整理と injection seam 追加

### DIFF
--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -35,7 +35,7 @@ use rurico::embed::{
     linreg::{linear_regression, r_squared},
     workloads::{workload_w1, workload_w2, workload_w3},
 };
-use rurico::model_probe;
+use rurico::handle_probe_if_needed;
 use rurico::sandbox;
 
 /// Minimal `tracing` subscriber that writes every record to stderr.
@@ -57,7 +57,7 @@ fn main() {
     init_tracing_subscriber();
 
     // Also acts as a probe subprocess when probe env vars are set.
-    model_probe::handle_probe_if_needed();
+    handle_probe_if_needed();
 
     sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 

--- a/src/bin/probe_embed_smoke.rs
+++ b/src/bin/probe_embed_smoke.rs
@@ -8,13 +8,14 @@
 //! `Embedder::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
-use rurico::embed::{Embedder, ModelId, ProbeStatus, cached_artifacts};
-use rurico::model_probe;
+use rurico::embed::{Embedder, ModelId, cached_artifacts};
+use rurico::handle_probe_if_needed;
+use rurico::model_probe::ProbeStatus;
 use rurico::sandbox;
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
-    model_probe::handle_probe_if_needed();
+    handle_probe_if_needed();
 
     sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 

--- a/src/bin/probe_reranker_smoke.rs
+++ b/src/bin/probe_reranker_smoke.rs
@@ -8,13 +8,14 @@
 //! `Reranker::probe()` re-execs `current_exe()`, it re-execs this binary —
 //! so the full probe cycle is exercised end-to-end.
 
-use rurico::model_probe;
-use rurico::reranker::{ProbeStatus, Reranker, RerankerModelId, cached_artifacts};
+use rurico::handle_probe_if_needed;
+use rurico::model_probe::ProbeStatus;
+use rurico::reranker::{Reranker, RerankerModelId, cached_artifacts};
 use rurico::sandbox;
 
 fn main() {
     // Must be first: handles re-exec when called as a probe subprocess.
-    model_probe::handle_probe_if_needed();
+    handle_probe_if_needed();
 
     sandbox::exit_if_seatbelt(env!("CARGO_BIN_NAME"));
 

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,89 @@
+//! Top-level probe dispatcher that wires the embed and reranker domains into
+//! a single `main()` entry point.
+//!
+//! Lives above `model_probe`, `embed`, and `reranker` to break the dependency
+//! cycle that previously had `model_probe` importing both domains while
+//! `embed`/`reranker` re-exported `model_probe` symbols.
+
+use std::env;
+
+use crate::{embed, model_probe, reranker};
+
+/// Single entry point for probe subprocess dispatch in host binaries.
+///
+/// Call at the start of `main()`. When invoked as a probe subprocess (detected
+/// via env vars), this function loads the appropriate model and exits via
+/// [`std::process::exit`]. Otherwise returns immediately.
+///
+/// # Process Behavior
+///
+/// When the current process is a probe subprocess:
+///
+/// - Exit 0: model loaded successfully
+/// - Exit 1: model load failed (reason written to stderr)
+/// - Exit 3: primary env var set but config or tokenizer env var missing
+pub fn handle_probe_if_needed() {
+    handle_probe_if_needed_with(|key| env::var(key).ok())
+}
+
+/// Like [`handle_probe_if_needed`] but the env-var lookup is provided
+/// explicitly. Used by tests to drive both probe paths without mutating the
+/// process environment (forbidden under Rust 2024).
+pub fn handle_probe_if_needed_with<F>(get: F)
+where
+    F: Fn(&str) -> Option<String>,
+{
+    if let Some(result) = embed::probe_env_to_paths(
+        get(embed::PROBE_ENV_MODEL),
+        get(embed::PROBE_ENV_CONFIG),
+        get(embed::PROBE_ENV_TOKENIZER),
+    ) {
+        model_probe::dispatch_probe(result, |candidate| {
+            let artifacts = candidate.verify().map_err(|e| e.to_string())?;
+            embed::Embedder::new(&artifacts)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        });
+    }
+
+    if let Some(result) = reranker::probe_env_to_paths(
+        get(reranker::PROBE_ENV_MODEL),
+        get(reranker::PROBE_ENV_CONFIG),
+        get(reranker::PROBE_ENV_TOKENIZER),
+    ) {
+        model_probe::dispatch_probe(result, |candidate| {
+            let artifacts = candidate.verify().map_err(|e| e.to_string())?;
+            reranker::Reranker::new(&artifacts)
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup_from(map: &HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+        let owned: HashMap<String, String> = map
+            .iter()
+            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
+            .collect();
+        move |key: &str| owned.get(key).cloned()
+    }
+
+    #[test]
+    fn handle_probe_if_needed_with_returns_when_no_env_set() {
+        let map: HashMap<&'static str, &'static str> = HashMap::new();
+        handle_probe_if_needed_with(lookup_from(&map));
+    }
+
+    #[test]
+    fn handle_probe_if_needed_with_skips_paths_without_primary_keys() {
+        let mut map = HashMap::new();
+        map.insert(embed::PROBE_ENV_CONFIG, "/tmp/c");
+        map.insert(reranker::PROBE_ENV_TOKENIZER, "/tmp/t");
+        handle_probe_if_needed_with(lookup_from(&map));
+    }
+}

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -36,6 +36,10 @@ use crate::model_io::{
     ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts, truncate_with_eos,
 };
 use crate::model_probe::ProbeError;
+use std::fmt;
+#[cfg(any(test, feature = "test-support"))]
+use std::path::Path;
+use std::path::PathBuf;
 
 /// Probe env-var key for the embedding model weights path.
 pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_PROBE_MODEL";
@@ -43,10 +47,6 @@ pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_PROBE_MODEL";
 pub(crate) const PROBE_ENV_CONFIG: &str = "__RURICO_PROBE_CONFIG";
 /// Probe env-var key for the embedding model tokenizer path.
 pub(crate) const PROBE_ENV_TOKENIZER: &str = "__RURICO_PROBE_TOKENIZER";
-use std::fmt;
-#[cfg(any(test, feature = "test-support"))]
-use std::path::Path;
-use std::path::PathBuf;
 
 // ── Domain alias ─────────────────────────────────────────────────────────────
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -26,7 +26,6 @@ pub use test_support::{
 };
 
 pub use crate::artifacts::{ArtifactError, EmbedKind, VerifiedArtifacts};
-pub use crate::model_probe::{ProbeStatus, handle_probe_if_needed};
 pub use embedder::Embedder;
 pub use metrics::BatchMetrics;
 pub use pooling::gpu_pool_and_normalize;
@@ -37,6 +36,13 @@ use crate::model_io::{
     ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts, truncate_with_eos,
 };
 use crate::model_probe::ProbeError;
+
+/// Probe env-var key for the embedding model weights path.
+pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_PROBE_MODEL";
+/// Probe env-var key for the embedding model config path.
+pub(crate) const PROBE_ENV_CONFIG: &str = "__RURICO_PROBE_CONFIG";
+/// Probe env-var key for the embedding model tokenizer path.
+pub(crate) const PROBE_ENV_TOKENIZER: &str = "__RURICO_PROBE_TOKENIZER";
 use std::fmt;
 #[cfg(any(test, feature = "test-support"))]
 use std::path::Path;

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -3,9 +3,8 @@ use std::sync::{Mutex, MutexGuard};
 
 use super::metrics::BatchMetrics;
 use super::mlx::EmbedderInner;
-use super::{
-    Artifacts, ChunkedEmbedding, Embed, EmbedError, EmbedInitError, ProbeStatus, QUERY_PREFIX,
-};
+use super::{Artifacts, ChunkedEmbedding, Embed, EmbedError, EmbedInitError, QUERY_PREFIX};
+use crate::model_probe::ProbeStatus;
 
 /// Thread-safe embedding model backed by MLX. Wraps the backend in a [`Mutex`].
 pub struct Embedder {

--- a/src/embed/probe.rs
+++ b/src/embed/probe.rs
@@ -1,8 +1,8 @@
-use super::{Artifacts, CandidateArtifacts, EmbedInitError};
-use crate::model_probe::{
-    self, EMBED_PROBE_ENV_CONFIG, EMBED_PROBE_ENV_MODEL, EMBED_PROBE_ENV_TOKENIZER, ProbeStatus,
-    resolve_probe_env,
+use super::{
+    Artifacts, CandidateArtifacts, EmbedInitError, PROBE_ENV_CONFIG, PROBE_ENV_MODEL,
+    PROBE_ENV_TOKENIZER,
 };
+use crate::model_probe::{self, ProbeStatus, resolve_probe_env};
 
 /// Resolve probe env vars into a [`CandidateArtifacts`].
 ///
@@ -23,9 +23,9 @@ pub(super) fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus,
     let paths = &artifacts.paths;
     model_probe::probe_paths_via_subprocess(
         paths,
-        EMBED_PROBE_ENV_MODEL,
-        EMBED_PROBE_ENV_CONFIG,
-        EMBED_PROBE_ENV_TOKENIZER,
+        PROBE_ENV_MODEL,
+        PROBE_ENV_CONFIG,
+        PROBE_ENV_TOKENIZER,
     )
     .map_err(Into::into)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 
 /// Typed artifact verification: [`CandidateArtifacts`](embed::CandidateArtifacts) → [`VerifiedArtifacts`](artifacts::VerifiedArtifacts).
 pub mod artifacts;
+/// Top-level probe dispatch wiring embed and reranker domains.
+pub mod dispatch;
 /// Embedding models and the [`Embed`](embed::Embed) trait.
 pub mod embed;
 /// Process-global MLX cache lock shared by embed and reranker.
@@ -30,3 +32,5 @@ pub mod storage;
 pub(crate) mod test_support;
 /// Text chunking utilities.
 pub mod text;
+
+pub use dispatch::{handle_probe_if_needed, handle_probe_if_needed_with};

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -1,8 +1,10 @@
 //! Shared subprocess probe infrastructure for model loading verification.
 //!
-//! Host binaries call `handle_probe_if_needed` once at the start of `main()`.
-//! Individual modules (embed, reranker) call `probe_via_subprocess` to
-//! re-exec the current binary as an isolated probe.
+//! Host binaries call [`handle_probe_if_needed`](crate::handle_probe_if_needed)
+//! once at the start of `main()` — that lives in [`crate::dispatch`] because it
+//! needs to know about both embed and reranker domains. Individual modules
+//! (embed, reranker) call [`probe_via_subprocess`] to re-exec the current
+//! binary as an isolated probe.
 
 use std::env;
 use std::fmt;
@@ -16,9 +18,7 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use std::process::ExitStatus;
 
-use crate::embed;
 use crate::model_io::ModelPaths;
-use crate::reranker;
 
 /// Handshake token written to stdout by probe subprocesses.
 pub const PROBE_ACK: &str = "RURICO_PROBE_OK";
@@ -56,16 +56,6 @@ pub enum ProbeError {
     SubprocessFailed(String),
 }
 
-// --- Embed probe env var keys ---
-pub(crate) const EMBED_PROBE_ENV_MODEL: &str = "__RURICO_PROBE_MODEL";
-pub(crate) const EMBED_PROBE_ENV_CONFIG: &str = "__RURICO_PROBE_CONFIG";
-pub(crate) const EMBED_PROBE_ENV_TOKENIZER: &str = "__RURICO_PROBE_TOKENIZER";
-
-// --- Reranker probe env var keys ---
-pub(crate) const RERANKER_PROBE_ENV_MODEL: &str = "__RURICO_RERANKER_PROBE_MODEL";
-pub(crate) const RERANKER_PROBE_ENV_CONFIG: &str = "__RURICO_RERANKER_PROBE_CONFIG";
-pub(crate) const RERANKER_PROBE_ENV_TOKENIZER: &str = "__RURICO_RERANKER_PROBE_TOKENIZER";
-
 /// Resolve probe env vars into a `(model, config, tokenizer)` path triple.
 ///
 /// Returns `None` if the primary model env var is absent (not a probe invocation).
@@ -86,51 +76,10 @@ pub(crate) fn resolve_probe_env(
 /// Timeout for probe subprocesses.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Single entry point for probe subprocess dispatch in host binaries.
-///
-/// Call at the start of `main()`. When invoked as a probe subprocess (detected
-/// via env vars), this function loads the appropriate model and exits. Otherwise
-/// returns immediately.
-///
-/// # Process Behavior
-///
-/// When the current process is a probe subprocess, this function terminates
-/// with `std::process::exit`:
-///
-/// - Exit 0: model loaded successfully
-/// - Exit 1: model load failed (reason written to stderr)
-/// - Exit 3: primary env var set but config or tokenizer env var missing
-///
-/// When the current process is not a probe subprocess, it returns immediately.
-pub fn handle_probe_if_needed() {
-    // --- Embed probe ---
-    if let Some(result) = embed::probe_env_to_paths(
-        env::var(EMBED_PROBE_ENV_MODEL).ok(),
-        env::var(EMBED_PROBE_ENV_CONFIG).ok(),
-        env::var(EMBED_PROBE_ENV_TOKENIZER).ok(),
-    ) {
-        dispatch_probe(result, |candidate| {
-            let artifacts = candidate.verify().map_err(|e| e.to_string())?;
-            embed::Embedder::new(&artifacts)
-                .map(|_| ())
-                .map_err(|e| e.to_string())
-        });
-    }
-
-    // --- Reranker probe ---
-    if let Some(result) = reranker::probe_env_to_paths(
-        env::var(RERANKER_PROBE_ENV_MODEL).ok(),
-        env::var(RERANKER_PROBE_ENV_CONFIG).ok(),
-        env::var(RERANKER_PROBE_ENV_TOKENIZER).ok(),
-    ) {
-        dispatch_probe(result, |candidate| {
-            let artifacts = candidate.verify().map_err(|e| e.to_string())?;
-            reranker::Reranker::new(&artifacts)
-                .map(|_| ())
-                .map_err(|e| e.to_string())
-        });
-    }
-}
+/// Default polling interval used by [`wait_with_timeout`] to check whether the
+/// child has exited. Tests inject a smaller interval via
+/// [`wait_with_timeout_with`] to keep timeout-path assertions fast.
+const DEFAULT_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Exit action computed by [`compute_probe_exit`].
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -164,7 +113,7 @@ pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> Pro
 /// Execute a probe dispatch: emit ACK, load model, exit with appropriate code.
 ///
 /// Always terminates the process via [`std::process::exit`].
-fn dispatch_probe<P, E: fmt::Display>(
+pub(crate) fn dispatch_probe<P, E: fmt::Display>(
     result: Result<P, i32>,
     load: impl FnOnce(P) -> Result<(), E>,
 ) -> ! {
@@ -196,7 +145,15 @@ fn emit_ack() {
 pub fn probe_via_subprocess(env_pairs: &[(&str, &str)]) -> Result<ProbeStatus, ProbeError> {
     let exe = env::current_exe()
         .map_err(|e| ProbeError::SubprocessFailed(format!("cannot locate executable: {e}")))?;
+    probe_via_subprocess_with(exe, env_pairs)
+}
 
+/// Like [`probe_via_subprocess`] but the executable to re-exec is provided
+/// explicitly. Used by tests to avoid depending on `env::current_exe()`.
+pub fn probe_via_subprocess_with(
+    exe: PathBuf,
+    env_pairs: &[(&str, &str)],
+) -> Result<ProbeStatus, ProbeError> {
     let mut cmd = Command::new(exe);
     for &(key, value) in env_pairs {
         cmd.env(key, value);
@@ -280,6 +237,16 @@ pub(crate) fn probe_paths_via_subprocess(
 /// Wait for a child process with a timeout. Kill and return a synthetic
 /// timeout output if the deadline is exceeded.
 fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<Output, ProbeError> {
+    wait_with_timeout_with(child, timeout, DEFAULT_WAIT_POLL_INTERVAL)
+}
+
+/// Like [`wait_with_timeout`] but the polling interval is provided explicitly.
+/// Used by tests to keep timeout-path assertions fast (e.g. 1 ms).
+fn wait_with_timeout_with(
+    child: &mut Child,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> Result<Output, ProbeError> {
     let deadline = Instant::now() + timeout;
     let stdout = spawn_drain_pipe(child.stdout.take(), "stdout");
     let stderr = spawn_drain_pipe(child.stderr.take(), "stderr");
@@ -309,7 +276,7 @@ fn wait_with_timeout(child: &mut Child, timeout: Duration) -> Result<Output, Pro
                         stderr: collect_pipe(stderr, "stderr"),
                     });
                 }
-                thread::sleep(Duration::from_millis(100));
+                thread::sleep(poll_interval);
             }
             Err(e) => {
                 return Err(ProbeError::SubprocessFailed(format!(
@@ -565,6 +532,45 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(5),
             "collect_pipe must not wait for the grandchild's inherited FDs; elapsed {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn probe_via_subprocess_with_reports_spawn_failure_for_missing_exe() {
+        let exe = PathBuf::from("/nonexistent/rurico-probe-test-binary");
+        let err = probe_via_subprocess_with(exe, &[]).unwrap_err();
+        assert!(
+            matches!(err, ProbeError::SubprocessFailed(_)),
+            "expected SubprocessFailed for missing executable, got {err}"
+        );
+    }
+
+    #[test]
+    fn wait_with_timeout_with_kills_long_running_child_on_short_timeout() {
+        let mut child = Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let start = Instant::now();
+        let output = wait_with_timeout_with(
+            &mut child,
+            Duration::from_millis(50),
+            Duration::from_millis(1),
+        )
+        .unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "1ms poll interval should detect the 50ms deadline promptly; elapsed {elapsed:?}"
+        );
+        assert!(
+            output.status.code().is_none() || output.status.code() == Some(0),
+            "child should be killed (no exit code) or have exited; got {:?}",
+            output.status.code()
         );
     }
 }

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -17,6 +17,8 @@ use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
 pub use crate::artifacts::{ArtifactError, RerankerKind, VerifiedArtifacts};
+#[cfg(any(test, feature = "test-support"))]
+pub use test_support::MockReranker;
 
 /// Probe env-var key for the reranker model weights path.
 pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_RERANKER_PROBE_MODEL";
@@ -24,9 +26,6 @@ pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_RERANKER_PROBE_MODEL";
 pub(crate) const PROBE_ENV_CONFIG: &str = "__RURICO_RERANKER_PROBE_CONFIG";
 /// Probe env-var key for the reranker model tokenizer path.
 pub(crate) const PROBE_ENV_TOKENIZER: &str = "__RURICO_RERANKER_PROBE_TOKENIZER";
-
-#[cfg(any(test, feature = "test-support"))]
-pub use test_support::MockReranker;
 
 // ── Domain alias ─────────────────────────────────────────────────────────────
 

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -9,10 +9,7 @@ mod tests;
 use self::mlx::RerankerInner;
 use crate::artifacts::verify_as_reranker;
 use crate::model_io::{ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts};
-use crate::model_probe::{
-    ProbeError, RERANKER_PROBE_ENV_CONFIG, RERANKER_PROBE_ENV_MODEL, RERANKER_PROBE_ENV_TOKENIZER,
-    probe_paths_via_subprocess, resolve_probe_env,
-};
+use crate::model_probe::{ProbeError, ProbeStatus, probe_paths_via_subprocess, resolve_probe_env};
 use std::fmt::{self, Debug, Display, Formatter};
 #[cfg(any(test, feature = "test-support"))]
 use std::path::Path;
@@ -20,7 +17,13 @@ use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
 pub use crate::artifacts::{ArtifactError, RerankerKind, VerifiedArtifacts};
-pub use crate::model_probe::ProbeStatus;
+
+/// Probe env-var key for the reranker model weights path.
+pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_RERANKER_PROBE_MODEL";
+/// Probe env-var key for the reranker model config path.
+pub(crate) const PROBE_ENV_CONFIG: &str = "__RURICO_RERANKER_PROBE_CONFIG";
+/// Probe env-var key for the reranker model tokenizer path.
+pub(crate) const PROBE_ENV_TOKENIZER: &str = "__RURICO_RERANKER_PROBE_TOKENIZER";
 
 #[cfg(any(test, feature = "test-support"))]
 pub use test_support::MockReranker;
@@ -390,9 +393,9 @@ pub(crate) fn probe_env_to_paths(
 fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, RerankerInitError> {
     probe_paths_via_subprocess(
         &artifacts.paths,
-        RERANKER_PROBE_ENV_MODEL,
-        RERANKER_PROBE_ENV_CONFIG,
-        RERANKER_PROBE_ENV_TOKENIZER,
+        PROBE_ENV_MODEL,
+        PROBE_ENV_CONFIG,
+        PROBE_ENV_TOKENIZER,
     )
     .map_err(Into::into)
 }


### PR DESCRIPTION
## What & Why

`model_probe` が embed/reranker を import しつつ embed/reranker が `model_probe` を re-export する bidirectional cycle、env-var key の所有不明、`env::var` / `current_exe` / 100ms hardcode の test 困難性が同居していた。`dispatch` module を crate root に新設して上流に上げ、env-var key を各 domain に戻し、3 つの `_with` injection seam を追加して構造的に解消する。

## Changes

- 新 `src/dispatch.rs`: `handle_probe_if_needed` / `handle_probe_if_needed_with(get: F)` を crate root に追加。embed と reranker domain を上流から wire
- env-var key constants を `embed::PROBE_ENV_*` / `reranker::PROBE_ENV_*` に移管 (`__RURICO_PROBE_*` / `__RURICO_RERANKER_PROBE_*`)
- `embed::ProbeStatus` / `reranker::ProbeStatus` / `embed::handle_probe_if_needed` の re-export 削除
- `dispatch_probe` を `pub(crate)` 化
- `probe_via_subprocess_with(exe, env_pairs)` 追加（thin wrapper 化）
- `wait_with_timeout_with(child, timeout, poll_interval)` 追加（100ms 引数化、`DEFAULT_WAIT_POLL_INTERVAL` 定数）
- 新規 unit test 4 件 (dispatch 2 + model_probe 2)
- smoke binaries (`mlx_smoke` / `probe_embed_smoke` / `probe_reranker_smoke`) の import 更新

## Design Decisions

- **option A1 (構造解消) を採用**: option A2 (model_probe rename だけ) では cycle の根本解消にならない。embed/reranker への `pub use` re-export 削除で API surface も統一
- **`handle_probe_if_needed` を crate root に新設**: embed と reranker 両方を import する関数なので model_probe より上流が必要 (issue 推奨どおり)
- **injection seam は thin wrapper パターン**: Rust LANG.md の `from_env()` / `from_env_with()` 慣例に従う
- **API path split**: `rurico::handle_probe_if_needed` (crate root) + `rurico::model_probe::ProbeStatus` (domain)。関数とデータ型で責任を分け、API 利用者は `rurico::handle_probe_if_needed()` を呼んで `rurico::model_probe::ProbeStatus` を match する

## Breaking Changes

破壊的変更（downstream に migrate issue 必要）:

- `rurico::model_probe::handle_probe_if_needed` → `rurico::handle_probe_if_needed`
- `rurico::embed::ProbeStatus` → `rurico::model_probe::ProbeStatus`
- `rurico::reranker::ProbeStatus` → `rurico::model_probe::ProbeStatus`

影響リポ: amici (`embed::ProbeStatus` / `reranker::ProbeStatus` を 4 箇所で import 中)、yomu / recall / sae (`model_probe::handle_probe_if_needed` を import 中)。

## How to Test

1. `cargo test --workspace --features test-support,test-mlx` 全 pass (266 passed, 24 ignored)
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
3. `cargo fmt --check` clean
4. 新規 4 test で seam の挙動を pin:
   - `dispatch::handle_probe_if_needed_with_returns_when_no_env_set`
   - `dispatch::handle_probe_if_needed_with_skips_paths_without_primary_keys`
   - `model_probe::probe_via_subprocess_with_reports_spawn_failure_for_missing_exe`
   - `model_probe::wait_with_timeout_with_kills_long_running_child_on_short_timeout`

## Related

- Closes #100
- `/polish` review で simplify quality reviewer 指摘の import 順序整理を Phase 1 に含む (commit `be6797b`)
- Codex/CodeRabbit minor (`#[cfg(unix)]` 漏れ) は既存 test 3 件と同 pattern + Windows 互換確保済のため skip
