### PR TITLE
probe child の path allowlist と env hardening 追加 (#107)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "temp-env",
  "tempfile",
  "thiserror",
  "tokenizers",
@@ -2331,6 +2332,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ unicode-normalization = "0.1"
 
 [dev-dependencies]
 serial_test = "3"
+temp-env = "0.3"
 tempfile = "3"
 tracing-test = "0.2"
 

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -74,7 +74,7 @@ impl CandidateArtifacts {
     ///
     /// Use this when you have raw paths (e.g. from environment variables).
     /// Call [`verify`](Self::verify) before passing the result to [`Embedder::new`].
-    pub fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
+    pub(crate) fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
         Self {
             paths: ModelPaths {
                 model,
@@ -290,6 +290,7 @@ impl From<ProbeError> for EmbedInitError {
         match e {
             ProbeError::HandlerNotInstalled => EmbedInitError::Backend(e.to_string()),
             ProbeError::ModelLoadFailed { reason } => EmbedInitError::ModelCorrupt { reason },
+            ProbeError::SetupRejected { .. } => EmbedInitError::Backend(e.to_string()),
             ProbeError::SubprocessFailed(msg) => EmbedInitError::Backend(msg),
         }
     }

--- a/src/embed/probe.rs
+++ b/src/embed/probe.rs
@@ -2,7 +2,7 @@ use super::{
     Artifacts, CandidateArtifacts, EmbedInitError, PROBE_ENV_CONFIG, PROBE_ENV_MODEL,
     PROBE_ENV_TOKENIZER,
 };
-use crate::model_probe::{self, ProbeStatus, resolve_probe_env};
+use crate::model_probe::{self, ProbeStatus, resolve_probe_env, validate_probe_paths};
 
 /// Resolve probe env vars into a [`CandidateArtifacts`].
 ///
@@ -14,8 +14,13 @@ pub(crate) fn probe_env_to_paths(
     config: Option<String>,
     tokenizer: Option<String>,
 ) -> Option<Result<CandidateArtifacts, i32>> {
-    resolve_probe_env(model, config, tokenizer)
-        .map(|r| r.map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t)))
+    resolve_probe_env(model, config, tokenizer).map(|r| {
+        r.and_then(|(m, c, t)| {
+            validate_probe_paths(&m, &c, &t)?;
+            Ok((m, c, t))
+        })
+        .map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t))
+    })
 }
 
 /// Re-exec the current binary as a probe subprocess for the embedding model.

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -3,6 +3,8 @@ use super::probe::probe_env_to_paths;
 use super::*;
 use crate::model_io::{EOS_TOKEN_ID, artifacts_from_cache, load_tokenizer};
 use crate::test_support::setup_fake_hf_cache;
+#[cfg(unix)]
+use crate::test_support::setup_fake_hf_cache_with_symlinks;
 use std::fs;
 
 #[test]
@@ -115,15 +117,90 @@ fn candidate_verify_returns_invalid_config_for_malformed_config() {
     );
 }
 
+// T-018: regression — probe_env_to_paths must return the snapshot symlink path,
+// not the canonicalized blob path. Failed branch fix/issue-107-canonicalize
+// (commit 33c91c1) violated this and broke MLX `load_safetensors`'s
+// extension-based dispatch across all standard HF cache usage.
+#[cfg(unix)]
 #[test]
-fn probe_env_to_paths_returns_paths_when_all_present() {
-    let candidate = probe_env_to_paths(Some("/m".into()), Some("/c".into()), Some("/t".into()))
+fn t_018_probe_env_to_paths_preserves_snapshot_symlink_filename() {
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    setup_fake_hf_cache_with_symlinks(
+        &cache_root,
+        "org/model",
+        "dev",
+        &[
+            ("model.safetensors", b"weights"),
+            ("config.json", b"{}"),
+            ("tokenizer.json", b"{}"),
+        ],
+    );
+    let snapshot_dir = cache_root.join("models--org--model/snapshots/abc123");
+    let m = snapshot_dir.join("model.safetensors");
+    let c = snapshot_dir.join("config.json");
+    let t = snapshot_dir.join("tokenizer.json");
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let candidate = probe_env_to_paths(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        )
         .unwrap()
         .unwrap();
-    // paths field is accessible within the embed module (child module can access parent's private)
-    assert_eq!(candidate.paths.model, PathBuf::from("/m"));
-    assert_eq!(candidate.paths.config, PathBuf::from("/c"));
-    assert_eq!(candidate.paths.tokenizer, PathBuf::from("/t"));
+        // Critical regression assertion: load path must be the snapshot
+        // symlink (filename ends in "model.safetensors"), not the
+        // canonicalized blob path (which would be "etag-model.safetensors").
+        assert_eq!(
+            candidate.paths.model.file_name().and_then(|s| s.to_str()),
+            Some("model.safetensors"),
+            "regression: probe_env_to_paths must preserve snapshot symlink filename"
+        );
+        assert_eq!(
+            candidate.paths.config.file_name().and_then(|s| s.to_str()),
+            Some("config.json")
+        );
+        assert_eq!(
+            candidate
+                .paths
+                .tokenizer
+                .file_name()
+                .and_then(|s| s.to_str()),
+            Some("tokenizer.json")
+        );
+    });
+}
+
+#[test]
+fn probe_env_to_paths_returns_paths_when_all_present() {
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    let m = cache_root.join("model.safetensors");
+    let c = cache_root.join("config.json");
+    let t = cache_root.join("tokenizer.json");
+    fs::write(&m, b"").unwrap();
+    fs::write(&c, b"{}").unwrap();
+    fs::write(&t, b"{}").unwrap();
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let candidate = probe_env_to_paths(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        )
+        .unwrap()
+        .unwrap();
+        // paths field is accessible within the embed module (child module can access parent's private)
+        // load step receives original (non-canonicalized) paths so HF cache symlinks survive
+        assert_eq!(candidate.paths.model, m);
+        assert_eq!(candidate.paths.config, c);
+        assert_eq!(candidate.paths.tokenizer, t);
+    });
 }
 
 #[test]

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -6,10 +6,12 @@
 //! (embed, reranker) call [`probe_via_subprocess`] to re-exec the current
 //! binary as an isolated probe.
 
+use std::collections::HashMap;
 use std::env;
 use std::fmt;
+use std::fs;
 use std::io::{self, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{self, Child, Command, Output, Stdio};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread;
@@ -26,6 +28,66 @@ pub const PROBE_ACK: &str = "RURICO_PROBE_OK";
 /// Exit code used when a probe subprocess was invoked with the primary model env var
 /// set but the config or tokenizer env vars were missing.
 pub(crate) const PROBE_EXIT_ENV_INCOMPLETE: i32 = 3;
+
+/// Exit code returned by the probe child when `std::fs::canonicalize` fails on
+/// any of the candidate paths (file missing, permission denied, symlink loop).
+pub(crate) const PROBE_EXIT_CANONICALIZE_FAILED: i32 = 4;
+
+/// Exit code returned by the probe child when a candidate path's canonical form
+/// is not a component-wise descendant of the canonical cache root.
+pub(crate) const PROBE_EXIT_PATH_OUTSIDE_CACHE: i32 = 5;
+
+/// Exit code returned by the probe child when `std::fs::canonicalize` fails on
+/// the cache root itself (HF cache directory missing or unreadable).
+pub(crate) const PROBE_EXIT_CACHE_ROOT_INVALID: i32 = 6;
+
+/// Verify that `model`, `config`, and `tokenizer` paths all canonicalize to
+/// component-wise descendants of `cache_root`. The candidate paths are
+/// not modified — the load step receives the original symlink path so HF
+/// cache snapshot symlinks (`snapshots/<commit>/<file>` -> `blobs/<etag>`)
+/// keep their original filenames, preserving MLX's extension-based dispatch.
+///
+/// # Errors
+///
+/// - [`PROBE_EXIT_CACHE_ROOT_INVALID`] if `cache_root` cannot be canonicalized
+/// - [`PROBE_EXIT_CANONICALIZE_FAILED`] if any candidate path cannot be canonicalized
+/// - [`PROBE_EXIT_PATH_OUTSIDE_CACHE`] if any candidate path's canonical form
+///   is not a component-wise descendant of `cache_root`'s canonical form
+pub(crate) fn validate_probe_paths_with_root(
+    model: &Path,
+    config: &Path,
+    tokenizer: &Path,
+    cache_root: &Path,
+) -> Result<(), i32> {
+    let canon_root = fs::canonicalize(cache_root).map_err(|_| PROBE_EXIT_CACHE_ROOT_INVALID)?;
+    for p in [model, config, tokenizer] {
+        let canon = fs::canonicalize(p).map_err(|_| PROBE_EXIT_CANONICALIZE_FAILED)?;
+        if !canon.starts_with(&canon_root) {
+            return Err(PROBE_EXIT_PATH_OUTSIDE_CACHE);
+        }
+    }
+    Ok(())
+}
+
+/// Production wrapper for [`validate_probe_paths_with_root`] that resolves
+/// the cache root via [`hf_hub::Cache::from_env`].
+///
+/// `Cache::from_env()` reads `HF_HOME` and falls back to the user's default
+/// `~/.cache/huggingface/hub`. The cache resolution happens at call time so
+/// parallel tests using `temp_env::with_vars` to scope env vars do not poison
+/// each other.
+///
+/// # Errors
+///
+/// Same as [`validate_probe_paths_with_root`].
+pub(crate) fn validate_probe_paths(
+    model: &Path,
+    config: &Path,
+    tokenizer: &Path,
+) -> Result<(), i32> {
+    let cache = hf_hub::Cache::from_env();
+    validate_probe_paths_with_root(model, config, tokenizer, cache.path())
+}
 
 /// Result of a model probe — whether the backend can load the model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,9 +113,32 @@ pub enum ProbeError {
         /// Failure detail from stderr.
         reason: String,
     },
+    /// Setup-phase rejection (path validation or env hardening) in the probe child.
+    ///
+    /// `code` is one of [`PROBE_EXIT_CANONICALIZE_FAILED`] (4),
+    /// [`PROBE_EXIT_PATH_OUTSIDE_CACHE`] (5), or
+    /// [`PROBE_EXIT_CACHE_ROOT_INVALID`] (6).
+    #[error("probe setup rejected (code {code}: {})", setup_label(*code))]
+    SetupRejected {
+        /// Setup-phase exit code.
+        code: i32,
+    },
     /// Subprocess spawn or wait failure.
     #[error("probe error: {0}")]
     SubprocessFailed(String),
+}
+
+/// Human-readable label for a setup-phase exit code, used in
+/// [`ProbeError::SetupRejected`] Display and in [`setup_failure_message`]
+/// (child stderr message).
+fn setup_label(code: i32) -> &'static str {
+    match code {
+        PROBE_EXIT_ENV_INCOMPLETE => "env incomplete",
+        PROBE_EXIT_CANONICALIZE_FAILED => "path canonicalize failed",
+        PROBE_EXIT_PATH_OUTSIDE_CACHE => "path outside cache",
+        PROBE_EXIT_CACHE_ROOT_INVALID => "cache root invalid",
+        _ => "unknown setup failure",
+    }
 }
 
 /// Resolve probe env vars into a `(model, config, tokenizer)` path triple.
@@ -148,6 +233,64 @@ pub fn probe_via_subprocess(env_pairs: &[(&str, &str)]) -> Result<ProbeStatus, P
     probe_via_subprocess_with(exe, env_pairs)
 }
 
+/// Allowlist of environment variable keys that the probe child inherits from
+/// the parent. After [`Command::env_clear`], only these keys plus the caller's
+/// `env_pairs` are applied to the spawn command, eliminating env-injection
+/// vectors that bypass `__RURICO_PROBE_*` validation (e.g. `HF_HOME`
+/// re-targeting).
+///
+/// New runtime dependencies that read environment variables must be added here
+/// (with rationale) for the probe to function in their presence.
+pub(super) const FORWARD: &[&str] = &[
+    // exe lookup
+    "PATH",
+    // Cache::from_env default fallback root resolution (`<HOME>/.cache/huggingface/hub`)
+    "HOME",
+    // HF cache root override
+    "HF_HOME",
+    // HF cache root override (alt)
+    "HF_HUB_CACHE",
+    // private repo authentication (optional)
+    "HF_TOKEN",
+    // macOS dynamic linker
+    "DYLD_LIBRARY_PATH",
+    // macOS dynamic linker fallback
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    // Linux dynamic linker
+    "LD_LIBRARY_PATH",
+    // locale
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    // tokenizers / tempfile cache
+    "TMPDIR",
+    "TMP",
+    // diagnostic
+    "RUST_LOG",
+    "RUST_BACKTRACE",
+];
+
+/// Compute the exact env map that [`probe_via_subprocess_with`] applies to
+/// the child after [`Command::env_clear`]. Pure function — does not spawn a
+/// child or mutate parent env. Tests assert against the returned map directly,
+/// avoiding the Rust 2024 unsafe-`set_var` parallel-test problem.
+///
+/// The map combines two sources:
+/// 1. Parent env vars matching keys in [`FORWARD`] (undefined keys are skipped silently)
+/// 2. Caller `env_pairs` (overlays / overrides FORWARD entries)
+pub(super) fn child_env_for_spawn(env_pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    for &key in FORWARD {
+        if let Ok(value) = env::var(key) {
+            env.insert(key.into(), value);
+        }
+    }
+    for &(key, value) in env_pairs {
+        env.insert(key.into(), value.into());
+    }
+    env
+}
+
 /// Like [`probe_via_subprocess`] but the executable to re-exec is provided
 /// explicitly. Used by tests to avoid depending on `env::current_exe()`.
 pub fn probe_via_subprocess_with(
@@ -155,7 +298,9 @@ pub fn probe_via_subprocess_with(
     env_pairs: &[(&str, &str)],
 ) -> Result<ProbeStatus, ProbeError> {
     let mut cmd = Command::new(exe);
-    for &(key, value) in env_pairs {
+    cmd.env_clear();
+    let env = child_env_for_spawn(env_pairs);
+    for (key, value) in &env {
         cmd.env(key, value);
     }
     let mut child = cmd
@@ -322,6 +467,11 @@ pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, Pro
 
     match output.status.code() {
         Some(0) => Ok(ProbeStatus::Available),
+        Some(
+            code @ (PROBE_EXIT_CANONICALIZE_FAILED
+            | PROBE_EXIT_PATH_OUTSIDE_CACHE
+            | PROBE_EXIT_CACHE_ROOT_INVALID),
+        ) => Err(ProbeError::SetupRejected { code }),
         Some(_) => {
             let reason = String::from_utf8_lossy(&output.stderr).trim().to_owned();
             Err(ProbeError::ModelLoadFailed {
@@ -337,240 +487,4 @@ pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, Pro
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resolve_probe_env_returns_none_when_model_absent() {
-        assert!(resolve_probe_env(None, None, None).is_none());
-        assert!(resolve_probe_env(None, Some("c".into()), Some("t".into())).is_none());
-    }
-
-    #[test]
-    fn resolve_probe_env_returns_err_when_incomplete() {
-        assert_eq!(
-            resolve_probe_env(Some("m".into()), None, Some("t".into())),
-            Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
-        );
-        assert_eq!(
-            resolve_probe_env(Some("m".into()), Some("c".into()), None),
-            Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
-        );
-    }
-
-    #[test]
-    fn resolve_probe_env_returns_paths_when_all_present() {
-        let (model, config, tokenizer) =
-            resolve_probe_env(Some("/m".into()), Some("/c".into()), Some("/t".into()))
-                .unwrap()
-                .unwrap();
-        assert_eq!(model, PathBuf::from("/m"));
-        assert_eq!(config, PathBuf::from("/c"));
-        assert_eq!(tokenizer, PathBuf::from("/t"));
-    }
-
-    fn exit_status(code: i32) -> ExitStatus {
-        Command::new("sh")
-            .args(["-c", &format!("exit {code}")])
-            .status()
-            .unwrap()
-    }
-
-    #[test]
-    fn interpret_available_on_exit_0() {
-        let output = Output {
-            status: exit_status(0),
-            stdout: format!("{PROBE_ACK}\n").into_bytes(),
-            stderr: Vec::new(),
-        };
-        assert_eq!(
-            interpret_probe_output(&output).unwrap(),
-            ProbeStatus::Available
-        );
-    }
-
-    #[test]
-    fn interpret_model_load_failed_on_nonzero_exit() {
-        let output = Output {
-            status: exit_status(1),
-            stdout: format!("{PROBE_ACK}\n").into_bytes(),
-            stderr: b"inference error: bad model".to_vec(),
-        };
-        let err = interpret_probe_output(&output).unwrap_err();
-        assert!(
-            matches!(err, ProbeError::ModelLoadFailed { ref reason } if reason.contains("bad model")),
-            "{err}"
-        );
-    }
-
-    #[test]
-    fn interpret_model_load_failed_empty_stderr() {
-        let output = Output {
-            status: exit_status(1),
-            stdout: format!("{PROBE_ACK}\n").into_bytes(),
-            stderr: Vec::new(),
-        };
-        let err = interpret_probe_output(&output).unwrap_err();
-        assert!(
-            matches!(err, ProbeError::ModelLoadFailed { ref reason } if reason == "model load failed"),
-            "{err}"
-        );
-    }
-
-    #[test]
-    fn interpret_handler_not_installed_on_missing_ack() {
-        let output = Output {
-            status: exit_status(0),
-            stdout: b"unexpected output".to_vec(),
-            stderr: Vec::new(),
-        };
-        let err = interpret_probe_output(&output).unwrap_err();
-        assert!(matches!(err, ProbeError::HandlerNotInstalled), "{err}");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn interpret_timeout_output_returns_backend_unavailable() {
-        let output = build_timeout_output();
-        assert_eq!(
-            interpret_probe_output(&output).unwrap(),
-            ProbeStatus::BackendUnavailable,
-        );
-    }
-
-    #[test]
-    fn probe_exit_env_incomplete() {
-        let action = compute_probe_exit(Err(PROBE_EXIT_ENV_INCOMPLETE));
-        assert_eq!(action.code, PROBE_EXIT_ENV_INCOMPLETE);
-        assert!(action.message.is_some());
-    }
-
-    #[test]
-    fn probe_exit_load_success() {
-        let action = compute_probe_exit(Ok(Ok(())));
-        assert_eq!(action.code, 0);
-        assert!(action.message.is_none());
-    }
-
-    #[test]
-    fn probe_exit_load_failure() {
-        let action = compute_probe_exit(Ok(Err("bad model".into())));
-        assert_eq!(action.code, 1);
-        assert_eq!(action.message.as_deref(), Some("bad model"));
-    }
-
-    #[test]
-    fn interpret_backend_unavailable_on_signal() {
-        let status = Command::new("sh")
-            .args(["-c", "kill -ABRT $$"])
-            .status()
-            .unwrap();
-        let output = Output {
-            status,
-            stdout: format!("{PROBE_ACK}\n").into_bytes(),
-            stderr: Vec::new(),
-        };
-        assert_eq!(
-            interpret_probe_output(&output).unwrap(),
-            ProbeStatus::BackendUnavailable
-        );
-    }
-
-    #[test]
-    fn wait_with_timeout_drains_verbose_failure_before_timeout() {
-        let mut child = Command::new("sh")
-            .args([
-                "-c",
-                "printf '%s\\n' \"$0\"; \
-                 i=0; \
-                 while [ \"$i\" -lt 5000 ]; do \
-                   printf 'verbose probe failure line %04d\\n' \"$i\" 1>&2; \
-                   i=$((i + 1)); \
-                 done; \
-                 exit 1",
-                PROBE_ACK,
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-
-        let output = wait_with_timeout(&mut child, Duration::from_secs(2)).unwrap();
-        assert_eq!(output.status.code(), Some(1), "child should exit normally");
-        assert!(
-            output.stderr.len() > 100_000,
-            "stderr should be fully drained, got {} bytes",
-            output.stderr.len()
-        );
-
-        let err = interpret_probe_output(&output).unwrap_err();
-        assert!(
-            matches!(err, ProbeError::ModelLoadFailed { .. }),
-            "expected verbose failure to remain ModelLoadFailed, got {err}"
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn wait_with_timeout_returns_when_grandchild_inherits_pipes() {
-        let mut child = Command::new("sh")
-            .args(["-c", "sleep 10 & printf '%s\\n' \"$0\"; exit 1", PROBE_ACK])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-
-        let start = Instant::now();
-        let output = wait_with_timeout(&mut child, Duration::from_secs(30)).unwrap();
-        let elapsed = start.elapsed();
-
-        assert_eq!(
-            output.status.code(),
-            Some(1),
-            "direct child should exit with 1 before the grandchild finishes"
-        );
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "collect_pipe must not wait for the grandchild's inherited FDs; elapsed {elapsed:?}"
-        );
-    }
-
-    #[test]
-    fn probe_via_subprocess_with_reports_spawn_failure_for_missing_exe() {
-        let exe = PathBuf::from("/nonexistent/rurico-probe-test-binary");
-        let err = probe_via_subprocess_with(exe, &[]).unwrap_err();
-        assert!(
-            matches!(err, ProbeError::SubprocessFailed(_)),
-            "expected SubprocessFailed for missing executable, got {err}"
-        );
-    }
-
-    #[test]
-    fn wait_with_timeout_with_kills_long_running_child_on_short_timeout() {
-        let mut child = Command::new("sh")
-            .args(["-c", "sleep 30"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-
-        let start = Instant::now();
-        let output = wait_with_timeout_with(
-            &mut child,
-            Duration::from_millis(50),
-            Duration::from_millis(1),
-        )
-        .unwrap();
-        let elapsed = start.elapsed();
-
-        assert!(
-            elapsed < Duration::from_secs(2),
-            "1ms poll interval should detect the 50ms deadline promptly; elapsed {elapsed:?}"
-        );
-        assert!(
-            output.status.code().is_none() || output.status.code() == Some(0),
-            "child should be killed (no exit code) or have exited; got {:?}",
-            output.status.code()
-        );
-    }
-}
+mod tests;

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -53,13 +53,13 @@ pub(crate) const PROBE_EXIT_CACHE_ROOT_INVALID: i32 = 6;
 /// - [`PROBE_EXIT_CANONICALIZE_FAILED`] if any candidate path cannot be canonicalized
 /// - [`PROBE_EXIT_PATH_OUTSIDE_CACHE`] if any candidate path's canonical form
 ///   is not a component-wise descendant of `cache_root`'s canonical form
-pub(crate) fn validate_probe_paths_with_root(
+pub(crate) fn validate_probe_paths_with_cache(
+    cache: &hf_hub::Cache,
     model: &Path,
     config: &Path,
     tokenizer: &Path,
-    cache_root: &Path,
 ) -> Result<(), i32> {
-    let canon_root = fs::canonicalize(cache_root).map_err(|_| PROBE_EXIT_CACHE_ROOT_INVALID)?;
+    let canon_root = fs::canonicalize(cache.path()).map_err(|_| PROBE_EXIT_CACHE_ROOT_INVALID)?;
     for p in [model, config, tokenizer] {
         let canon = fs::canonicalize(p).map_err(|_| PROBE_EXIT_CANONICALIZE_FAILED)?;
         if !canon.starts_with(&canon_root) {
@@ -69,8 +69,8 @@ pub(crate) fn validate_probe_paths_with_root(
     Ok(())
 }
 
-/// Production wrapper for [`validate_probe_paths_with_root`] that resolves
-/// the cache root via [`hf_hub::Cache::from_env`].
+/// Production wrapper for [`validate_probe_paths_with_cache`] that resolves
+/// the cache via [`hf_hub::Cache::from_env`].
 ///
 /// `Cache::from_env()` reads `HF_HOME` and falls back to the user's default
 /// `~/.cache/huggingface/hub`. The cache resolution happens at call time so
@@ -79,14 +79,13 @@ pub(crate) fn validate_probe_paths_with_root(
 ///
 /// # Errors
 ///
-/// Same as [`validate_probe_paths_with_root`].
+/// Same as [`validate_probe_paths_with_cache`].
 pub(crate) fn validate_probe_paths(
     model: &Path,
     config: &Path,
     tokenizer: &Path,
 ) -> Result<(), i32> {
-    let cache = hf_hub::Cache::from_env();
-    validate_probe_paths_with_root(model, config, tokenizer, cache.path())
+    validate_probe_paths_with_cache(&hf_hub::Cache::from_env(), model, config, tokenizer)
 }
 
 /// Result of a model probe — whether the backend can load the model.
@@ -182,7 +181,7 @@ pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> Pro
     match result {
         Err(code) => ProbeExitAction {
             code,
-            message: Some("probe env incomplete: config or tokenizer env var missing".into()),
+            message: Some(format!("probe setup rejected: {}", setup_label(code))),
         },
         Ok(Ok(())) => ProbeExitAction {
             code: 0,
@@ -468,7 +467,8 @@ pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, Pro
     match output.status.code() {
         Some(0) => Ok(ProbeStatus::Available),
         Some(
-            code @ (PROBE_EXIT_CANONICALIZE_FAILED
+            code @ (PROBE_EXIT_ENV_INCOMPLETE
+            | PROBE_EXIT_CANONICALIZE_FAILED
             | PROBE_EXIT_PATH_OUTSIDE_CACHE
             | PROBE_EXIT_CACHE_ROOT_INVALID),
         ) => Err(ProbeError::SetupRejected { code }),

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -278,8 +278,8 @@ fn t_001_validate_probe_paths_with_root_returns_ok_when_all_paths_under_cache_ro
     let (model, config, tokenizer) = write_three_artifacts(cache_dir.path());
 
     // Act
-    let result =
-        super::validate_probe_paths_with_root(&model, &config, &tokenizer, cache_dir.path());
+    let cache = hf_hub::Cache::new(cache_dir.path().to_path_buf());
+    let result = super::validate_probe_paths_with_cache(&cache, &model, &config, &tokenizer);
 
     // Assert
     assert_eq!(result, Ok(()), "expected Ok(()) for paths under cache root");
@@ -296,12 +296,9 @@ fn t_002_validate_probe_paths_with_root_rejects_path_outside_cache_root() {
     fs::write(&outside_model, b"evil").unwrap();
 
     // Act
-    let result = super::validate_probe_paths_with_root(
-        &outside_model,
-        &config,
-        &tokenizer,
-        cache_dir.path(),
-    );
+    let cache = hf_hub::Cache::new(cache_dir.path().to_path_buf());
+    let result =
+        super::validate_probe_paths_with_cache(&cache, &outside_model, &config, &tokenizer);
 
     // Assert
     assert_eq!(
@@ -322,12 +319,9 @@ fn t_003_validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_
     // Intentionally do not create the file.
 
     // Act
-    let result = super::validate_probe_paths_with_root(
-        &missing_model,
-        &config,
-        &tokenizer,
-        cache_dir.path(),
-    );
+    let cache = hf_hub::Cache::new(cache_dir.path().to_path_buf());
+    let result =
+        super::validate_probe_paths_with_cache(&cache, &missing_model, &config, &tokenizer);
 
     // Assert
     assert_eq!(
@@ -347,7 +341,8 @@ fn t_004_validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root
     let bogus_root = PathBuf::from("/nonexistent/rurico-test-cache-root");
 
     // Act
-    let result = super::validate_probe_paths_with_root(&model, &config, &tokenizer, &bogus_root);
+    let cache = hf_hub::Cache::new(bogus_root.clone());
+    let result = super::validate_probe_paths_with_cache(&cache, &model, &config, &tokenizer);
 
     // Assert
     assert_eq!(
@@ -390,8 +385,8 @@ fn t_005_validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
     symlink(&blob_tokenizer, &tokenizer).unwrap();
 
     // Act
-    let result =
-        super::validate_probe_paths_with_root(&model, &config, &tokenizer, cache_dir.path());
+    let cache = hf_hub::Cache::new(cache_dir.path().to_path_buf());
+    let result = super::validate_probe_paths_with_cache(&cache, &model, &config, &tokenizer);
 
     // Assert: function accepts the symlink as long as the canonicalized form
     // resolves under cache_root (which it does — blobs/ is under cache_dir).
@@ -418,8 +413,8 @@ fn t_006_validate_probe_paths_with_root_rejects_string_prefix_sibling() {
     fs::write(&evil_model, b"evil").unwrap();
 
     // Act
-    let result =
-        super::validate_probe_paths_with_root(&evil_model, &config, &tokenizer, &cache_root);
+    let cache = hf_hub::Cache::new(cache_root.clone());
+    let result = super::validate_probe_paths_with_cache(&cache, &evil_model, &config, &tokenizer);
 
     // Assert: even though `evil_root` shares a string prefix with `cache_root`,
     // component-wise starts_with rejects it.
@@ -545,6 +540,21 @@ fn t_008_interpret_probe_output_maps_exit_5_to_setup_rejected() {
     );
 }
 
+// T-007a: exit 3 (env incomplete) -> ProbeError::SetupRejected { code: 3 }
+#[test]
+fn t_007a_interpret_probe_output_maps_exit_3_to_setup_rejected() {
+    let output = Output {
+        status: exit_status(3),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: b"probe setup rejected: env incomplete".to_vec(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::SetupRejected { code: 3 }),
+        "expected SetupRejected {{ code: 3 }}, got {err}"
+    );
+}
+
 // T-009: exit 6 -> ProbeError::SetupRejected { code: 6 }
 #[test]
 fn t_009_interpret_probe_output_maps_exit_6_to_setup_rejected() {
@@ -585,6 +595,15 @@ fn t_011c_setup_rejected_display_for_code_6_includes_label() {
     let s = format!("{err}");
     assert!(s.contains('6'), "{s}");
     assert!(s.contains("cache root invalid"), "{s}");
+}
+
+// T-011d: SetupRejected { code: 3 } Display label
+#[test]
+fn t_011d_setup_rejected_display_for_code_3_includes_label() {
+    let err = ProbeError::SetupRejected { code: 3 };
+    let s = format!("{err}");
+    assert!(s.contains('3'), "{s}");
+    assert!(s.contains("env incomplete"), "{s}");
 }
 
 // ── Issue #107 Phase 3 tests (AC-3) ──────────────────────────────────────────
@@ -655,4 +674,48 @@ fn t_022_child_env_for_spawn_skips_undefined_forward_keys() {
             "HF_HOME must NOT be in map when undefined in parent"
         );
     });
+}
+
+// T-013b: e2e — `probe_via_subprocess_with` actually applies env_clear + FORWARD
+// to a real spawned child (TC-001 from /audit). Spawns a sh script that dumps its
+// env to a tempfile, then asserts attacker-injected env is absent and FORWARD
+// keys propagate.
+#[cfg(unix)]
+#[test]
+fn t_013b_probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let env_dump = dir.path().join("env_dump.txt");
+    let script = dir.path().join("probe_env_dump.sh");
+    fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\nenv > {}\nprintf '{PROBE_ACK}\\n'\nexit 0\n",
+            env_dump.display()
+        ),
+    )
+    .unwrap();
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+
+    temp_env::with_vars(
+        [
+            ("HF_HOME", Some("/tmp/test_hf_clear")),
+            ("RURICO_TEST_ATTACKER_ENV", Some("evil")),
+        ],
+        || {
+            // exec succeeds; we ignore the ProbeStatus and inspect env_dump directly.
+            let _ = super::probe_via_subprocess_with(script.clone(), &[]);
+            let dumped = fs::read_to_string(&env_dump).unwrap();
+            assert!(
+                dumped.lines().any(|l| l == "HF_HOME=/tmp/test_hf_clear"),
+                "child must inherit HF_HOME via FORWARD allowlist; dump:\n{dumped}"
+            );
+            assert!(
+                !dumped.contains("RURICO_TEST_ATTACKER_ENV"),
+                "child must NOT inherit non-FORWARD parent env; dump:\n{dumped}"
+            );
+        },
+    );
 }

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -1,0 +1,658 @@
+//! Tests for `crate::model_probe`.
+//!
+//! Existing tests cover `resolve_probe_env`, `interpret_probe_output`,
+//! `compute_probe_exit`, and the wait/spawn machinery. New tests added for
+//! Issue #107 Phase 1 (AC-1, AC-4) cover `validate_probe_paths_with_root`,
+//! the production wrapper `validate_probe_paths`, and the visibility
+//! downgrade of `embed::CandidateArtifacts::from_paths` /
+//! `reranker::CandidateArtifacts::from_paths`.
+
+use super::*;
+use std::process::ExitStatus;
+
+// ── Existing tests preserved verbatim ───────────────────────────────────────
+
+#[test]
+fn resolve_probe_env_returns_none_when_model_absent() {
+    assert!(resolve_probe_env(None, None, None).is_none());
+    assert!(resolve_probe_env(None, Some("c".into()), Some("t".into())).is_none());
+}
+
+#[test]
+fn resolve_probe_env_returns_err_when_incomplete() {
+    assert_eq!(
+        resolve_probe_env(Some("m".into()), None, Some("t".into())),
+        Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
+    );
+    assert_eq!(
+        resolve_probe_env(Some("m".into()), Some("c".into()), None),
+        Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
+    );
+}
+
+#[test]
+fn resolve_probe_env_returns_paths_when_all_present() {
+    let (model, config, tokenizer) =
+        resolve_probe_env(Some("/m".into()), Some("/c".into()), Some("/t".into()))
+            .unwrap()
+            .unwrap();
+    assert_eq!(model, PathBuf::from("/m"));
+    assert_eq!(config, PathBuf::from("/c"));
+    assert_eq!(tokenizer, PathBuf::from("/t"));
+}
+
+fn exit_status(code: i32) -> ExitStatus {
+    Command::new("sh")
+        .args(["-c", &format!("exit {code}")])
+        .status()
+        .unwrap()
+}
+
+#[test]
+fn interpret_available_on_exit_0() {
+    let output = Output {
+        status: exit_status(0),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    assert_eq!(
+        interpret_probe_output(&output).unwrap(),
+        ProbeStatus::Available
+    );
+}
+
+#[test]
+fn interpret_model_load_failed_on_nonzero_exit() {
+    let output = Output {
+        status: exit_status(1),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: b"inference error: bad model".to_vec(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::ModelLoadFailed { ref reason } if reason.contains("bad model")),
+        "{err}"
+    );
+}
+
+#[test]
+fn interpret_model_load_failed_empty_stderr() {
+    let output = Output {
+        status: exit_status(1),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::ModelLoadFailed { ref reason } if reason == "model load failed"),
+        "{err}"
+    );
+}
+
+#[test]
+fn interpret_handler_not_installed_on_missing_ack() {
+    let output = Output {
+        status: exit_status(0),
+        stdout: b"unexpected output".to_vec(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(matches!(err, ProbeError::HandlerNotInstalled), "{err}");
+}
+
+#[cfg(unix)]
+#[test]
+fn interpret_timeout_output_returns_backend_unavailable() {
+    let output = super::build_timeout_output();
+    assert_eq!(
+        interpret_probe_output(&output).unwrap(),
+        ProbeStatus::BackendUnavailable,
+    );
+}
+
+#[test]
+fn probe_exit_env_incomplete() {
+    let action = compute_probe_exit(Err(PROBE_EXIT_ENV_INCOMPLETE));
+    assert_eq!(action.code, PROBE_EXIT_ENV_INCOMPLETE);
+    assert!(action.message.is_some());
+}
+
+#[test]
+fn probe_exit_load_success() {
+    let action = compute_probe_exit(Ok(Ok(())));
+    assert_eq!(action.code, 0);
+    assert!(action.message.is_none());
+}
+
+#[test]
+fn probe_exit_load_failure() {
+    let action = compute_probe_exit(Ok(Err("bad model".into())));
+    assert_eq!(action.code, 1);
+    assert_eq!(action.message.as_deref(), Some("bad model"));
+}
+
+#[test]
+fn interpret_backend_unavailable_on_signal() {
+    let status = Command::new("sh")
+        .args(["-c", "kill -ABRT $$"])
+        .status()
+        .unwrap();
+    let output = Output {
+        status,
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    assert_eq!(
+        interpret_probe_output(&output).unwrap(),
+        ProbeStatus::BackendUnavailable
+    );
+}
+
+#[test]
+fn wait_with_timeout_drains_verbose_failure_before_timeout() {
+    let mut child = Command::new("sh")
+        .args([
+            "-c",
+            "printf '%s\\n' \"$0\"; \
+                 i=0; \
+                 while [ \"$i\" -lt 5000 ]; do \
+                   printf 'verbose probe failure line %04d\\n' \"$i\" 1>&2; \
+                   i=$((i + 1)); \
+                 done; \
+                 exit 1",
+            PROBE_ACK,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let output = super::wait_with_timeout(&mut child, Duration::from_secs(2)).unwrap();
+    assert_eq!(output.status.code(), Some(1), "child should exit normally");
+    assert!(
+        output.stderr.len() > 100_000,
+        "stderr should be fully drained, got {} bytes",
+        output.stderr.len()
+    );
+
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::ModelLoadFailed { .. }),
+        "expected verbose failure to remain ModelLoadFailed, got {err}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn wait_with_timeout_returns_when_grandchild_inherits_pipes() {
+    let mut child = Command::new("sh")
+        .args(["-c", "sleep 10 & printf '%s\\n' \"$0\"; exit 1", PROBE_ACK])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let start = Instant::now();
+    let output = super::wait_with_timeout(&mut child, Duration::from_secs(30)).unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "direct child should exit with 1 before the grandchild finishes"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "collect_pipe must not wait for the grandchild's inherited FDs; elapsed {elapsed:?}"
+    );
+}
+
+#[test]
+fn probe_via_subprocess_with_reports_spawn_failure_for_missing_exe() {
+    let exe = PathBuf::from("/nonexistent/rurico-probe-test-binary");
+    let err = probe_via_subprocess_with(exe, &[]).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::SubprocessFailed(_)),
+        "expected SubprocessFailed for missing executable, got {err}"
+    );
+}
+
+#[test]
+fn wait_with_timeout_with_kills_long_running_child_on_short_timeout() {
+    let mut child = Command::new("sh")
+        .args(["-c", "sleep 30"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let start = Instant::now();
+    let output = super::wait_with_timeout_with(
+        &mut child,
+        Duration::from_millis(50),
+        Duration::from_millis(1),
+    )
+    .unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "1ms poll interval should detect the 50ms deadline promptly; elapsed {elapsed:?}"
+    );
+    assert!(
+        output.status.code().is_none() || output.status.code() == Some(0),
+        "child should be killed (no exit code) or have exited; got {:?}",
+        output.status.code()
+    );
+}
+
+// ── Issue #107 Phase 1 tests (AC-1, AC-4) ────────────────────────────────────
+//
+// Red-phase tests against `validate_probe_paths_with_root`,
+// `validate_probe_paths`, and the constants `PROBE_EXIT_CANONICALIZE_FAILED`
+// (4) / `PROBE_EXIT_PATH_OUTSIDE_CACHE` (5) / `PROBE_EXIT_CACHE_ROOT_INVALID`
+// (6). None of these symbols exist yet, so the Red signal is a compile error.
+// The Green implementation must declare them with `pub(crate)` visibility.
+
+use std::fs;
+
+/// Helper: write the three artifact files into `dir` and return their paths.
+///
+/// Used by T-001/T-002/T-003/T-006 (and the symlink variants in T-005/T-021)
+/// to keep arrangement uniform.
+fn write_three_artifacts(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let model = dir.join("model.safetensors");
+    let config = dir.join("config.json");
+    let tokenizer = dir.join("tokenizer.json");
+    fs::write(&model, b"weights").unwrap();
+    fs::write(&config, b"{}").unwrap();
+    fs::write(&tokenizer, b"{}").unwrap();
+    (model, config, tokenizer)
+}
+
+// T-001: validate_probe_paths_with_root happy path -- 3 cached files inside cache root return Ok(())
+#[test]
+fn t_001_validate_probe_paths_with_root_returns_ok_when_all_paths_under_cache_root() {
+    // Arrange
+    let cache_dir = tempfile::tempdir().unwrap();
+    let (model, config, tokenizer) = write_three_artifacts(cache_dir.path());
+
+    // Act
+    let result =
+        super::validate_probe_paths_with_root(&model, &config, &tokenizer, cache_dir.path());
+
+    // Assert
+    assert_eq!(result, Ok(()), "expected Ok(()) for paths under cache root");
+}
+
+// T-002: validate_probe_paths_with_root rejects path outside cache_root with Err(5)
+#[test]
+fn t_002_validate_probe_paths_with_root_rejects_path_outside_cache_root() {
+    // Arrange
+    let cache_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let (_, config, tokenizer) = write_three_artifacts(cache_dir.path());
+    let outside_model = outside_dir.path().join("outside.bin");
+    fs::write(&outside_model, b"evil").unwrap();
+
+    // Act
+    let result = super::validate_probe_paths_with_root(
+        &outside_model,
+        &config,
+        &tokenizer,
+        cache_dir.path(),
+    );
+
+    // Assert
+    assert_eq!(
+        result,
+        Err(super::PROBE_EXIT_PATH_OUTSIDE_CACHE),
+        "expected Err(5) for path outside cache root"
+    );
+    assert_eq!(super::PROBE_EXIT_PATH_OUTSIDE_CACHE, 5);
+}
+
+// T-003: validate_probe_paths_with_root reports canonicalize failure with Err(4)
+#[test]
+fn t_003_validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_path() {
+    // Arrange
+    let cache_dir = tempfile::tempdir().unwrap();
+    let (_, config, tokenizer) = write_three_artifacts(cache_dir.path());
+    let missing_model = cache_dir.path().join("nonexistent.safetensors");
+    // Intentionally do not create the file.
+
+    // Act
+    let result = super::validate_probe_paths_with_root(
+        &missing_model,
+        &config,
+        &tokenizer,
+        cache_dir.path(),
+    );
+
+    // Assert
+    assert_eq!(
+        result,
+        Err(super::PROBE_EXIT_CANONICALIZE_FAILED),
+        "expected Err(4) for nonexistent candidate path"
+    );
+    assert_eq!(super::PROBE_EXIT_CANONICALIZE_FAILED, 4);
+}
+
+// T-004: validate_probe_paths_with_root reports invalid cache root with Err(6)
+#[test]
+fn t_004_validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root() {
+    // Arrange
+    let cache_dir = tempfile::tempdir().unwrap();
+    let (model, config, tokenizer) = write_three_artifacts(cache_dir.path());
+    let bogus_root = PathBuf::from("/nonexistent/rurico-test-cache-root");
+
+    // Act
+    let result = super::validate_probe_paths_with_root(&model, &config, &tokenizer, &bogus_root);
+
+    // Assert
+    assert_eq!(
+        result,
+        Err(super::PROBE_EXIT_CACHE_ROOT_INVALID),
+        "expected Err(6) when cache_root cannot be canonicalized"
+    );
+    assert_eq!(super::PROBE_EXIT_CACHE_ROOT_INVALID, 6);
+}
+
+// T-005: validate_probe_paths_with_root accepts symlink path inside cache_root
+//
+// The function MUST return Ok(()) and MUST NOT modify the caller's PathBuf
+// (signature is `&Path` in, `Result<(), i32>` out — symlink invariant guarded
+// by FR-005's type-level constraint, exercised here through behavior).
+#[cfg(unix)]
+#[test]
+fn t_005_validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
+    // Arrange: HF cache layout — blobs/<etag> is the real file, snapshots/<commit>/<name>
+    // is a symlink pointing at the blob.
+    let cache_dir = tempfile::tempdir().unwrap();
+    let blobs_dir = cache_dir.path().join("blobs");
+    let snapshot_dir = cache_dir.path().join("snapshots").join("commit-abc");
+    fs::create_dir_all(&blobs_dir).unwrap();
+    fs::create_dir_all(&snapshot_dir).unwrap();
+
+    let blob_model = blobs_dir.join("etag-model");
+    let blob_config = blobs_dir.join("etag-config");
+    let blob_tokenizer = blobs_dir.join("etag-tokenizer");
+    fs::write(&blob_model, b"weights").unwrap();
+    fs::write(&blob_config, b"{}").unwrap();
+    fs::write(&blob_tokenizer, b"{}").unwrap();
+
+    use std::os::unix::fs::symlink;
+    let model = snapshot_dir.join("model.safetensors");
+    let config = snapshot_dir.join("config.json");
+    let tokenizer = snapshot_dir.join("tokenizer.json");
+    symlink(&blob_model, &model).unwrap();
+    symlink(&blob_config, &config).unwrap();
+    symlink(&blob_tokenizer, &tokenizer).unwrap();
+
+    // Act
+    let result =
+        super::validate_probe_paths_with_root(&model, &config, &tokenizer, cache_dir.path());
+
+    // Assert: function accepts the symlink as long as the canonicalized form
+    // resolves under cache_root (which it does — blobs/ is under cache_dir).
+    assert_eq!(result, Ok(()));
+}
+
+// T-006: validate_probe_paths_with_root rejects component-wise prefix collision
+//
+// `cache_x_evil/...` shares a string prefix with `cache_x` but is NOT a
+// component-wise descendant. PathBuf::starts_with handles this correctly via
+// component comparison; the test guards against a regression to byte-prefix
+// comparison.
+#[test]
+fn t_006_validate_probe_paths_with_root_rejects_string_prefix_sibling() {
+    // Arrange: two sibling tempdirs, "cache_x" and "cache_x_evil".
+    let workspace = tempfile::tempdir().unwrap();
+    let cache_root = workspace.path().join("cache_x");
+    let evil_root = workspace.path().join("cache_x_evil");
+    fs::create_dir_all(&cache_root).unwrap();
+    fs::create_dir_all(&evil_root).unwrap();
+
+    let (_, config, tokenizer) = write_three_artifacts(&cache_root);
+    let evil_model = evil_root.join("model.bin");
+    fs::write(&evil_model, b"evil").unwrap();
+
+    // Act
+    let result =
+        super::validate_probe_paths_with_root(&evil_model, &config, &tokenizer, &cache_root);
+
+    // Assert: even though `evil_root` shares a string prefix with `cache_root`,
+    // component-wise starts_with rejects it.
+    assert_eq!(
+        result,
+        Err(super::PROBE_EXIT_PATH_OUTSIDE_CACHE),
+        "component-wise prefix check must reject `cache_x_evil` against `cache_x`"
+    );
+}
+
+// T-016: CandidateArtifacts::from_paths visibility -- pub(crate) downgrade
+//
+// Build verification: source-level inspection at red phase shows `from_paths`
+// is currently `pub`. The Phase 1 Green change downgrades to `pub(crate)`.
+// This test does not discriminate visibility levels at runtime (a `pub`
+// function and a `pub(crate)` function both compile from inside the crate);
+// the discriminator lives in the source check below and in downstream
+// `cargo build --workspace` after rev bump (covered by AC-4-3, out of scope
+// for this in-crate test file).
+//
+// To make T-016 a meaningful Red signal in the source-level sense, this test
+// reads the current declaration and asserts the expected `pub(crate) fn`
+// prefix. After the Green change, this assertion will pass; before the Green
+// change, the assertion fails on the `pub fn` line.
+#[test]
+fn t_016_from_paths_is_declared_pub_crate_in_embed_and_reranker_modules() {
+    // Arrange
+    let embed_src = fs::read_to_string("src/embed.rs").unwrap();
+    let reranker_src = fs::read_to_string("src/reranker.rs").unwrap();
+
+    // Assert
+    assert!(
+        embed_src.contains("pub(crate) fn from_paths("),
+        "embed::CandidateArtifacts::from_paths must be declared `pub(crate) fn from_paths(`"
+    );
+    assert!(
+        reranker_src.contains("pub(crate) fn from_paths("),
+        "reranker::CandidateArtifacts::from_paths must be declared `pub(crate) fn from_paths(`"
+    );
+    // Negative assertion: bare `pub fn from_paths(` must not exist.
+    assert!(
+        !embed_src.contains("\n    pub fn from_paths("),
+        "embed::CandidateArtifacts::from_paths must not be declared `pub fn`"
+    );
+    assert!(
+        !reranker_src.contains("\n    pub fn from_paths("),
+        "reranker::CandidateArtifacts::from_paths must not be declared `pub fn`"
+    );
+}
+
+// T-021: validate_probe_paths (production wrapper) HF_HOME unset fallback (FR-101 + FR-006)
+//
+// The production wrapper resolves cache_root via `hf_hub::Cache::from_env()`.
+// When `HF_HOME` is unset, hf_hub falls back to `dirs::home_dir() /
+// .cache/huggingface/hub`. On Unix, `dirs::home_dir()` reads `$HOME` first
+// (verified against `dirs-sys-0.5.0/src/lib.rs` line 33-71). Setting
+// `HOME=tempdir` redirects the fallback into the test's tempdir.
+//
+// NOTE for Phase 1 Green implementer: `validate_probe_paths` MUST call
+// `Cache::from_env()` at call time. A `LazyLock` / `OnceLock` cache root would
+// poison parallel tests (the first caller fixes the value crate-wide).
+#[cfg(unix)]
+#[test]
+fn t_021_validate_probe_paths_falls_back_to_home_when_hf_home_unset() {
+    // Arrange: tempdir + HF cache layout under <tempdir>/.cache/huggingface/hub.
+    let home_dir = tempfile::tempdir().unwrap();
+    let hub_dir = home_dir.path().join(".cache/huggingface/hub");
+    let snapshot_dir = hub_dir.join("models--cl-nagoya--ruri-v3-310m/snapshots/commit-xyz");
+    fs::create_dir_all(&snapshot_dir).unwrap();
+    let (model, config, tokenizer) = write_three_artifacts(&snapshot_dir);
+
+    // Act + Assert: scope HOME / HF_HOME / HF_HUB_CACHE inside the closure.
+    let home_path = home_dir.path().to_path_buf();
+    temp_env::with_vars(
+        [
+            ("HF_HOME", None::<&str>),
+            ("HF_HUB_CACHE", None::<&str>),
+            ("HOME", Some(home_path.to_str().unwrap())),
+        ],
+        || {
+            let result = super::validate_probe_paths(&model, &config, &tokenizer);
+            assert_eq!(
+                result,
+                Ok(()),
+                "fallback to $HOME/.cache/huggingface/hub must accept paths under it"
+            );
+        },
+    );
+}
+
+// ── Issue #107 Phase 2 tests (AC-2) ──────────────────────────────────────────
+//
+// Tests for typed setup-failure error variant `ProbeError::SetupRejected { code }`
+// and the `interpret_probe_output` dispatch from setup-phase exit codes 4 / 5 / 6.
+
+// T-007: exit 4 -> ProbeError::SetupRejected { code: 4 }
+#[test]
+fn t_007_interpret_probe_output_maps_exit_4_to_setup_rejected() {
+    let output = Output {
+        status: exit_status(4),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: b"path canonicalize failed".to_vec(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::SetupRejected { code: 4 }),
+        "expected SetupRejected {{ code: 4 }}, got {err}"
+    );
+}
+
+// T-008: exit 5 -> ProbeError::SetupRejected { code: 5 }
+#[test]
+fn t_008_interpret_probe_output_maps_exit_5_to_setup_rejected() {
+    let output = Output {
+        status: exit_status(5),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::SetupRejected { code: 5 }),
+        "expected SetupRejected {{ code: 5 }}, got {err}"
+    );
+}
+
+// T-009: exit 6 -> ProbeError::SetupRejected { code: 6 }
+#[test]
+fn t_009_interpret_probe_output_maps_exit_6_to_setup_rejected() {
+    let output = Output {
+        status: exit_status(6),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::SetupRejected { code: 6 }),
+        "expected SetupRejected {{ code: 6 }}, got {err}"
+    );
+}
+
+// T-011a: SetupRejected { code: 4 } Display label
+#[test]
+fn t_011a_setup_rejected_display_for_code_4_includes_label() {
+    let err = ProbeError::SetupRejected { code: 4 };
+    let s = format!("{err}");
+    assert!(s.contains('4'), "{s}");
+    assert!(s.contains("path canonicalize failed"), "{s}");
+}
+
+// T-011b: SetupRejected { code: 5 } Display label
+#[test]
+fn t_011b_setup_rejected_display_for_code_5_includes_label() {
+    let err = ProbeError::SetupRejected { code: 5 };
+    let s = format!("{err}");
+    assert!(s.contains('5'), "{s}");
+    assert!(s.contains("path outside cache"), "{s}");
+}
+
+// T-011c: SetupRejected { code: 6 } Display label
+#[test]
+fn t_011c_setup_rejected_display_for_code_6_includes_label() {
+    let err = ProbeError::SetupRejected { code: 6 };
+    let s = format!("{err}");
+    assert!(s.contains('6'), "{s}");
+    assert!(s.contains("cache root invalid"), "{s}");
+}
+
+// ── Issue #107 Phase 3 tests (AC-3) ──────────────────────────────────────────
+//
+// Tests for the FORWARD env allowlist constant, the `child_env_for_spawn` test
+// seam (FR-016 — pure function returning the spawn env map), and the silent
+// skip behavior for undefined FORWARD keys (FR-102).
+
+// T-012: FORWARD list contains exactly the 15 expected keys
+#[test]
+fn t_012_forward_list_contains_expected_15_keys() {
+    let expected: &[&str] = &[
+        "PATH",
+        "HOME",
+        "HF_HOME",
+        "HF_HUB_CACHE",
+        "HF_TOKEN",
+        "DYLD_LIBRARY_PATH",
+        "DYLD_FALLBACK_LIBRARY_PATH",
+        "LD_LIBRARY_PATH",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TMPDIR",
+        "TMP",
+        "RUST_LOG",
+        "RUST_BACKTRACE",
+    ];
+    assert_eq!(super::FORWARD.len(), 15);
+    for key in expected {
+        assert!(
+            super::FORWARD.contains(key),
+            "FORWARD list missing key {key}"
+        );
+    }
+}
+
+// T-013: child_env_for_spawn forwards HF_HOME, drops attacker-injected env
+#[test]
+fn t_013_child_env_for_spawn_drops_attacker_env_keeps_forward() {
+    temp_env::with_vars(
+        [
+            ("HF_HOME", Some("/tmp/test_hf")),
+            ("RURICO_TEST_ATTACKER_ENV", Some("evil")),
+        ],
+        || {
+            let env = super::child_env_for_spawn(&[]);
+            assert_eq!(
+                env.get("HF_HOME").map(String::as_str),
+                Some("/tmp/test_hf"),
+                "HF_HOME must be forwarded from parent"
+            );
+            assert!(
+                !env.contains_key("RURICO_TEST_ATTACKER_ENV"),
+                "RURICO_TEST_ATTACKER_ENV must NOT be forwarded (env_clear hardening)"
+            );
+        },
+    );
+}
+
+// T-022: child_env_for_spawn skips undefined FORWARD keys silently (FR-102)
+#[test]
+fn t_022_child_env_for_spawn_skips_undefined_forward_keys() {
+    temp_env::with_vars([("HF_HOME", None::<&str>)], || {
+        let env = super::child_env_for_spawn(&[]);
+        assert!(
+            !env.contains_key("HF_HOME"),
+            "HF_HOME must NOT be in map when undefined in parent"
+        );
+    });
+}

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -9,7 +9,9 @@ mod tests;
 use self::mlx::RerankerInner;
 use crate::artifacts::verify_as_reranker;
 use crate::model_io::{ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts};
-use crate::model_probe::{ProbeError, ProbeStatus, probe_paths_via_subprocess, resolve_probe_env};
+use crate::model_probe::{
+    ProbeError, ProbeStatus, probe_paths_via_subprocess, resolve_probe_env, validate_probe_paths,
+};
 use std::fmt::{self, Debug, Display, Formatter};
 #[cfg(any(test, feature = "test-support"))]
 use std::path::Path;
@@ -54,7 +56,7 @@ impl CandidateArtifacts {
     ///
     /// Use this when you have raw paths (e.g. from environment variables).
     /// Call [`verify`](Self::verify) before passing the result to [`Reranker::new`].
-    pub fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
+    pub(crate) fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
         Self {
             paths: ModelPaths {
                 model,
@@ -154,6 +156,7 @@ impl From<ProbeError> for RerankerInitError {
         match e {
             ProbeError::HandlerNotInstalled => RerankerInitError::Backend(e.to_string()),
             ProbeError::ModelLoadFailed { reason } => RerankerInitError::ModelCorrupt { reason },
+            ProbeError::SetupRejected { .. } => RerankerInitError::Backend(e.to_string()),
             ProbeError::SubprocessFailed(msg) => RerankerInitError::Backend(msg),
         }
     }
@@ -385,8 +388,13 @@ pub(crate) fn probe_env_to_paths(
     config: Option<String>,
     tokenizer: Option<String>,
 ) -> Option<Result<CandidateArtifacts, i32>> {
-    resolve_probe_env(model, config, tokenizer)
-        .map(|r| r.map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t)))
+    resolve_probe_env(model, config, tokenizer).map(|r| {
+        r.and_then(|(m, c, t)| {
+            validate_probe_paths(&m, &c, &t)?;
+            Ok((m, c, t))
+        })
+        .map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t))
+    })
 }
 
 fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, RerankerInitError> {

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -1,6 +1,8 @@
 use super::mlx::truncate_pair;
 use super::*;
 use crate::model_io::artifacts_from_cache;
+#[cfg(unix)]
+use crate::test_support::setup_fake_hf_cache_with_symlinks;
 use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
 use std::fs;
 
@@ -119,14 +121,82 @@ fn t_015_candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
     );
 }
 
+// T-019: regression — same invariant as T-018 for the reranker module.
+#[cfg(unix)]
+#[test]
+fn t_019_probe_env_to_paths_preserves_snapshot_symlink_filename() {
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    setup_fake_hf_cache_with_symlinks(
+        &cache_root,
+        "org/reranker",
+        "dev",
+        &[
+            ("model.safetensors", b"weights"),
+            ("config.json", b"{}"),
+            ("tokenizer.json", b"{}"),
+        ],
+    );
+    let snapshot_dir = cache_root.join("models--org--reranker/snapshots/abc123");
+    let m = snapshot_dir.join("model.safetensors");
+    let c = snapshot_dir.join("config.json");
+    let t = snapshot_dir.join("tokenizer.json");
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let candidate = super::probe_env_to_paths(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            candidate.paths.model.file_name().and_then(|s| s.to_str()),
+            Some("model.safetensors"),
+            "regression: probe_env_to_paths must preserve snapshot symlink filename"
+        );
+        assert_eq!(
+            candidate.paths.config.file_name().and_then(|s| s.to_str()),
+            Some("config.json")
+        );
+        assert_eq!(
+            candidate
+                .paths
+                .tokenizer
+                .file_name()
+                .and_then(|s| s.to_str()),
+            Some("tokenizer.json")
+        );
+    });
+}
+
 #[test]
 fn probe_env_to_paths_returns_ok_when_all_present() {
-    let result = super::probe_env_to_paths(Some("/m".into()), Some("/c".into()), Some("/t".into()));
-    // CandidateArtifacts is returned — verify it was constructed (path accessible in submodule)
-    let candidate = result.unwrap().unwrap();
-    assert_eq!(candidate.paths.model, PathBuf::from("/m"));
-    assert_eq!(candidate.paths.config, PathBuf::from("/c"));
-    assert_eq!(candidate.paths.tokenizer, PathBuf::from("/t"));
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    let m = cache_root.join("model.safetensors");
+    let c = cache_root.join("config.json");
+    let t = cache_root.join("tokenizer.json");
+    fs::write(&m, b"").unwrap();
+    fs::write(&c, b"{}").unwrap();
+    fs::write(&t, b"{}").unwrap();
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let result = super::probe_env_to_paths(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        );
+        // CandidateArtifacts is returned with original (non-canonicalized) paths
+        let candidate = result.unwrap().unwrap();
+        assert_eq!(candidate.paths.model, m);
+        assert_eq!(candidate.paths.config, c);
+        assert_eq!(candidate.paths.tokenizer, t);
+    });
 }
 
 #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -47,6 +47,44 @@ pub(crate) fn setup_fake_hf_cache(
     }
 }
 
+/// Like [`setup_fake_hf_cache`] but with snapshot files as symlinks to blob
+/// files, mirroring the production HF Hub cache layout
+/// (`snapshots/<commit>/<file>` -> `../../blobs/<etag>`).
+///
+/// Used by Issue #107 regression tests to exercise the symlink-preserving
+/// invariant: `validate_probe_paths` and `probe_env_to_paths` must NOT
+/// substitute the canonicalized blob path for the snapshot path, because
+/// MLX `load_safetensors` dispatches on the filename extension.
+#[cfg(unix)]
+pub(crate) fn setup_fake_hf_cache_with_symlinks(
+    hub_dir: &Path,
+    repo_id: &str,
+    revision: &str,
+    files: &[(&str, &[u8])],
+) {
+    use std::os::unix::fs::symlink;
+    let repo_slug = repo_id.replace('/', "--");
+    let repo_dir = hub_dir.join(format!("models--{repo_slug}"));
+    let refs_dir = repo_dir.join("refs");
+    fs::create_dir_all(&refs_dir).unwrap();
+    let commit_hash = "abc123";
+    fs::write(refs_dir.join(revision), commit_hash).unwrap();
+
+    let blobs_dir = repo_dir.join("blobs");
+    fs::create_dir_all(&blobs_dir).unwrap();
+    let snapshot_dir = repo_dir.join("snapshots").join(commit_hash);
+    fs::create_dir_all(&snapshot_dir).unwrap();
+    for &(name, content) in files {
+        // Stable etag derived from filename so the blob name is deterministic.
+        let etag = format!("etag-{name}");
+        let blob = blobs_dir.join(&etag);
+        fs::write(&blob, content).unwrap();
+        let snapshot_link = snapshot_dir.join(name);
+        // Relative symlink target: snapshots/<commit>/X -> ../../blobs/<etag>
+        symlink(format!("../../blobs/{etag}"), &snapshot_link).unwrap();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -78,6 +116,33 @@ mod tests {
             b"model-data"
         );
         assert_eq!(fs::read(snapshot_dir.join("config.json")).unwrap(), b"{}");
+    }
+
+    // T-017: setup_fake_hf_cache_with_symlinks builds the production HF cache layout
+    #[cfg(unix)]
+    #[test]
+    fn t_017_setup_fake_hf_cache_with_symlinks_creates_symlink_structure() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_fake_hf_cache_with_symlinks(
+            dir.path(),
+            "org/model",
+            "dev",
+            &[("model.safetensors", b"weights")],
+        );
+
+        let snapshot_link = dir
+            .path()
+            .join("models--org--model/snapshots/abc123/model.safetensors");
+        assert!(
+            snapshot_link.is_symlink(),
+            "snapshot file must be a symlink"
+        );
+        let canon = fs::canonicalize(&snapshot_link).unwrap();
+        assert!(
+            canon.to_string_lossy().contains("blobs/"),
+            "canonicalize must resolve into blobs/: {}",
+            canon.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

`probe child` が env (`__RURICO_PROBE_MODEL` / `_CONFIG` / `_TOKENIZER`) から受け取った path を canonicalize / allowlist なしに `File::open` / `fs::read_to_string` / `Tokenizer::from_file` する状態だった。container / multi-tenant / suid 類似デプロイで attacker が env inject できる構成では任意 file read 攻撃が成立。/audit Wave 1 で SEC-003 として検出済 (P1)。

前回 fix (commit `33c91c1`, branch `fix/issue-107-canonicalize`) は canonicalize 結果をそのまま load 側に渡したため、HF cache の symlink (`snapshots/<commit>/*.safetensors -> blobs/<etag>`) を blob path (拡張子なし) に解決し、MLX `load_safetensors` の拡張子判定が壊れて probe が production で全滅した。**本実装は canonicalize を validation 用のみに使い、load 側には元の symlink path を渡す。**

Closes #107

## 主な変更

### Phase 1 (AC-1, AC-4): cache root allowlist + visibility 降格
- `validate_probe_paths_with_cache(&hf_hub::Cache, model, config, tokenizer)` test seam: 全 path が cache root の component-wise descendant か canonicalize 比較で検証
- `validate_probe_paths(...)` production wrapper: `hf_hub::Cache::from_env()` 経由
- 新規 exit codes: `PROBE_EXIT_CANONICALIZE_FAILED=4` / `PROBE_EXIT_PATH_OUTSIDE_CACHE=5` / `PROBE_EXIT_CACHE_ROOT_INVALID=6`
- `embed::CandidateArtifacts::from_paths` / `reranker::CandidateArtifacts::from_paths` を `pub(crate)` 降格 (subprocess 内部専用、downstream 直接利用なし)

### Phase 2 (AC-2): typed setup error
- `ProbeError::SetupRejected { code: i32 }` variant 追加 + Display labels (code 3/4/5/6)
- `interpret_probe_output` で exit 3/4/5/6 を `SetupRejected` に分岐 (exit 1 は `ModelLoadFailed` 維持)
- `From<ProbeError>` で `EmbedInitError::Backend` / `RerankerInitError::Backend` にマップ

### Phase 3 (AC-3): env_clear + minimum forward allowlist
- `probe_via_subprocess_with` で `Command::env_clear()` を先制適用
- `FORWARD` 定数 (15 keys): `PATH` / `HOME` / `HF_HOME` / `HF_HUB_CACHE` / `HF_TOKEN` / `DYLD_LIBRARY_PATH` / `DYLD_FALLBACK_LIBRARY_PATH` / `LD_LIBRARY_PATH` / `LANG` / `LC_ALL` / `LC_CTYPE` / `TMPDIR` / `TMP` / `RUST_LOG` / `RUST_BACKTRACE`
- `child_env_for_spawn(env_pairs) -> HashMap<String, String>` test seam: spawn せず env map を直接 inspect 可 (Rust 2024 unsafe `set_var` 回避)

### Phase 4 (AC-5): symlink regression test 基盤
- `setup_fake_hf_cache_with_symlinks` helper: production HF cache layout を tempdir 内に再現
- T-018 / T-019 regression test: probe_env_to_paths が snapshot symlink filename を保持

### audit fix (commit `ac8cbd3` で追加)
/audit (5 reviewer + cross-cutting consolidation) の P0/P1 fix:
- **SEC-002 (P1)**: `compute_probe_exit` の hardcoded "env incomplete" stderr → `setup_label(code)` を使った dynamic message に変更 (forensic log で path-outside-cache 攻撃が誤帰属される問題)
- **SEC-001 / DP.006 / CHX-007 (P1)**: exit 3 (env incomplete) を `SetupRejected` の match arm に追加 (3 reviewer 一致指摘)
- **DP.001 (P0)**: DI seam を `validate_probe_paths_with_root(_, _, _, &Path)` から `validate_probe_paths_with_cache(&Cache, _, _, _)` に変更。既存 `artifacts_from_cache(&Cache, _)` convention に揃える + test で `temp_env::with_vars` 強制が解消
- **TC-001 (P0)**: env_clear の e2e test 追加 (T-013b)。tempdir に env-dump shell script を置き、`probe_via_subprocess_with` で実 spawn、attacker env が child に届かないことを assert

## 脅威モデル

| 区分         | 内容                                                                                                |
| ------------ | --------------------------------------------------------------------------------------------------- |
| In-scope     | `__RURICO_PROBE_*` env-injection from a less-trusted caller                                          |
| Out-of-scope | (a) parent process compromise (一般 code execution 攻撃)                                            |
|              | (b) FS-write to HF cache directory (TOCTOU)                                                          |
|              | (c) `HF_HOME` / `HF_HUB_CACHE` の inject (HF ecosystem 全体課題、env_clear で subprocess context は防御済) |

## test 結果

```
cargo test --lib: 289 PASS / 0 FAIL (12 new T-NNN tests, 0 regression)
cargo clippy --all-targets --all-features -- -D warnings: clean
cargo fmt --check: clean
```

## レビュー観点

- **`src/model_probe.rs`**: `validate_probe_paths_with_cache` の component-wise prefix check, `child_env_for_spawn` の FORWARD allowlist 設計, `interpret_probe_output` の typed dispatch
- **`src/model_probe/tests.rs`**: T-018/T-019 regression test (failed branch 33c91c1 cherry-pick で本当に落ちる構造になってるか + T-013b の e2e env_clear)
- **threat model boundary**: out-of-scope 宣言が SOW/Spec と一致してるか

## defer 項目 (別 issue で起票予定)

| ID                       | 内容                                                                       |
| ------------------------ | -------------------------------------------------------------------------- |
| DP.002 / REUSE-002       | `probe_env_to_paths` が embed/reranker で byte-identical (DRY、trait 抽出可) |
| DP.003                   | `From<ProbeError>` 4-arm match 重複                                          |
| DP.004 / DP.005          | `SetupRejected { code: i32 }` を `enum SetupReason` + `#[repr(i32)]` に     |
| CHX-003                  | FORWARD list に `SSL_CERT_FILE` / `SSL_CERT_DIR` 追加 (HF_TOKEN + corp proxy) |
| SEC-003 / SEC-004        | 受容リスク (exit code FS oracle / DYLD linker injection) を doc 明記           |
| TC-008 / P0-2            | T-016 の source-string match を trybuild compile-fail に置換                   |
| CHX-008                  | `setup_fake_hf_cache_with_symlinks` の blob filename を拡張子なしに変更 (regression detection 強化) |

## downstream 追従

API 影響: `CandidateArtifacts::from_paths` の `pub` → `pub(crate)` 降格のみ。downstream 4 リポ (amici / yomu / recall / sae) で grep 確認、直接利用なし。merge 後に rev bump issue を各リポで起票予定。

## SOW / Spec 文書

`.claude/workspace/planning/2026-05-02-issue-107-allowlist/sow.md` / `spec.md` (status: completed)
