### PR TITLE
fix(model_probe): probe サブプロセスの IO 失敗をエラー伝播する

### DIFF
--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -5,6 +5,24 @@
 //! needs to know about both embed and reranker domains. Individual modules
 //! (embed, reranker) call [`probe_via_subprocess`] to re-exec the current
 //! binary as an isolated probe.
+//!
+//! # Probe child exit codes
+//!
+//! | Code | Constant                          | Parent's interpretation              |
+//! | ---- | --------------------------------- | ------------------------------------ |
+//! | 0    | (success)                         | `ProbeStatus::Available`             |
+//! | 1    | (model load failed)               | `ProbeError::ModelLoadFailed`        |
+//! | 3    | `PROBE_EXIT_ENV_INCOMPLETE`       | `ProbeError::SetupRejected`          |
+//! | 4    | `PROBE_EXIT_CANONICALIZE_FAILED`  | `ProbeError::SetupRejected`          |
+//! | 5    | `PROBE_EXIT_PATH_OUTSIDE_CACHE`   | `ProbeError::SetupRejected`          |
+//! | 6    | `PROBE_EXIT_CACHE_ROOT_INVALID`   | `ProbeError::SetupRejected`          |
+//! | 7    | `PROBE_EXIT_ACK_FAILED`           | `ProbeError::SubprocessFailed` (IO)  |
+//! | 8    | `PROBE_EXIT_STDERR_FAILED`        | `ProbeError::SubprocessFailed` (IO)  |
+//!
+//! Code 2 is intentionally unused. Killed by signal (no exit code) maps to
+//! `ProbeStatus::BackendUnavailable`. Missing handshake ACK in stdout maps to
+//! `ProbeError::HandlerNotInstalled` regardless of exit code (except code 7,
+//! which is checked first because the ACK write itself failed).
 
 use std::collections::HashMap;
 use std::env;

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -41,6 +41,19 @@ pub(crate) const PROBE_EXIT_PATH_OUTSIDE_CACHE: i32 = 5;
 /// the cache root itself (HF cache directory missing or unreadable).
 pub(crate) const PROBE_EXIT_CACHE_ROOT_INVALID: i32 = 6;
 
+/// Exit code returned by the probe child when emitting the handshake ACK to
+/// stdout fails (e.g., the parent's pipe reader dropped, or `flush()` fails).
+///
+/// Distinct from `HandlerNotInstalled`: this signals an IO infrastructure
+/// failure inside the probe, not a missing handler installation.
+pub(crate) const PROBE_EXIT_ACK_FAILED: i32 = 7;
+
+/// Exit code returned by the probe child when writing the failure-reason
+/// message to stderr fails. The reason is unobservable to the parent in this
+/// case, but the exit code itself signals "stderr write failed" rather than
+/// "model load failed with empty reason".
+pub(crate) const PROBE_EXIT_STDERR_FAILED: i32 = 8;
+
 /// Verify that `model`, `config`, and `tokenizer` paths all canonicalize to
 /// component-wise descendants of `cache_root`. The candidate paths are
 /// not modified — the load step receives the original symlink path so HF
@@ -196,26 +209,42 @@ pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> Pro
 
 /// Execute a probe dispatch: emit ACK, load model, exit with appropriate code.
 ///
-/// Always terminates the process via [`std::process::exit`].
+/// Always terminates the process via [`std::process::exit`]. IO failures
+/// during ACK emission or stderr write surface as the dedicated exit codes
+/// [`PROBE_EXIT_ACK_FAILED`] / [`PROBE_EXIT_STDERR_FAILED`] so the parent
+/// can distinguish them from `HandlerNotInstalled` (caller forgot the probe
+/// handler) or `ModelLoadFailed` (load itself failed with a reason).
 pub(crate) fn dispatch_probe<P, E: fmt::Display>(
     result: Result<P, i32>,
     load: impl FnOnce(P) -> Result<(), E>,
 ) -> ! {
-    emit_ack();
+    if emit_ack().is_err() {
+        process::exit(PROBE_EXIT_ACK_FAILED);
+    }
     let outcome = match result {
         Err(code) => Err(code),
         Ok(candidate) => Ok(load(candidate).map_err(|e| e.to_string())),
     };
     let action = compute_probe_exit(outcome);
-    if let Some(ref msg) = action.message {
-        let _ = write!(io::stderr(), "{msg}");
+    if let Some(ref msg) = action.message
+        && write!(io::stderr(), "{msg}").is_err()
+    {
+        process::exit(PROBE_EXIT_STDERR_FAILED);
     }
     process::exit(action.code);
 }
 
-fn emit_ack() {
-    let _ = writeln!(io::stdout(), "{PROBE_ACK}");
-    let _ = io::stdout().flush();
+fn emit_ack() -> io::Result<()> {
+    emit_ack_to(&mut io::stdout())
+}
+
+/// Testable seam over [`emit_ack`]. Production calls `emit_ack` which writes
+/// to `io::stdout()`; tests inject a `Vec<u8>` or a failing writer via this
+/// entry point to cover the success and IO-failure paths without spawning a
+/// subprocess.
+fn emit_ack_to<W: Write>(stdout: &mut W) -> io::Result<()> {
+    writeln!(stdout, "{PROBE_ACK}")?;
+    stdout.flush()
 }
 
 /// Re-exec the current binary as a probe subprocess with the given env vars.
@@ -446,11 +475,23 @@ fn build_timeout_output() -> Output {
 
 /// Interpret the output of a probe subprocess.
 ///
+/// - Exit [`PROBE_EXIT_ACK_FAILED`] → [`ProbeError::SubprocessFailed`]
+///   (checked before the ACK presence test because the ACK write itself failed)
+/// - No ACK in stdout → [`ProbeError::HandlerNotInstalled`]
+/// - Exit [`PROBE_EXIT_STDERR_FAILED`] with ACK → [`ProbeError::SubprocessFailed`]
+///   (only emitted after `emit_ack` succeeds, so ACK presence is required to
+///   distinguish from a host binary that lacks the probe handler and happens
+///   to exit with code 8)
 /// - Exit 0 with ACK → [`ProbeStatus::Available`]
 /// - Exit non-zero with ACK → [`ProbeError::ModelLoadFailed`]
 /// - Killed by signal with ACK → [`ProbeStatus::BackendUnavailable`]
-/// - No ACK in stdout → [`ProbeError::HandlerNotInstalled`]
 pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, ProbeError> {
+    if output.status.code() == Some(PROBE_EXIT_ACK_FAILED) {
+        return Err(ProbeError::SubprocessFailed(
+            "probe child failed to emit handshake ACK".into(),
+        ));
+    }
+
     let stdout = String::from_utf8_lossy(&output.stdout);
     if !stdout.starts_with(PROBE_ACK) {
         return Err(ProbeError::HandlerNotInstalled);
@@ -466,6 +507,9 @@ pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, Pro
 
     match output.status.code() {
         Some(0) => Ok(ProbeStatus::Available),
+        Some(PROBE_EXIT_STDERR_FAILED) => Err(ProbeError::SubprocessFailed(
+            "probe child failed to write failure reason to stderr".into(),
+        )),
         Some(
             code @ (PROBE_EXIT_ENV_INCOMPLETE
             | PROBE_EXIT_CANONICALIZE_FAILED

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -8,6 +8,7 @@
 //! `reranker::CandidateArtifacts::from_paths`.
 
 use super::*;
+use std::io;
 use std::process::ExitStatus;
 
 // ── Existing tests preserved verbatim ───────────────────────────────────────
@@ -717,5 +718,113 @@ fn t_013b_probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child(
                 "child must NOT inherit non-FORWARD parent env; dump:\n{dumped}"
             );
         },
+    );
+}
+
+// ── Issue #94 (probe IO error propagation) tests ────────────────────────────
+//
+// `emit_ack_to` is a testable seam exposed for these tests; production calls
+// `emit_ack` which delegates to `emit_ack_to(&mut io::stdout())`. The new
+// IO-infrastructure exit codes `PROBE_EXIT_ACK_FAILED` (7) and
+// `PROBE_EXIT_STDERR_FAILED` (8) signal that the probe child could not
+// emit its handshake (stdout) or its failure reason (stderr) — distinct
+// from `HandlerNotInstalled` (caller forgot the probe handler) and
+// `ModelLoadFailed` (load itself failed).
+
+// T-023: emit_ack_to writes PROBE_ACK + newline on a valid writer
+#[test]
+fn t_023_emit_ack_to_writes_ack_token_with_newline() {
+    let mut buf: Vec<u8> = Vec::new();
+    let result = super::emit_ack_to(&mut buf);
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+    assert_eq!(buf, format!("{PROBE_ACK}\n").into_bytes());
+}
+
+// T-024: emit_ack_to propagates IO errors from a failing writer
+//
+// `FailingWriter::write` fails first and `?` short-circuits before `flush`
+// runs, so this test only exercises the write-failure arm. The flush-only
+// arm (write success + flush error) is not unit-tested; in production the
+// pipe-broken case typically surfaces at write time on `io::stdout()`.
+#[test]
+fn t_024_emit_ack_to_propagates_writer_error() {
+    struct FailingWriter;
+    impl io::Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+    }
+    let err = super::emit_ack_to(&mut FailingWriter)
+        .expect_err("expected emit_ack_to to propagate writer error");
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+}
+
+// T-025: interpret_probe_output maps exit 7 to SubprocessFailed even without ACK
+//
+// IO infrastructure failures (ACK write itself failed) MUST be detected
+// before the ACK presence check — otherwise an empty stdout caused by a
+// failed ACK write would be misclassified as `HandlerNotInstalled`.
+#[test]
+fn t_025_interpret_probe_output_maps_exit_7_to_subprocess_failed_even_without_ack() {
+    let output = Output {
+        status: exit_status(super::PROBE_EXIT_ACK_FAILED),
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    let ProbeError::SubprocessFailed(msg) = &err else {
+        panic!("expected SubprocessFailed, got {err}");
+    };
+    assert!(
+        msg.contains("ACK") || msg.contains("handshake"),
+        "expected ACK/handshake mention, got: {msg}"
+    );
+    assert_eq!(super::PROBE_EXIT_ACK_FAILED, 7);
+}
+
+// T-026: interpret_probe_output maps exit 8 to SubprocessFailed when ACK is present
+//
+// `dispatch_probe` only emits exit 8 after `emit_ack` succeeds, so a real
+// probe failure of this kind always carries the ACK in stdout.
+#[test]
+fn t_026_interpret_probe_output_maps_exit_8_to_subprocess_failed() {
+    let output = Output {
+        status: exit_status(super::PROBE_EXIT_STDERR_FAILED),
+        stdout: format!("{PROBE_ACK}\n").into_bytes(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    let ProbeError::SubprocessFailed(msg) = &err else {
+        panic!("expected SubprocessFailed, got {err}");
+    };
+    assert!(
+        msg.contains("stderr") || msg.contains("reason"),
+        "expected stderr/reason mention, got: {msg}"
+    );
+    assert_eq!(super::PROBE_EXIT_STDERR_FAILED, 8);
+}
+
+// T-027: exit 8 without ACK preserves HandlerNotInstalled diagnostic
+//
+// Regression guard: if a host binary lacks the probe handler and happens to
+// exit with code 8, the missing ACK must classify it as
+// `HandlerNotInstalled`, not `SubprocessFailed`. Exit 8 is meaningful only
+// when emitted by `dispatch_probe` after a successful ACK; an exit 8 from
+// any other code path predates the probe contract.
+#[test]
+fn t_027_interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
+    let output = Output {
+        status: exit_status(super::PROBE_EXIT_STDERR_FAILED),
+        stdout: Vec::new(),
+        stderr: Vec::new(),
+    };
+    let err = interpret_probe_output(&output).unwrap_err();
+    assert!(
+        matches!(err, ProbeError::HandlerNotInstalled),
+        "expected HandlerNotInstalled when exit 8 is emitted without ACK (host \
+         binary lacks probe handler), got {err}"
     );
 }


### PR DESCRIPTION
## 概要

probe サブプロセスの ACK 送信 (stdout) と失敗理由送信 (stderr) を fire-and-forget で書いており、IO エラーを silently discard していた。書き込み失敗時に parent 側は ACK 不在を `HandlerNotInstalled` と誤判定したり、空 stderr を理由に hardcoded 文字列でフォールバックしてしまっていた。本 PR で IO 失敗を専用 exit code として伝播し、parent 側で正しく診断可能にする。

## 変更内容

- `PROBE_EXIT_ACK_FAILED` (7) / `PROBE_EXIT_STDERR_FAILED` (8) 定数を追加
- `emit_ack()` を `io::Result<()>` 返却に変更、IO エラー時 exit 7 で終了
- `emit_ack_to<W: Write>()` testable seam を追加
- `dispatch_probe()` stderr write 失敗時 exit 8 で終了
- `interpret_probe_output()` 判定順: exit 7 → ACK → exit 8 の順番に再設計
- T-023..T-027 の 5 件テスト (success / IO error / regression)

## 設計判断

- exit code を分けた理由: ACK 不在 → HandlerNotInstalled, 空 stderr → hardcoded fallback の両方を IO 失敗から区別するため
- 順序: exit 8 は ACK チェックより後に置く。host bin が probe handler 不在のまま exit 8 で終了したケースで HandlerNotInstalled を維持 (T-027 regression guard)
- testable seam: subprocess なしで IO エラー経路を unit test するため `emit_ack_to<W>` で failing writer injection

## 動作確認

1. `cargo test --workspace` で 294 件全て通過
2. `cargo test t_023 t_024 t_025 t_026 t_027` で新規 5 件通過
3. `cargo clippy --workspace --all-targets --all-features -- -D warnings` で lint エラーなし

## 関連

- Closes #94