### PR TITLE
refactor(embed/reranker): モデルライフサイクル抽象を共有化する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@
 
 ### Breaking Changes
 
+- **`EmbedInitError` and `RerankerInitError` removed; replaced by single
+  `ModelInitError` (`rurico::model_init::ModelInitError`).** Variant set
+  (`Backend(String)` and `ModelCorrupt { reason: String }`) is unchanged;
+  callers that previously matched on the per-kind enum must rename the type
+  only. `embed::Embedder::new` / `embed::Embedder::probe` /
+  `reranker::Reranker::new` / `reranker::Reranker::probe` now return
+  `Result<_, ModelInitError>`.
+- **`download_model` and `cached_artifacts` signatures changed.** Both
+  functions are now generic over `ModelArtifact` and live in
+  `rurico::model_lifecycle`: `pub fn download_model<Id: ModelArtifact>(model: Id)
+  -> Result<VerifiedArtifacts<Id::Kind>, ArtifactError>` and
+  `pub fn cached_artifacts<Id: ModelArtifact>(model: Id)
+  -> Result<Option<VerifiedArtifacts<Id::Kind>>, ArtifactError>`.
+  `embed::download_model` / `embed::cached_artifacts` /
+  `reranker::download_model` / `reranker::cached_artifacts` are kept as
+  re-exports so existing call sites continue to compile.
+- **`ModelArtifact` trait gains an `Kind: ModelKind` associated type.**
+  Implementors must now specify `type Kind = EmbedKind;` (or `RerankerKind`).
+  This binds the model identifier to its kind so wrong-kind combinations
+  (e.g. `download_model::<EmbedKind, _>(RerankerModelId::default())`) are
+  no longer expressible at the call site.
+- **`CandidateArtifacts` is now generic over a kind marker.**
+  `rurico::artifacts::CandidateArtifacts<K>` is the canonical definition;
+  `embed::CandidateArtifacts` and `reranker::CandidateArtifacts` are now
+  type aliases for `CandidateArtifacts<EmbedKind>` /
+  `CandidateArtifacts<RerankerKind>` respectively.
 - **`embed_document` returns `ChunkedEmbedding` instead of `Vec<f32>`.** Long
   documents are split into overlapping chunks. Short documents return
   `chunks.len() == 1` with an identical embedding value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,19 @@
   `pub fn cached_artifacts<Id: ModelArtifact>(model: Id)
   -> Result<Option<VerifiedArtifacts<Id::Kind>>, ArtifactError>`.
   `embed::download_model` / `embed::cached_artifacts` /
-  `reranker::download_model` / `reranker::cached_artifacts` are kept as
-  re-exports so existing call sites continue to compile.
-- **`ModelArtifact` trait gains an `Kind: ModelKind` associated type.**
-  Implementors must now specify `type Kind = EmbedKind;` (or `RerankerKind`).
-  This binds the model identifier to its kind so wrong-kind combinations
-  (e.g. `download_model::<EmbedKind, _>(RerankerModelId::default())`) are
-  no longer expressible at the call site.
+  `reranker::download_model` / `reranker::cached_artifacts` remain as
+  `pub use` re-exports of the canonical functions, so existing call
+  sites continue to compile unchanged.
+- **Internal: `ModelArtifact` trait gains an associated type `Kind: ModelKind`.**
+  `ModelArtifact` is a `pub trait` inside the `pub(crate) mod model_io`,
+  so it has no external implementors and this is not a caller-visible
+  change. The associated type binds each model identifier to its kind
+  marker (`ModelId::Kind = EmbedKind`, `RerankerModelId::Kind =
+  RerankerKind`), which lets `download_model(model)` return
+  `VerifiedArtifacts<Id::Kind>` without an explicit kind type parameter.
+  Wrong-kind combinations (e.g. constructing a candidate for the embed
+  kind from a `RerankerModelId`) are no longer expressible at the call
+  site.
 - **`CandidateArtifacts` is now generic over a kind marker.**
   `rurico::artifacts::CandidateArtifacts<K>` is the canonical definition;
   `embed::CandidateArtifacts` and `reranker::CandidateArtifacts` are now
@@ -36,13 +42,16 @@
 - **`embed_documents_batch` returns `Vec<ChunkedEmbedding>` instead of
   `Vec<Vec<f32>>`.** Each element maps 1:1 to an input document.
 - **Remove `mlx` Cargo feature.** `mlx-rs` is now a regular (non-optional)
-  dependency. Downstream crates referencing `rurico/mlx` in their `Cargo.toml`
-  must remove that feature reference. The crate is now explicitly MLX-backend
-  only.
+  dependency. The crate is explicitly MLX-backend only and compiles
+  unconditionally with MLX. Downstream migration: remove
+  `features = ["mlx"]` from any `rurico` dependency entry, and remove
+  `#[cfg(feature = "rurico/mlx")]` guards from downstream code (those
+  paths are now always active).
 - **Remove `EmbedError::BackendUnavailable` and `EmbedError::ModelNotAvailable`
-  variants.** Neither variant was constructed within the crate.
-  `ProbeStatus::BackendUnavailable` remains available for probe-based backend
-  detection.
+  variants.** Neither variant was ever constructed within the crate.
+  Migration: callers that pattern-match on either variant must remove
+  the corresponding match arm. `ProbeStatus::BackendUnavailable` is the
+  replacement for backend-availability detection.
 - **MSRV bump to 1.95.** `rust-version` in `Cargo.toml` is now `1.95`.
   Downstream crates pinning an older toolchain must upgrade.
 
@@ -54,11 +63,14 @@
   the upstream pooling contract (prefix tokens are always included in the
   attended sequence).
 - **Query truncation.** `embed_query` truncates oversize queries to
-  `MAX_SEQ_LEN` with a `log::warn` instead of failing. BOS/EOS are preserved.
-- **Defense-in-depth in `model.forward()`.** Oversize inputs are truncated with
-  a warning instead of returning an error. Normal API paths do not depend on
-  this fallback.
-- **Prefix-aware chunking (IG-001).** Long documents re-tokenize each chunk
+  `MAX_SEQ_LEN` with a `log::warn` instead of failing. BOS/EOS
+  (beginning- and end-of-sequence tokens) are preserved.
+- **Defense-in-depth in `model.forward()`.** Oversize inputs are truncated
+  with a warning instead of returning an error. Public API paths
+  (`embed_query` / `embed_document`) already truncate before calling
+  `forward()`, so this fallback only fires when callers invoke
+  `forward()` directly with un-truncated inputs.
+- **Prefix-aware chunking.** Long documents re-tokenize each chunk
   with the document prefix to avoid token boundary mismatch from prefix
   merging. Chunk boundaries are adjusted to fit within `MAX_SEQ_LEN` without
   truncation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1105,16 +1105,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1510,15 +1500,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1542,9 +1531,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2476,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -2580,20 +2569,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -139,6 +139,91 @@ impl From<ModelIoError> for ArtifactError {
     }
 }
 
+// ── ModelKind trait ──────────────────────────────────────────────────────────
+
+/// Per-kind verifier dispatch for [`CandidateArtifacts`].
+///
+/// Implemented by the kind markers ([`EmbedKind`] / [`RerankerKind`]) so that
+/// `CandidateArtifacts<K>::verify` can hand the paths to the kind-specific
+/// safetensors header check (`verify_as_embed` / `verify_as_reranker`) without
+/// duplicating per-kind glue at the call site.
+pub trait ModelKind: Sized {
+    /// Verify `paths` against this kind's safetensors signature.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same [`ArtifactError`] variants as the underlying
+    /// kind-specific verifier (`verify_as_embed` / `verify_as_reranker`).
+    fn verify(paths: ModelPaths) -> Result<VerifiedArtifacts<Self>, ArtifactError>;
+}
+
+impl ModelKind for EmbedKind {
+    fn verify(paths: ModelPaths) -> Result<VerifiedArtifacts<Self>, ArtifactError> {
+        verify_as_embed(paths)
+    }
+}
+
+impl ModelKind for RerankerKind {
+    fn verify(paths: ModelPaths) -> Result<VerifiedArtifacts<Self>, ArtifactError> {
+        verify_as_reranker(paths)
+    }
+}
+
+// ── CandidateArtifacts ───────────────────────────────────────────────────────
+
+/// Unverified model artifact paths bound to a kind marker `K`.
+///
+/// Construct with [`from_paths`](Self::from_paths) (or [`from_dir`](Self::from_dir)
+/// in test contexts), then call [`verify`](Self::verify) to obtain a
+/// [`VerifiedArtifacts<K>`] that can be passed to the kind's runtime
+/// constructor (e.g. `Embedder::new` / `Reranker::new`).
+pub struct CandidateArtifacts<K> {
+    pub(crate) paths: ModelPaths,
+    _kind: PhantomData<K>,
+}
+
+impl<K> fmt::Debug for CandidateArtifacts<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CandidateArtifacts")
+            .field("paths", &self.paths)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<K: ModelKind> CandidateArtifacts<K> {
+    /// Construct from explicit file paths without verification.
+    pub(crate) fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
+        Self {
+            paths: ModelPaths {
+                model,
+                config,
+                tokenizer,
+            },
+            _kind: PhantomData,
+        }
+    }
+
+    /// Construct from a directory using standard filenames (`model.safetensors`,
+    /// `config.json`, `tokenizer.json`). Available for development and test use only.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn from_dir(dir: &Path) -> Self {
+        Self {
+            paths: ModelPaths::from_dir(dir),
+            _kind: PhantomData,
+        }
+    }
+
+    /// Verify file existence, config integrity, tokenizer validity, and kind dispatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ArtifactError`] for missing files, invalid config, invalid tokenizer,
+    /// or weights that do not match the bound kind `K`.
+    pub fn verify(self) -> Result<VerifiedArtifacts<K>, ArtifactError> {
+        K::verify(self.paths)
+    }
+}
+
 // ── pub(crate) entry points ──────────────────────────────────────────────────
 
 /// Verify `paths` as an embedding model artifact.
@@ -726,5 +811,104 @@ mod tests {
         fs::remove_file(dir.path().join("model.safetensors")).unwrap();
 
         assert!(artifacts.delete_files().is_err());
+    }
+
+    // ── CandidateArtifacts<K> verify dispatch ───────────────────────────────
+
+    use crate::artifacts::CandidateArtifacts;
+
+    // T-001: CandidateArtifacts<EmbedKind>::verify happy path
+    #[test]
+    fn candidate_verify_embed_kind_succeeds_with_valid_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
+        write_valid_config(dir.path());
+        write_valid_tokenizer(dir.path());
+
+        let candidate: CandidateArtifacts<EmbedKind> = CandidateArtifacts::from_dir(dir.path());
+        let result: Result<VerifiedArtifacts<EmbedKind>, ArtifactError> = candidate.verify();
+        assert!(
+            result.is_ok(),
+            "CandidateArtifacts::<EmbedKind>::verify should succeed for backbone-only safetensors + valid config + valid tokenizer; got: {:?}",
+            result.err()
+        );
+    }
+
+    // T-002: CandidateArtifacts<RerankerKind>::verify happy path
+    #[test]
+    fn candidate_verify_reranker_kind_succeeds_with_valid_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fake_safetensors(
+            &dir.path().join("model.safetensors"),
+            &[
+                FAKE_BACKBONE_KEY,
+                "classifier.weight",
+                "head.dense.weight",
+                "head.norm.weight",
+            ],
+        );
+        write_valid_config(dir.path());
+        write_valid_tokenizer(dir.path());
+
+        let candidate: CandidateArtifacts<RerankerKind> = CandidateArtifacts::from_dir(dir.path());
+        let result: Result<VerifiedArtifacts<RerankerKind>, ArtifactError> = candidate.verify();
+        assert!(
+            result.is_ok(),
+            "CandidateArtifacts::<RerankerKind>::verify should succeed for backbone+classifier+head safetensors + valid config + valid tokenizer; got: {:?}",
+            result.err()
+        );
+    }
+
+    // T-003: CandidateArtifacts<EmbedKind>::verify rejects reranker weights
+    //        → ArtifactError::WrongModelKind { expected: "embed model", .. }
+    #[test]
+    fn candidate_verify_embed_kind_rejects_reranker_weights() {
+        let dir = tempfile::tempdir().unwrap();
+        // Reranker classifier/head keys without backbone — a reranker-shaped
+        // weights file passed to the embed-kind verifier.
+        write_fake_safetensors(
+            &dir.path().join("model.safetensors"),
+            &["classifier.weight", "head.dense.weight", "head.norm.weight"],
+        );
+        write_valid_config(dir.path());
+        write_valid_tokenizer(dir.path());
+
+        let candidate: CandidateArtifacts<EmbedKind> = CandidateArtifacts::from_dir(dir.path());
+        let err = candidate.verify().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ArtifactError::WrongModelKind {
+                    expected: "embed model",
+                    ..
+                }
+            ),
+            "expected WrongModelKind {{ expected: \"embed model\", .. }}, got: {err}"
+        );
+    }
+
+    // T-004: CandidateArtifacts<RerankerKind>::verify rejects backbone-only weights
+    //        → ArtifactError::WrongModelKind { expected: "reranker model", .. }
+    #[test]
+    fn candidate_verify_reranker_kind_rejects_backbone_only_weights() {
+        let dir = tempfile::tempdir().unwrap();
+        // Backbone-only — an embed-shaped weights file passed to the
+        // reranker-kind verifier.
+        write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
+        write_valid_config(dir.path());
+        write_valid_tokenizer(dir.path());
+
+        let candidate: CandidateArtifacts<RerankerKind> = CandidateArtifacts::from_dir(dir.path());
+        let err = candidate.verify().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ArtifactError::WrongModelKind {
+                    expected: "reranker model",
+                    ..
+                }
+            ),
+            "expected WrongModelKind {{ expected: \"reranker model\", .. }}, got: {err}"
+        );
     }
 }

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -427,39 +427,7 @@ fn read_safetensors_keys(path: &Path) -> Result<Vec<String>, ArtifactError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Representative backbone tensor key that satisfies `MODERNBERT_KEY_PREFIXES`.
-    const FAKE_BACKBONE_KEY: &str = "layers.0.attn.Wo.weight";
-
-    /// Write a minimal but structurally valid safetensors file containing the given
-    /// tensor keys. Each tensor has one `f32` element of weight data.
-    fn write_fake_safetensors(path: &Path, tensor_keys: &[&str]) {
-        let mut header_obj = serde_json::Map::new();
-        header_obj.insert("__metadata__".to_owned(), serde_json::json!({}));
-        let mut offset = 0usize;
-        for &key in tensor_keys {
-            let end = offset + 4; // 4 bytes per f32
-            header_obj.insert(
-                key.to_owned(),
-                serde_json::json!({
-                    "dtype": "F32",
-                    "shape": [1],
-                    "data_offsets": [offset, end]
-                }),
-            );
-            offset = end;
-        }
-        let header_json = serde_json::to_vec(&header_obj).unwrap();
-        let header_len = header_json.len() as u64;
-
-        let mut data = Vec::new();
-        data.extend_from_slice(&header_len.to_le_bytes());
-        data.extend_from_slice(&header_json);
-        for _ in tensor_keys {
-            data.extend_from_slice(&0f32.to_le_bytes());
-        }
-        fs::write(path, data).unwrap();
-    }
+    use crate::test_support::{FAKE_BACKBONE_KEY, write_fake_safetensors};
 
     #[test]
     fn read_safetensors_keys_returns_expected_keys() {
@@ -663,20 +631,7 @@ mod tests {
 
     // ── TC-002 / TC-003: verify_as_embed / verify_as_reranker happy-path ────
 
-    /// Minimal BPE tokenizer JSON accepted by tokenizers 0.22+.
-    const MINIMAL_TOKENIZER_JSON: &str = r#"{
-        "version": "1.0",
-        "model": {"type": "BPE", "vocab": {}, "merges": []},
-        "added_tokens": [],
-        "normalizer": null,
-        "pre_tokenizer": null,
-        "post_processor": null,
-        "decoder": null,
-        "truncation": null,
-        "padding": null
-    }"#;
-
-    use crate::test_support::VALID_CONFIG_JSON;
+    use crate::test_support::{MINIMAL_TOKENIZER_JSON, VALID_CONFIG_JSON};
 
     fn write_valid_config(dir: &Path) {
         fs::write(dir.join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -7,6 +7,8 @@
 
 use std::env;
 
+use crate::artifacts::{EmbedKind, RerankerKind};
+use crate::model_lifecycle;
 use crate::{embed, model_probe, reranker};
 
 /// Single entry point for probe subprocess dispatch in host binaries.
@@ -33,7 +35,7 @@ pub fn handle_probe_if_needed_with<F>(get: F)
 where
     F: Fn(&str) -> Option<String>,
 {
-    if let Some(result) = embed::probe_env_to_paths(
+    if let Some(result) = model_lifecycle::probe_env_to_paths::<EmbedKind>(
         get(embed::PROBE_ENV_MODEL),
         get(embed::PROBE_ENV_CONFIG),
         get(embed::PROBE_ENV_TOKENIZER),
@@ -46,7 +48,7 @@ where
         });
     }
 
-    if let Some(result) = reranker::probe_env_to_paths(
+    if let Some(result) = model_lifecycle::probe_env_to_paths::<RerankerKind>(
         get(reranker::PROBE_ENV_MODEL),
         get(reranker::PROBE_ENV_CONFIG),
         get(reranker::PROBE_ENV_TOKENIZER),

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -26,20 +26,15 @@ pub use test_support::{
 };
 
 pub use crate::artifacts::{ArtifactError, EmbedKind, VerifiedArtifacts};
+pub use crate::model_init::ModelInitError;
+pub use crate::model_lifecycle::{cached_artifacts, download_model};
 pub use embedder::Embedder;
 pub use metrics::BatchMetrics;
 pub use pooling::gpu_pool_and_normalize;
-pub(crate) use probe::probe_env_to_paths;
 
-use crate::artifacts::verify_as_embed;
-use crate::model_io::{
-    ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts, truncate_with_eos,
-};
-use crate::model_probe::ProbeError;
+use crate::artifacts;
+use crate::model_io::{ModelArtifact, truncate_with_eos};
 use std::fmt;
-#[cfg(any(test, feature = "test-support"))]
-use std::path::Path;
-use std::path::PathBuf;
 
 /// Probe env-var key for the embedding model weights path.
 pub(crate) const PROBE_ENV_MODEL: &str = "__RURICO_PROBE_MODEL";
@@ -62,52 +57,10 @@ pub type Artifacts = VerifiedArtifacts<EmbedKind>;
 
 /// Unverified embedding model artifact paths.
 ///
-/// Construct with [`from_paths`](Self::from_paths) (or [`from_dir`](Self::from_dir)
-/// in test contexts), then call [`verify`](Self::verify) to obtain
-/// [`Artifacts`] that can be passed to [`Embedder::new`].
-pub struct CandidateArtifacts {
-    paths: ModelPaths,
-}
-
-impl CandidateArtifacts {
-    /// Construct from explicit file paths without any verification.
-    ///
-    /// Use this when you have raw paths (e.g. from environment variables).
-    /// Call [`verify`](Self::verify) before passing the result to [`Embedder::new`].
-    pub(crate) fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
-        Self {
-            paths: ModelPaths {
-                model,
-                config,
-                tokenizer,
-            },
-        }
-    }
-
-    /// Construct from a directory using standard filenames (`model.safetensors`,
-    /// `config.json`, `tokenizer.json`).
-    ///
-    /// Available for development and test use only.
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn from_dir(dir: &Path) -> Self {
-        Self {
-            paths: ModelPaths::from_dir(dir),
-        }
-    }
-
-    /// Verify file existence, config integrity, tokenizer validity, and embed model kind.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ArtifactError`] for any of the following:
-    /// - A required file is missing ([`ArtifactError::MissingFile`])
-    /// - `config.json` cannot be parsed ([`ArtifactError::InvalidConfig`])
-    /// - `tokenizer.json` cannot be loaded ([`ArtifactError::InvalidTokenizer`])
-    /// - Weights are for a reranker, not an embed model ([`ArtifactError::WrongModelKind`])
-    pub fn verify(self) -> Result<Artifacts, ArtifactError> {
-        verify_as_embed(self.paths)
-    }
-}
+/// Type alias for [`crate::artifacts::CandidateArtifacts<EmbedKind>`] so the
+/// downstream-visible name `embed::CandidateArtifacts` keeps working while the
+/// underlying definition lives in `artifacts.rs` (single source of truth).
+pub type CandidateArtifacts = artifacts::CandidateArtifacts<EmbedKind>;
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -251,6 +204,8 @@ impl ModelId {
 }
 
 impl ModelArtifact for ModelId {
+    type Kind = EmbedKind;
+
     fn repo_id(self) -> &'static str {
         ModelId::repo_id(self)
     }
@@ -261,40 +216,6 @@ impl ModelArtifact for ModelId {
 }
 
 // ── EmbedInitError ────────────────────────────────────────────────────────────
-
-/// Errors from initialising the embedding backend ([`Embedder::new`], [`Embedder::probe`]).
-///
-/// These errors occur after artifact verification has already succeeded. They
-/// indicate a failure during MLX backend setup or model weight loading.
-#[derive(Debug, thiserror::Error)]
-pub enum EmbedInitError {
-    /// MLX backend initialisation, weight loading, or subprocess probe failure.
-    #[error("embed init failed: {0}")]
-    Backend(String),
-    /// Model weights loaded but are corrupt or incompatible with the expected architecture.
-    #[error("model load failed: {reason}")]
-    ModelCorrupt {
-        /// Failure detail from the backend.
-        reason: String,
-    },
-}
-
-impl EmbedInitError {
-    pub(crate) fn backend(e: impl fmt::Display) -> Self {
-        Self::Backend(e.to_string())
-    }
-}
-
-impl From<ProbeError> for EmbedInitError {
-    fn from(e: ProbeError) -> Self {
-        match e {
-            ProbeError::HandlerNotInstalled => EmbedInitError::Backend(e.to_string()),
-            ProbeError::ModelLoadFailed { reason } => EmbedInitError::ModelCorrupt { reason },
-            ProbeError::SetupRejected { .. } => EmbedInitError::Backend(e.to_string()),
-            ProbeError::SubprocessFailed(msg) => EmbedInitError::Backend(msg),
-        }
-    }
-}
 
 // ── EmbedError (runtime) ──────────────────────────────────────────────────────
 
@@ -392,37 +313,6 @@ pub trait Embed: Send + Sync {
     /// such as tokenization, inference, or output post-processing.
     /// Callers should not rely on exact error message text.
     fn embed_text(&self, text: &str, prefix: &str) -> Result<Vec<f32>, EmbedError>;
-}
-
-// ── Public API: download / cache ──────────────────────────────────────────────
-
-/// Download model files from Hugging Face Hub and verify them as embed artifacts.
-///
-/// # Errors
-///
-/// Returns [`ArtifactError::DownloadFailed`] if the Hugging Face client cannot be
-/// initialised or any required artifact download fails.
-/// Returns other [`ArtifactError`] variants if verification of the downloaded
-/// files fails.
-pub fn download_model(model: ModelId) -> Result<Artifacts, ArtifactError> {
-    let paths = download_artifacts(model)?;
-    verify_as_embed(paths)
-}
-
-/// Check whether embed model files exist in the local HF Hub cache and verify them.
-///
-/// Returns `Ok(Some(artifacts))` if all three files are cached and pass
-/// verification, `Ok(None)` otherwise. Never accesses the network.
-///
-/// # Errors
-///
-/// Returns [`ArtifactError`] if cached files fail verification.
-/// Cache misses are reported as `Ok(None)`.
-pub fn cached_artifacts(model: ModelId) -> Result<Option<Artifacts>, ArtifactError> {
-    let Some(paths) = artifacts_if_cached(model)? else {
-        return Ok(None);
-    };
-    verify_as_embed(paths).map(Some)
 }
 
 // ── TokenizedInput ────────────────────────────────────────────────────────────

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -34,6 +34,7 @@ impl Embedder {
     pub fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let inner = EmbedderInner::new(artifacts)?;
         let embedding_dims = inner.embedding_dims();
+        tracing::info!(embedding_dims, "embedder: model loaded");
         Ok(Self {
             inner: Mutex::new(inner),
             embedding_dims,
@@ -90,9 +91,13 @@ impl Embedder {
     }
 
     fn lock_inner(&self) -> Result<MutexGuard<'_, EmbedderInner>, EmbedError> {
-        self.inner
-            .lock()
-            .map_err(|_| EmbedError::inference("embedder lock poisoned"))
+        self.inner.lock().map_err(|e| {
+            tracing::error!(
+                error = %e,
+                "embedder: mutex poisoned (prior panic in critical section)"
+            );
+            EmbedError::inference("embedder lock poisoned")
+        })
     }
 }
 

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use super::metrics::BatchMetrics;
 use super::mlx::EmbedderInner;
-use super::{Artifacts, ChunkedEmbedding, Embed, EmbedError, EmbedInitError, QUERY_PREFIX};
+use super::{Artifacts, ChunkedEmbedding, Embed, EmbedError, ModelInitError, QUERY_PREFIX};
 use crate::model_probe::ProbeStatus;
 
 /// Thread-safe embedding model backed by MLX. Wraps the backend in a [`Mutex`].
@@ -30,8 +30,8 @@ impl Embedder {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedInitError::Backend`] if MLX model construction or weight loading fails.
-    pub fn new(artifacts: &Artifacts) -> Result<Self, EmbedInitError> {
+    /// Returns [`ModelInitError::Backend`] if MLX model construction or weight loading fails.
+    pub fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let inner = EmbedderInner::new(artifacts)?;
         let embedding_dims = inner.embedding_dims();
         Ok(Self {
@@ -81,11 +81,11 @@ impl Embedder {
     /// # Errors
     ///
     /// Returns:
-    /// - [`EmbedInitError::Backend`] if the probe subprocess cannot be spawned
+    /// - [`ModelInitError::Backend`] if the probe subprocess cannot be spawned
     ///   or the probe handler is not installed in the host binary
-    /// - [`EmbedInitError::ModelCorrupt`] if the subprocess exits non-zero after
+    /// - [`ModelInitError::ModelCorrupt`] if the subprocess exits non-zero after
     ///   starting successfully
-    pub fn probe(artifacts: &Artifacts) -> Result<ProbeStatus, EmbedInitError> {
+    pub fn probe(artifacts: &Artifacts) -> Result<ProbeStatus, ModelInitError> {
         super::probe::probe_via_subprocess(artifacts)
     }
 

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -5,9 +5,9 @@ use mlx_rs::Array;
 use super::Artifacts;
 use super::metrics::{BatchMetrics, PhaseMetrics};
 use super::{
-    CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, EmbedInitError,
-    MAX_SEQ_LEN, extract_prefix_tokens, gpu_pool_and_normalize, max_content, tokenize_with_prefix,
-    truncate_for_query,
+    CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, MAX_SEQ_LEN,
+    ModelInitError, extract_prefix_tokens, gpu_pool_and_normalize, max_content,
+    tokenize_with_prefix, truncate_for_query,
 };
 use crate::mlx_cache::{clear_inference_cache, release_inference_output};
 use crate::model_io::{BUCKET_BOUNDS, assign_bucket, pad_sequences};
@@ -98,15 +98,15 @@ pub(super) struct EmbedderInner {
 }
 
 impl EmbedderInner {
-    pub(super) fn new(artifacts: &Artifacts) -> Result<Self, EmbedInitError> {
+    pub(super) fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let config = &artifacts.config;
         let tokenizer = artifacts.tokenizer.clone();
 
         let model =
-            ModernBert::load(&artifacts.paths.model, config).map_err(EmbedInitError::backend)?;
+            ModernBert::load(&artifacts.paths.model, config).map_err(ModelInitError::backend)?;
 
         let doc_prefix_tokens =
-            extract_prefix_tokens(&tokenizer, DOCUMENT_PREFIX).map_err(EmbedInitError::backend)?;
+            extract_prefix_tokens(&tokenizer, DOCUMENT_PREFIX).map_err(ModelInitError::backend)?;
         let embedding_dims = config.hidden_size;
 
         Ok(Self {

--- a/src/embed/probe.rs
+++ b/src/embed/probe.rs
@@ -1,30 +1,8 @@
-use super::{
-    Artifacts, CandidateArtifacts, EmbedInitError, PROBE_ENV_CONFIG, PROBE_ENV_MODEL,
-    PROBE_ENV_TOKENIZER,
-};
-use crate::model_probe::{self, ProbeStatus, resolve_probe_env, validate_probe_paths};
-
-/// Resolve probe env vars into a [`CandidateArtifacts`].
-///
-/// Returns `None` if this is not a probe invocation (primary model env var absent).
-/// Returns `Some(Ok(candidate))` if all three vars are set.
-/// Returns `Some(Err(3))` if the model var is set but config or tokenizer is missing.
-pub(crate) fn probe_env_to_paths(
-    model: Option<String>,
-    config: Option<String>,
-    tokenizer: Option<String>,
-) -> Option<Result<CandidateArtifacts, i32>> {
-    resolve_probe_env(model, config, tokenizer).map(|r| {
-        r.and_then(|(m, c, t)| {
-            validate_probe_paths(&m, &c, &t)?;
-            Ok((m, c, t))
-        })
-        .map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t))
-    })
-}
+use super::{Artifacts, ModelInitError, PROBE_ENV_CONFIG, PROBE_ENV_MODEL, PROBE_ENV_TOKENIZER};
+use crate::model_probe::{self, ProbeStatus};
 
 /// Re-exec the current binary as a probe subprocess for the embedding model.
-pub(super) fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, EmbedInitError> {
+pub(super) fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, ModelInitError> {
     let paths = &artifacts.paths;
     model_probe::probe_paths_via_subprocess(
         paths,

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -3,9 +3,13 @@ use super::*;
 use crate::artifacts::EmbedKind;
 use crate::model_io::{EOS_TOKEN_ID, artifacts_from_cache, load_tokenizer};
 use crate::model_lifecycle::probe_env_to_paths;
-use crate::test_support::setup_fake_hf_cache;
 #[cfg(unix)]
 use crate::test_support::setup_fake_hf_cache_with_symlinks;
+use crate::test_support::{
+    assert_cache_lookup_returns_none_when_empty,
+    assert_cache_lookup_returns_some_when_all_files_present,
+    assert_from_probe_error_maps_correctly, setup_fake_hf_cache,
+};
 use std::fs;
 use std::path::Path;
 
@@ -36,22 +40,12 @@ fn setup_fake_cache_for(hub_dir: &Path, model: ModelId) {
 
 #[test]
 fn cache_lookup_returns_none_when_empty() {
-    let dir = tempfile::tempdir().unwrap();
-    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = artifacts_from_cache(&cache, ModelId::default()).unwrap();
-    assert!(result.is_none());
+    assert_cache_lookup_returns_none_when_empty(ModelId::default());
 }
 
 #[test]
 fn cache_lookup_returns_some_when_all_files_present() {
-    let dir = tempfile::tempdir().unwrap();
-    setup_fake_cache_for(dir.path(), ModelId::default());
-    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = artifacts_from_cache(&cache, ModelId::default()).unwrap();
-    let paths = result.expect("should return Some when all files cached");
-    assert!(paths.model.ends_with("model.safetensors"));
-    assert!(paths.config.ends_with("config.json"));
-    assert!(paths.tokenizer.ends_with("tokenizer.json"));
+    assert_cache_lookup_returns_some_when_all_files_present(ModelId::default());
 }
 
 #[test]
@@ -508,26 +502,5 @@ fn embed_text_propagates_error() {
 
 #[test]
 fn from_probe_error_maps_correctly() {
-    use crate::model_probe::ProbeError;
-
-    let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
-    assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
-        "{err}"
-    );
-
-    let err: ModelInitError = ProbeError::ModelLoadFailed {
-        reason: "bad weights".into(),
-    }
-    .into();
-    assert!(
-        matches!(err, ModelInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
-        "{err}"
-    );
-
-    let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
-    assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
-        "{err}"
-    );
+    assert_from_probe_error_maps_correctly();
 }

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -1,11 +1,13 @@
 use super::mlx::shrink_chunk_to_fit;
-use super::probe::probe_env_to_paths;
 use super::*;
+use crate::artifacts::EmbedKind;
 use crate::model_io::{EOS_TOKEN_ID, artifacts_from_cache, load_tokenizer};
+use crate::model_lifecycle::probe_env_to_paths;
 use crate::test_support::setup_fake_hf_cache;
 #[cfg(unix)]
 use crate::test_support::setup_fake_hf_cache_with_symlinks;
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn validate_partial_download_reports_missing_file() {
@@ -144,7 +146,7 @@ fn t_018_probe_env_to_paths_preserves_snapshot_symlink_filename() {
 
     let hf_home_path = hf_home.path().to_path_buf();
     temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = probe_env_to_paths(
+        let candidate = probe_env_to_paths::<EmbedKind>(
             Some(m.to_string_lossy().into_owned()),
             Some(c.to_string_lossy().into_owned()),
             Some(t.to_string_lossy().into_owned()),
@@ -188,7 +190,7 @@ fn probe_env_to_paths_returns_paths_when_all_present() {
 
     let hf_home_path = hf_home.path().to_path_buf();
     temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = probe_env_to_paths(
+        let candidate = probe_env_to_paths::<EmbedKind>(
             Some(m.to_string_lossy().into_owned()),
             Some(c.to_string_lossy().into_owned()),
             Some(t.to_string_lossy().into_owned()),
@@ -508,24 +510,24 @@ fn embed_text_propagates_error() {
 fn from_probe_error_maps_correctly() {
     use crate::model_probe::ProbeError;
 
-    let err: EmbedInitError = ProbeError::HandlerNotInstalled.into();
+    let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
     assert!(
-        matches!(err, EmbedInitError::Backend(ref m) if m.contains("probe handler not installed")),
+        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
         "{err}"
     );
 
-    let err: EmbedInitError = ProbeError::ModelLoadFailed {
+    let err: ModelInitError = ProbeError::ModelLoadFailed {
         reason: "bad weights".into(),
     }
     .into();
     assert!(
-        matches!(err, EmbedInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
+        matches!(err, ModelInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
         "{err}"
     );
 
-    let err: EmbedInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
+    let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
     assert!(
-        matches!(err, EmbedInitError::Backend(ref m) if m == "spawn failed"),
+        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
         "{err}"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,12 @@ pub mod dispatch;
 pub mod embed;
 /// Process-global MLX cache lock shared by embed and reranker.
 pub(crate) mod mlx_cache;
+/// Unified [`ModelInitError`](model_init::ModelInitError) for embed and reranker constructors.
+pub mod model_init;
 /// Shared model I/O utilities (config, tokenizer, constants).
 pub(crate) mod model_io;
+/// Generic model lifecycle entry points: download / cache lookup / probe-env resolution.
+pub mod model_lifecycle;
 /// Shared subprocess probe infrastructure for model loading verification.
 pub mod model_probe;
 /// ModernBERT transformer implementation on MLX.

--- a/src/model_init.rs
+++ b/src/model_init.rs
@@ -1,0 +1,106 @@
+//! Unified model initialization error type.
+//!
+//! Carries the single `ModelInitError` enum used by both embed and reranker
+//! constructors (`Embedder::new`/`Reranker::new`) and probe entry points. The
+//! variant set is identical for both kinds; call sites distinguish kinds via
+//! structured logging fields rather than via the error type.
+
+use std::fmt::Display;
+
+use crate::model_probe::ProbeError;
+
+/// Errors from initialising a model backend (e.g. `Embedder::new` /
+/// `Embedder::probe`, `Reranker::new` / `Reranker::probe`).
+///
+/// These errors occur after artifact verification has already succeeded. They
+/// indicate a failure during MLX backend setup or model weight loading.
+#[derive(Debug, thiserror::Error)]
+pub enum ModelInitError {
+    /// MLX backend initialisation, weight loading, or subprocess probe failure.
+    #[error("model init failed: {0}")]
+    Backend(String),
+    /// Model weights loaded but are corrupt or incompatible with the expected architecture.
+    #[error("model load failed: {reason}")]
+    ModelCorrupt {
+        /// Failure detail from the backend.
+        reason: String,
+    },
+}
+
+impl ModelInitError {
+    #[allow(dead_code)] // wired up by Phase 1 Unit 1.2 (embed) / 1.3 (reranker)
+    pub(crate) fn backend(e: impl Display) -> Self {
+        Self::Backend(e.to_string())
+    }
+}
+
+impl From<ProbeError> for ModelInitError {
+    fn from(e: ProbeError) -> Self {
+        match e {
+            ProbeError::HandlerNotInstalled => ModelInitError::Backend(e.to_string()),
+            ProbeError::ModelLoadFailed { reason } => ModelInitError::ModelCorrupt { reason },
+            ProbeError::SetupRejected { .. } => ModelInitError::Backend(e.to_string()),
+            ProbeError::SubprocessFailed(msg) => ModelInitError::Backend(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests reference items that do not exist yet; compile failure here is the
+    // Red signal. Green phase (`/code` next pass) implements `ModelInitError`
+    // and the `From<ProbeError>` mapping inside this module's parent scope.
+    use crate::model_init::ModelInitError;
+    use crate::model_probe::{PROBE_EXIT_PATH_OUTSIDE_CACHE, ProbeError};
+
+    // T-006: From<ProbeError::HandlerNotInstalled> → Backend(s) where s == Display verbatim
+    #[test]
+    fn from_probe_error_handler_not_installed_maps_to_backend_with_verbatim_display() {
+        let probe_err = ProbeError::HandlerNotInstalled;
+        let display = probe_err.to_string();
+        let init_err: ModelInitError = probe_err.into();
+        let ModelInitError::Backend(s) = init_err else {
+            panic!("expected ModelInitError::Backend, got: {init_err:?}");
+        };
+        assert_eq!(
+            s, display,
+            "Backend payload must equal ProbeError::HandlerNotInstalled Display output verbatim"
+        );
+    }
+
+    // T-007: From<ProbeError::ModelLoadFailed { reason }> → ModelCorrupt { reason } (verbatim)
+    #[test]
+    fn from_probe_error_model_load_failed_maps_to_model_corrupt_verbatim_reason() {
+        let probe_err = ProbeError::ModelLoadFailed { reason: "x".into() };
+        let init_err: ModelInitError = probe_err.into();
+        let ModelInitError::ModelCorrupt { reason } = init_err else {
+            panic!("expected ModelInitError::ModelCorrupt, got: {init_err:?}");
+        };
+        assert_eq!(
+            reason, "x",
+            "ModelCorrupt.reason must preserve the source ProbeError::ModelLoadFailed reason verbatim"
+        );
+    }
+
+    // T-008: From<ProbeError::SetupRejected { .. }> and other backend-failure variants → Backend(_)
+    #[test]
+    fn from_probe_error_setup_rejected_and_subprocess_failed_both_map_to_backend() {
+        let setup_err: ModelInitError = ProbeError::SetupRejected {
+            code: PROBE_EXIT_PATH_OUTSIDE_CACHE,
+        }
+        .into();
+        assert!(
+            matches!(setup_err, ModelInitError::Backend(_)),
+            "ProbeError::SetupRejected must map to ModelInitError::Backend, got: {setup_err:?}"
+        );
+
+        let subprocess_err: ModelInitError = ProbeError::SubprocessFailed("y".into()).into();
+        let ModelInitError::Backend(s) = subprocess_err else {
+            panic!("expected ModelInitError::Backend for SubprocessFailed");
+        };
+        assert_eq!(
+            s, "y",
+            "SubprocessFailed payload must round-trip through Backend"
+        );
+    }
+}

--- a/src/model_init.rs
+++ b/src/model_init.rs
@@ -28,7 +28,6 @@ pub enum ModelInitError {
 }
 
 impl ModelInitError {
-    #[allow(dead_code)] // wired up by Phase 1 Unit 1.2 (embed) / 1.3 (reranker)
     pub(crate) fn backend(e: impl Display) -> Self {
         Self::Backend(e.to_string())
     }

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -9,6 +9,8 @@ use std::path::{Path, PathBuf};
 use hf_hub::api::sync::Api;
 use serde::de::DeserializeOwned;
 
+use crate::artifacts::ModelKind;
+
 /// EOS (end of sequence) token ID for ruri-v3 models.
 pub(crate) const EOS_TOKEN_ID: u32 = 2;
 
@@ -53,7 +55,14 @@ pub(crate) fn truncate_with_eos(ids: &mut Vec<u32>, mask: &mut Vec<u32>, max_len
 }
 
 /// Implemented by model ID enums to provide HuggingFace repository metadata.
+///
+/// The `Kind` associated type binds the identifier to a model kind marker so
+/// that `download_model::<Id>` and `cached_artifacts::<Id>` can return
+/// `VerifiedArtifacts<Id::Kind>` without taking a redundant kind parameter and
+/// without admitting wrong-kind combinations at the call site.
 pub trait ModelArtifact: Copy {
+    /// Kind marker bound to this identifier (e.g. `EmbedKind` for embed model IDs).
+    type Kind: ModelKind;
     /// HuggingFace repository ID (e.g., `"cl-nagoya/ruri-v3-310m"`).
     fn repo_id(self) -> &'static str;
     /// Pinned commit hash for reproducible downloads.
@@ -350,5 +359,30 @@ mod tests {
         );
         assert_eq!(flat_ids, vec![1, 2, 3, 4, 5, 6, 0, 0]);
         assert_eq!(flat_mask, vec![1, 1, 1, 1, 1, 1, 0, 0]);
+    }
+
+    // ── ModelArtifact::Kind associated type ─────────────────────────────────
+
+    // T-009: <ModelId as ModelArtifact>::Kind == EmbedKind
+    //        and <RerankerModelId as ModelArtifact>::Kind == RerankerKind
+    #[test]
+    fn model_artifact_kind_associated_type_is_fixed_per_id() {
+        use crate::artifacts::{EmbedKind, RerankerKind};
+        use crate::embed::ModelId;
+        use crate::reranker::RerankerModelId;
+
+        // Compile-time type-equality assertion: the `where` clause forces the
+        // type checker to confirm `<I as ModelArtifact>::Kind` resolves to `K`.
+        fn assert_kind<I, K>()
+        where
+            I: ModelArtifact<Kind = K>,
+        {
+        }
+
+        assert_kind::<ModelId, EmbedKind>();
+        assert_kind::<RerankerModelId, RerankerKind>();
+
+        // Force at least one runtime assertion so the test body is not empty.
+        assert_eq!(ModelId::default().repo_id(), "cl-nagoya/ruri-v3-310m");
     }
 }

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -5,11 +5,23 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use hf_hub::api::sync::Api;
 use serde::de::DeserializeOwned;
 
 use crate::artifacts::ModelKind;
+
+/// Hard upper bound for a full `download_model` call (init + 3 file downloads).
+///
+/// Guards against an unreachable HF Hub endpoint or stalled corporate proxy
+/// from blocking the calling thread indefinitely. The download thread itself
+/// is detached on timeout and continues until the OS reclaims it on process
+/// exit; the user-visible behaviour is a deterministic `ModelIoError::Download`
+/// after the deadline.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// EOS (end of sequence) token ID for ruri-v3 models.
 pub(crate) const EOS_TOKEN_ID: u32 = 2;
@@ -137,11 +149,11 @@ pub fn load_tokenizer(path: &Path) -> Result<tokenizers::Tokenizer, ModelIoError
     tokenizers::Tokenizer::from_file(path).map_err(|e| ModelIoError::Tokenizer(e.to_string()))
 }
 
-fn model_repo_for<Id: ModelArtifact>(model: Id) -> hf_hub::Repo {
+fn make_repo(repo_id: &str, revision: &str) -> hf_hub::Repo {
     hf_hub::Repo::with_revision(
-        model.repo_id().to_owned(),
+        repo_id.to_owned(),
         hf_hub::RepoType::Model,
-        model.revision().to_owned(),
+        revision.to_owned(),
     )
 }
 
@@ -162,19 +174,42 @@ fn model_repo_for<Id: ModelArtifact>(model: Id) -> hf_hub::Repo {
 /// On the next invocation, [`artifacts_if_cached`] finds no valid pointer and
 /// returns `None`, so the download retries cleanly — no manual cache cleanup needed.
 pub fn download_artifacts<Id: ModelArtifact>(model: Id) -> Result<ModelPaths, ModelIoError> {
-    let api = Api::new().map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
-    let repo = api.repo(model_repo_for(model));
+    // Extract `&'static str` identifiers up-front so the worker closure does
+    // not need to carry the generic `Id` across the thread boundary (which
+    // would force a `Send + 'static` bound on every caller).
+    let repo_id: &'static str = model.repo_id();
+    let revision: &'static str = model.revision();
 
-    let get = |name: &str| {
-        repo.get(name)
-            .map_err(|e| ModelIoError::Download(format!("{name} download failed: {e}")))
-    };
+    let (tx, rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let result = (|| -> Result<ModelPaths, ModelIoError> {
+            let api = Api::new()
+                .map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
+            let repo = api.repo(make_repo(repo_id, revision));
 
-    Ok(ModelPaths {
-        model: get("model.safetensors")?,
-        config: get("config.json")?,
-        tokenizer: get("tokenizer.json")?,
-    })
+            let get = |name: &str| {
+                repo.get(name)
+                    .map_err(|e| ModelIoError::Download(format!("{name} download failed: {e}")))
+            };
+
+            Ok(ModelPaths {
+                model: get("model.safetensors")?,
+                config: get("config.json")?,
+                tokenizer: get("tokenizer.json")?,
+            })
+        })();
+        let _ = tx.send(result);
+    });
+
+    rx.recv_timeout(DOWNLOAD_TIMEOUT).map_err(|e| match e {
+        mpsc::RecvTimeoutError::Timeout => ModelIoError::Download(format!(
+            "download exceeded {} second timeout (HF Hub may be unreachable or proxy stalled)",
+            DOWNLOAD_TIMEOUT.as_secs()
+        )),
+        mpsc::RecvTimeoutError::Disconnected => {
+            ModelIoError::Download("download worker terminated unexpectedly".to_owned())
+        }
+    })?
 }
 
 /// Check whether model files exist in the local HF Hub cache.
@@ -191,7 +226,7 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
     cache: &hf_hub::Cache,
     model: Id,
 ) -> Result<Option<ModelPaths>, ModelIoError> {
-    let repo = cache.repo(model_repo_for(model));
+    let repo = cache.repo(make_repo(model.repo_id(), model.revision()));
     let Some(model_weights) = repo.get("model.safetensors") else {
         return Ok(None);
     };

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -25,8 +25,17 @@ use crate::model_probe::{resolve_probe_env, validate_probe_paths};
 pub fn download_model<Id: ModelArtifact>(
     model: Id,
 ) -> Result<VerifiedArtifacts<Id::Kind>, ArtifactError> {
+    let repo_id = model.repo_id();
+    let revision = model.revision();
+    tracing::info!(
+        repo_id,
+        revision,
+        "model_lifecycle: downloading artifacts from HF Hub"
+    );
     let paths = download_artifacts(model)?;
-    Id::Kind::verify(paths)
+    let verified = Id::Kind::verify(paths)?;
+    tracing::debug!(repo_id, "model_lifecycle: artifacts verified");
+    Ok(verified)
 }
 
 /// Check whether model files exist in the local HF Hub cache and verify them.
@@ -41,10 +50,14 @@ pub fn download_model<Id: ModelArtifact>(
 pub fn cached_artifacts<Id: ModelArtifact>(
     model: Id,
 ) -> Result<Option<VerifiedArtifacts<Id::Kind>>, ArtifactError> {
+    let repo_id = model.repo_id();
     let Some(paths) = artifacts_if_cached(model)? else {
+        tracing::debug!(repo_id, "model_lifecycle: cache miss");
         return Ok(None);
     };
-    Id::Kind::verify(paths).map(Some)
+    let verified = Id::Kind::verify(paths)?;
+    tracing::info!(repo_id, "model_lifecycle: loaded from cache");
+    Ok(Some(verified))
 }
 
 /// Resolve probe env vars into a [`CandidateArtifacts<K>`].
@@ -54,7 +67,6 @@ pub fn cached_artifacts<Id: ModelArtifact>(
 /// Returns `Some(Err(_))` if the model var is set but config or tokenizer is
 /// missing or the paths fail validation (exit code from
 /// [`validate_probe_paths`]).
-#[allow(dead_code)] // wired up by Phase 1 Unit 1.2 (embed) / 1.3 (reranker)
 pub(crate) fn probe_env_to_paths<K: ModelKind>(
     model: Option<String>,
     config: Option<String>,
@@ -81,74 +93,14 @@ mod tests {
     use crate::model_io::ModelArtifact;
     use crate::model_lifecycle::{cached_artifacts, download_model, probe_env_to_paths};
     use crate::reranker::RerankerModelId;
-    use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
-
-    /// Minimal BPE tokenizer JSON accepted by tokenizers 0.22+.
-    /// Mirrors `artifacts::tests::MINIMAL_TOKENIZER_JSON` (kept local to
-    /// preserve the existing `artifacts.rs` tests untouched per Unit 1.1
-    /// scope).
-    const MINIMAL_TOKENIZER_JSON: &str = r#"{
-        "version": "1.0",
-        "model": {"type": "BPE", "vocab": {}, "merges": []},
-        "added_tokens": [],
-        "normalizer": null,
-        "pre_tokenizer": null,
-        "post_processor": null,
-        "decoder": null,
-        "truncation": null,
-        "padding": null
-    }"#;
-
-    /// Representative backbone tensor key satisfying the `MODERNBERT_KEY_PREFIXES`
-    /// any-of check in `artifacts.rs`.
-    const FAKE_BACKBONE_KEY: &str = "layers.0.attn.Wo.weight";
+    use crate::test_support::{
+        FAKE_BACKBONE_KEY, MINIMAL_TOKENIZER_JSON, VALID_CONFIG_JSON, setup_fake_hf_cache,
+        write_fake_safetensors,
+    };
 
     /// Build an embed-kind safetensors file (backbone-only keys).
     fn write_embed_safetensors(path: &Path) {
         write_fake_safetensors(path, &[FAKE_BACKBONE_KEY]);
-    }
-
-    /// Build a reranker-kind safetensors file (backbone + classifier + head keys).
-    fn write_reranker_safetensors(path: &Path) {
-        write_fake_safetensors(
-            path,
-            &[
-                FAKE_BACKBONE_KEY,
-                "classifier.weight",
-                "head.dense.weight",
-                "head.norm.weight",
-            ],
-        );
-    }
-
-    /// Write a minimal but structurally valid safetensors file containing the
-    /// given tensor keys. Each tensor has one `f32` element of weight data.
-    fn write_fake_safetensors(path: &Path, tensor_keys: &[&str]) {
-        let mut header_obj = serde_json::Map::new();
-        header_obj.insert("__metadata__".to_owned(), serde_json::json!({}));
-        let mut offset = 0usize;
-        for &key in tensor_keys {
-            let end = offset + 4;
-            header_obj.insert(
-                key.to_owned(),
-                serde_json::json!({
-                    "dtype": "F32",
-                    "shape": [1],
-                    "data_offsets": [offset, end]
-                }),
-            );
-            offset = end;
-        }
-        let header_json = serde_json::to_vec(&header_obj).unwrap();
-        let header_len = header_json.len() as u64;
-
-        let mut data = Vec::new();
-        data.extend_from_slice(&header_len.to_le_bytes());
-        data.extend_from_slice(&header_json);
-        for _ in tensor_keys {
-            data.extend_from_slice(&0f32.to_le_bytes());
-        }
-        fs::write(path, data).unwrap();
     }
 
     /// Compile-time signature assertion helper. The function body is unused;
@@ -303,8 +255,6 @@ mod tests {
                 inner.is_ok(),
                 "expected Ok(CandidateArtifacts<RerankerKind>) for three valid paths"
             );
-            // Sanity-check helpers exist; otherwise unused-import noise.
-            let _ = write_reranker_safetensors;
         });
     }
 }

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -1,0 +1,310 @@
+//! Generic model lifecycle: download / cache lookup / probe-env resolution.
+//!
+//! Provides the three kind-generic entry points that replace the per-module
+//! duplicates that previously lived in `embed.rs` / `reranker.rs`:
+//!
+//! - [`download_model`] -- fetch HF Hub artifacts and verify them as `Id::Kind`.
+//! - [`cached_artifacts`] -- inspect the local HF cache for `Id::Kind` artifacts.
+//! - [`probe_env_to_paths`] -- resolve probe env vars into a kind-bound candidate.
+//!
+//! The single `Id::Kind` associated type binds the model identifier to its
+//! kind marker so wrong-kind combinations (e.g. an embed identifier returning
+//! reranker artifacts) cannot be expressed at the call site.
+
+use crate::artifacts::{ArtifactError, CandidateArtifacts, ModelKind, VerifiedArtifacts};
+use crate::model_io::{ModelArtifact, artifacts_if_cached, download_artifacts};
+use crate::model_probe::{resolve_probe_env, validate_probe_paths};
+
+/// Download model files from Hugging Face Hub and verify them as `Id::Kind` artifacts.
+///
+/// # Errors
+///
+/// Returns [`ArtifactError::DownloadFailed`] if the Hugging Face client cannot be
+/// initialised or any required artifact download fails. Returns other
+/// [`ArtifactError`] variants if verification of the downloaded files fails.
+pub fn download_model<Id: ModelArtifact>(
+    model: Id,
+) -> Result<VerifiedArtifacts<Id::Kind>, ArtifactError> {
+    let paths = download_artifacts(model)?;
+    Id::Kind::verify(paths)
+}
+
+/// Check whether model files exist in the local HF Hub cache and verify them.
+///
+/// Returns `Ok(Some(_))` if all three files are cached and pass verification,
+/// `Ok(None)` if any file is missing from the cache. Never accesses the network.
+///
+/// # Errors
+///
+/// Returns [`ArtifactError`] if cached files exist but fail verification.
+/// Cache misses are reported as `Ok(None)`.
+pub fn cached_artifacts<Id: ModelArtifact>(
+    model: Id,
+) -> Result<Option<VerifiedArtifacts<Id::Kind>>, ArtifactError> {
+    let Some(paths) = artifacts_if_cached(model)? else {
+        return Ok(None);
+    };
+    Id::Kind::verify(paths).map(Some)
+}
+
+/// Resolve probe env vars into a [`CandidateArtifacts<K>`].
+///
+/// Returns `None` if this is not a probe invocation (primary model env var absent).
+/// Returns `Some(Ok(_))` if all three vars are set and pass path validation.
+/// Returns `Some(Err(_))` if the model var is set but config or tokenizer is
+/// missing or the paths fail validation (exit code from
+/// [`validate_probe_paths`]).
+#[allow(dead_code)] // wired up by Phase 1 Unit 1.2 (embed) / 1.3 (reranker)
+pub(crate) fn probe_env_to_paths<K: ModelKind>(
+    model: Option<String>,
+    config: Option<String>,
+    tokenizer: Option<String>,
+) -> Option<Result<CandidateArtifacts<K>, i32>> {
+    resolve_probe_env(model, config, tokenizer).map(|r| {
+        r.and_then(|(m, c, t)| {
+            validate_probe_paths(&m, &c, &t)?;
+            Ok((m, c, t))
+        })
+        .map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use crate::artifacts::{
+        ArtifactError, CandidateArtifacts, EmbedKind, RerankerKind, VerifiedArtifacts,
+    };
+    use crate::embed::ModelId;
+    use crate::model_io::ModelArtifact;
+    use crate::model_lifecycle::{cached_artifacts, download_model, probe_env_to_paths};
+    use crate::reranker::RerankerModelId;
+    use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
+
+    /// Minimal BPE tokenizer JSON accepted by tokenizers 0.22+.
+    /// Mirrors `artifacts::tests::MINIMAL_TOKENIZER_JSON` (kept local to
+    /// preserve the existing `artifacts.rs` tests untouched per Unit 1.1
+    /// scope).
+    const MINIMAL_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "model": {"type": "BPE", "vocab": {}, "merges": []},
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": null,
+        "post_processor": null,
+        "decoder": null,
+        "truncation": null,
+        "padding": null
+    }"#;
+
+    /// Representative backbone tensor key satisfying the `MODERNBERT_KEY_PREFIXES`
+    /// any-of check in `artifacts.rs`.
+    const FAKE_BACKBONE_KEY: &str = "layers.0.attn.Wo.weight";
+
+    /// Build an embed-kind safetensors file (backbone-only keys).
+    fn write_embed_safetensors(path: &Path) {
+        write_fake_safetensors(path, &[FAKE_BACKBONE_KEY]);
+    }
+
+    /// Build a reranker-kind safetensors file (backbone + classifier + head keys).
+    fn write_reranker_safetensors(path: &Path) {
+        write_fake_safetensors(
+            path,
+            &[
+                FAKE_BACKBONE_KEY,
+                "classifier.weight",
+                "head.dense.weight",
+                "head.norm.weight",
+            ],
+        );
+    }
+
+    /// Write a minimal but structurally valid safetensors file containing the
+    /// given tensor keys. Each tensor has one `f32` element of weight data.
+    fn write_fake_safetensors(path: &Path, tensor_keys: &[&str]) {
+        let mut header_obj = serde_json::Map::new();
+        header_obj.insert("__metadata__".to_owned(), serde_json::json!({}));
+        let mut offset = 0usize;
+        for &key in tensor_keys {
+            let end = offset + 4;
+            header_obj.insert(
+                key.to_owned(),
+                serde_json::json!({
+                    "dtype": "F32",
+                    "shape": [1],
+                    "data_offsets": [offset, end]
+                }),
+            );
+            offset = end;
+        }
+        let header_json = serde_json::to_vec(&header_obj).unwrap();
+        let header_len = header_json.len() as u64;
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&header_len.to_le_bytes());
+        data.extend_from_slice(&header_json);
+        for _ in tensor_keys {
+            data.extend_from_slice(&0f32.to_le_bytes());
+        }
+        fs::write(path, data).unwrap();
+    }
+
+    /// Compile-time signature assertion helper. The function body is unused;
+    /// the `where` clause forces the type checker to confirm `F` returns `T`.
+    fn assert_returns<F, T>(_f: F)
+    where
+        F: FnOnce() -> T,
+    {
+    }
+
+    // T-010: download_model(ModelId::default()) returns Result<VerifiedArtifacts<EmbedKind>, ArtifactError>
+    #[test]
+    fn download_model_for_embed_id_returns_verified_artifacts_of_embed_kind() {
+        // Compile-time signature check only; do not invoke (would hit network).
+        assert_returns::<_, Result<VerifiedArtifacts<EmbedKind>, ArtifactError>>(|| {
+            download_model(ModelId::default())
+        });
+    }
+
+    // T-011: download_model(RerankerModelId::default()) returns Result<VerifiedArtifacts<RerankerKind>, ArtifactError>
+    #[test]
+    fn download_model_for_reranker_id_returns_verified_artifacts_of_reranker_kind() {
+        assert_returns::<_, Result<VerifiedArtifacts<RerankerKind>, ArtifactError>>(|| {
+            download_model(RerankerModelId::default())
+        });
+    }
+
+    // T-012: cached_artifacts(ModelId::default()) with all artifacts present → Ok(Some(VerifiedArtifacts<EmbedKind>))
+    #[test]
+    fn cached_artifacts_for_embed_id_returns_some_when_cache_populated() {
+        let hf_home = tempfile::tempdir().unwrap();
+        let cache_root = hf_home.path().join("hub");
+        fs::create_dir_all(&cache_root).unwrap();
+
+        // Stage real backbone-keyed safetensors + valid config + valid tokenizer
+        // outside the cache, then point the fake HF cache at them via direct
+        // file content so verify() can succeed.
+        let model_id = ModelId::default();
+        let scratch = tempfile::tempdir().unwrap();
+        let model_path = scratch.path().join("model.safetensors");
+        write_embed_safetensors(&model_path);
+        let model_bytes = fs::read(&model_path).unwrap();
+
+        setup_fake_hf_cache(
+            &cache_root,
+            model_id.repo_id(),
+            model_id.revision(),
+            &[
+                ("model.safetensors", model_bytes.as_slice()),
+                ("config.json", VALID_CONFIG_JSON.as_bytes()),
+                ("tokenizer.json", MINIMAL_TOKENIZER_JSON.as_bytes()),
+            ],
+        );
+
+        let hf_home_path = hf_home.path().to_path_buf();
+        temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+            let result: Result<Option<VerifiedArtifacts<EmbedKind>>, ArtifactError> =
+                cached_artifacts(model_id);
+            let opt = result.expect("cached_artifacts should succeed when cache is populated");
+            assert!(
+                opt.is_some(),
+                "expected Some(VerifiedArtifacts<EmbedKind>) when all three files are cached"
+            );
+        });
+    }
+
+    // T-013: cached_artifacts(RerankerModelId::default()) missing tokenizer → Ok(None)
+    #[test]
+    fn cached_artifacts_for_reranker_id_returns_none_when_tokenizer_missing() {
+        let hf_home = tempfile::tempdir().unwrap();
+        let cache_root = hf_home.path().join("hub");
+        fs::create_dir_all(&cache_root).unwrap();
+
+        let model_id = RerankerModelId::default();
+        // Omit tokenizer.json so cache lookup short-circuits to None before verify.
+        setup_fake_hf_cache(
+            &cache_root,
+            model_id.repo_id(),
+            model_id.revision(),
+            &[
+                ("model.safetensors", b"placeholder"),
+                ("config.json", b"{}"),
+            ],
+        );
+
+        let hf_home_path = hf_home.path().to_path_buf();
+        temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+            let result: Result<Option<VerifiedArtifacts<RerankerKind>>, ArtifactError> =
+                cached_artifacts(model_id);
+            let opt = result.expect("cached_artifacts should not error on cache miss");
+            assert!(
+                opt.is_none(),
+                "expected Ok(None) when tokenizer.json is absent from cache"
+            );
+        });
+    }
+
+    // T-014: probe_env_to_paths::<EmbedKind>(...) with three valid paths → Some(Ok(CandidateArtifacts<EmbedKind>))
+    #[test]
+    fn probe_env_to_paths_for_embed_kind_returns_candidate_when_all_paths_valid() {
+        let hf_home = tempfile::tempdir().unwrap();
+        let cache_root = hf_home.path().join("hub");
+        fs::create_dir_all(&cache_root).unwrap();
+        let m = cache_root.join("model.safetensors");
+        let c = cache_root.join("config.json");
+        let t = cache_root.join("tokenizer.json");
+        fs::write(&m, b"").unwrap();
+        fs::write(&c, b"{}").unwrap();
+        fs::write(&t, b"{}").unwrap();
+
+        let hf_home_path = hf_home.path().to_path_buf();
+        temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+            let result: Option<Result<CandidateArtifacts<EmbedKind>, i32>> =
+                probe_env_to_paths::<EmbedKind>(
+                    Some(m.to_string_lossy().into_owned()),
+                    Some(c.to_string_lossy().into_owned()),
+                    Some(t.to_string_lossy().into_owned()),
+                );
+            let inner =
+                result.expect("probe_env_to_paths should return Some when model var is set");
+            assert!(
+                inner.is_ok(),
+                "expected Ok(CandidateArtifacts<EmbedKind>) for three valid paths"
+            );
+        });
+    }
+
+    // T-015: probe_env_to_paths::<RerankerKind>(...) with three valid paths → Some(Ok(CandidateArtifacts<RerankerKind>))
+    #[test]
+    fn probe_env_to_paths_for_reranker_kind_returns_candidate_when_all_paths_valid() {
+        let hf_home = tempfile::tempdir().unwrap();
+        let cache_root = hf_home.path().join("hub");
+        fs::create_dir_all(&cache_root).unwrap();
+        let m = cache_root.join("model.safetensors");
+        let c = cache_root.join("config.json");
+        let t = cache_root.join("tokenizer.json");
+        fs::write(&m, b"").unwrap();
+        fs::write(&c, b"{}").unwrap();
+        fs::write(&t, b"{}").unwrap();
+
+        let hf_home_path = hf_home.path().to_path_buf();
+        temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+            let result: Option<Result<CandidateArtifacts<RerankerKind>, i32>> =
+                probe_env_to_paths::<RerankerKind>(
+                    Some(m.to_string_lossy().into_owned()),
+                    Some(c.to_string_lossy().into_owned()),
+                    Some(t.to_string_lossy().into_owned()),
+                );
+            let inner =
+                result.expect("probe_env_to_paths should return Some when model var is set");
+            assert!(
+                inner.is_ok(),
+                "expected Ok(CandidateArtifacts<RerankerKind>) for three valid paths"
+            );
+            // Sanity-check helpers exist; otherwise unused-import noise.
+            let _ = write_reranker_safetensors;
+        });
+    }
+}

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -441,28 +441,24 @@ fn t_006_validate_probe_paths_with_root_rejects_string_prefix_sibling() {
 // prefix. After the Green change, this assertion will pass; before the Green
 // change, the assertion fails on the `pub fn` line.
 #[test]
-fn t_016_from_paths_is_declared_pub_crate_in_embed_and_reranker_modules() {
-    // Arrange
-    let embed_src = fs::read_to_string("src/embed.rs").unwrap();
-    let reranker_src = fs::read_to_string("src/reranker.rs").unwrap();
+fn t_016_from_paths_is_declared_pub_crate_in_artifacts_module() {
+    // After Phase 1 Unit 1.1, the single `CandidateArtifacts<K>::from_paths`
+    // definition lives in `src/artifacts.rs` and is consumed by
+    // `model_lifecycle::probe_env_to_paths<K>`. The downstream-visible aliases
+    // `embed::CandidateArtifacts` / `reranker::CandidateArtifacts` are typedefs
+    // and carry no `from_paths` declaration of their own. This text-based audit
+    // therefore targets the canonical definition site.
+    let artifacts_src = fs::read_to_string("src/artifacts.rs").unwrap();
 
-    // Assert
     assert!(
-        embed_src.contains("pub(crate) fn from_paths("),
-        "embed::CandidateArtifacts::from_paths must be declared `pub(crate) fn from_paths(`"
+        artifacts_src.contains("pub(crate) fn from_paths("),
+        "artifacts::CandidateArtifacts::from_paths must be declared `pub(crate) fn from_paths(`"
     );
+    // Negative assertion: bare `pub fn from_paths(` must not exist on the
+    // canonical definition.
     assert!(
-        reranker_src.contains("pub(crate) fn from_paths("),
-        "reranker::CandidateArtifacts::from_paths must be declared `pub(crate) fn from_paths(`"
-    );
-    // Negative assertion: bare `pub fn from_paths(` must not exist.
-    assert!(
-        !embed_src.contains("\n    pub fn from_paths("),
-        "embed::CandidateArtifacts::from_paths must not be declared `pub fn`"
-    );
-    assert!(
-        !reranker_src.contains("\n    pub fn from_paths("),
-        "reranker::CandidateArtifacts::from_paths must not be declared `pub fn`"
+        !artifacts_src.contains("\n    pub fn from_paths("),
+        "artifacts::CandidateArtifacts::from_paths must not be declared `pub fn`"
     );
 }
 

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -7,18 +7,15 @@ mod test_support;
 mod tests;
 
 use self::mlx::RerankerInner;
-use crate::artifacts::verify_as_reranker;
-use crate::model_io::{ModelArtifact, ModelPaths, artifacts_if_cached, download_artifacts};
-use crate::model_probe::{
-    ProbeError, ProbeStatus, probe_paths_via_subprocess, resolve_probe_env, validate_probe_paths,
-};
+use crate::artifacts;
+use crate::model_io::ModelArtifact;
+use crate::model_probe::{ProbeStatus, probe_paths_via_subprocess};
 use std::fmt::{self, Debug, Display, Formatter};
-#[cfg(any(test, feature = "test-support"))]
-use std::path::Path;
-use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
 pub use crate::artifacts::{ArtifactError, RerankerKind, VerifiedArtifacts};
+pub use crate::model_init::ModelInitError;
+pub use crate::model_lifecycle::{cached_artifacts, download_model};
 #[cfg(any(test, feature = "test-support"))]
 pub use test_support::MockReranker;
 
@@ -43,53 +40,10 @@ pub type Artifacts = VerifiedArtifacts<RerankerKind>;
 
 /// Unverified reranker model artifact paths.
 ///
-/// Construct with [`from_paths`](Self::from_paths) (or [`from_dir`](Self::from_dir)
-/// in test contexts), then call [`verify`](Self::verify) to obtain
-/// [`Artifacts`] that can be passed to [`Reranker::new`].
-#[derive(Debug)]
-pub struct CandidateArtifacts {
-    paths: ModelPaths,
-}
-
-impl CandidateArtifacts {
-    /// Construct from explicit file paths without any verification.
-    ///
-    /// Use this when you have raw paths (e.g. from environment variables).
-    /// Call [`verify`](Self::verify) before passing the result to [`Reranker::new`].
-    pub(crate) fn from_paths(model: PathBuf, config: PathBuf, tokenizer: PathBuf) -> Self {
-        Self {
-            paths: ModelPaths {
-                model,
-                config,
-                tokenizer,
-            },
-        }
-    }
-
-    /// Construct from a directory using standard filenames (`model.safetensors`,
-    /// `config.json`, `tokenizer.json`).
-    ///
-    /// Available for development and test use only.
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn from_dir(dir: &Path) -> Self {
-        Self {
-            paths: ModelPaths::from_dir(dir),
-        }
-    }
-
-    /// Verify file existence, config integrity, tokenizer validity, and reranker model kind.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ArtifactError`] for any of the following:
-    /// - A required file is missing ([`ArtifactError::MissingFile`])
-    /// - `config.json` cannot be parsed ([`ArtifactError::InvalidConfig`])
-    /// - `tokenizer.json` cannot be loaded ([`ArtifactError::InvalidTokenizer`])
-    /// - Weights are for an embed model, not a reranker ([`ArtifactError::WrongModelKind`])
-    pub fn verify(self) -> Result<Artifacts, ArtifactError> {
-        verify_as_reranker(self.paths)
-    }
-}
+/// Type alias for [`crate::artifacts::CandidateArtifacts<RerankerKind>`] so the
+/// downstream-visible name `reranker::CandidateArtifacts` keeps working while
+/// the underlying definition lives in `artifacts.rs` (single source of truth).
+pub type CandidateArtifacts = artifacts::CandidateArtifacts<RerankerKind>;
 
 // ── RerankerModelId ───────────────────────────────────────────────────────────
 
@@ -117,48 +71,14 @@ impl RerankerModelId {
 }
 
 impl ModelArtifact for RerankerModelId {
+    type Kind = RerankerKind;
+
     fn repo_id(self) -> &'static str {
         RerankerModelId::repo_id(self)
     }
 
     fn revision(self) -> &'static str {
         self.revision()
-    }
-}
-
-// ── RerankerInitError ─────────────────────────────────────────────────────────
-
-/// Errors from initialising the reranker backend ([`Reranker::new`], [`Reranker::probe`]).
-///
-/// These errors occur after artifact verification has already succeeded. They
-/// indicate a failure during MLX backend setup or model weight loading.
-#[derive(Debug, thiserror::Error)]
-pub enum RerankerInitError {
-    /// MLX backend initialisation, weight loading, or subprocess probe failure.
-    #[error("reranker init failed: {0}")]
-    Backend(String),
-    /// Model weights loaded but are corrupt or incompatible with the expected architecture.
-    #[error("model load failed: {reason}")]
-    ModelCorrupt {
-        /// Failure detail from the backend.
-        reason: String,
-    },
-}
-
-impl RerankerInitError {
-    pub(crate) fn backend(e: impl Display) -> Self {
-        Self::Backend(e.to_string())
-    }
-}
-
-impl From<ProbeError> for RerankerInitError {
-    fn from(e: ProbeError) -> Self {
-        match e {
-            ProbeError::HandlerNotInstalled => RerankerInitError::Backend(e.to_string()),
-            ProbeError::ModelLoadFailed { reason } => RerankerInitError::ModelCorrupt { reason },
-            ProbeError::SetupRejected { .. } => RerankerInitError::Backend(e.to_string()),
-            ProbeError::SubprocessFailed(msg) => RerankerInitError::Backend(msg),
-        }
     }
 }
 
@@ -246,8 +166,8 @@ impl Reranker {
     ///
     /// # Errors
     ///
-    /// Returns [`RerankerInitError::Backend`] if MLX model construction or weight loading fails.
-    pub fn new(artifacts: &Artifacts) -> Result<Self, RerankerInitError> {
+    /// Returns [`ModelInitError::Backend`] if MLX model construction or weight loading fails.
+    pub fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let inner = RerankerInner::new(artifacts)?;
         Ok(Self {
             inner: Mutex::new(inner),
@@ -306,7 +226,7 @@ impl Reranker {
     /// The host binary must call
     /// [`model_probe::handle_probe_if_needed`](crate::model_probe::handle_probe_if_needed)
     /// at the start of `main()`.
-    pub fn probe(artifacts: &Artifacts) -> Result<ProbeStatus, RerankerInitError> {
+    pub fn probe(artifacts: &Artifacts) -> Result<ProbeStatus, ModelInitError> {
         probe_via_subprocess(artifacts)
     }
 
@@ -345,59 +265,9 @@ fn sort_results(scores: &[f32]) -> Vec<RankedResult> {
     results
 }
 
-// ── Public API: download / cache ──────────────────────────────────────────────
-
-/// Download reranker model files from Hugging Face Hub and verify them as reranker artifacts.
-///
-/// # Errors
-///
-/// Returns [`ArtifactError::DownloadFailed`] if the Hugging Face client cannot be
-/// initialised or any required artifact download fails.
-/// Returns other [`ArtifactError`] variants if verification of the downloaded
-/// files fails.
-pub fn download_model(model: RerankerModelId) -> Result<Artifacts, ArtifactError> {
-    let paths = download_artifacts(model)?;
-    verify_as_reranker(paths)
-}
-
-/// Check whether reranker model files exist in the local HF Hub cache and verify them.
-///
-/// Returns `Ok(Some(artifacts))` if all three files are cached and pass
-/// verification, `Ok(None)` otherwise. Never accesses the network.
-///
-/// # Errors
-///
-/// Returns [`ArtifactError`] if cached files fail verification.
-/// Cache misses are reported as `Ok(None)`.
-pub fn cached_artifacts(model: RerankerModelId) -> Result<Option<Artifacts>, ArtifactError> {
-    let Some(paths) = artifacts_if_cached(model)? else {
-        return Ok(None);
-    };
-    verify_as_reranker(paths).map(Some)
-}
-
 // ── Probe infrastructure ──────────────────────────────────────────────────────
 
-/// Resolve reranker probe env vars into a [`CandidateArtifacts`].
-///
-/// Returns `None` if this is not a probe invocation (primary model env var absent).
-/// Returns `Some(Ok(candidate))` if all three vars are set.
-/// Returns `Some(Err(3))` if the model var is set but config or tokenizer is missing.
-pub(crate) fn probe_env_to_paths(
-    model: Option<String>,
-    config: Option<String>,
-    tokenizer: Option<String>,
-) -> Option<Result<CandidateArtifacts, i32>> {
-    resolve_probe_env(model, config, tokenizer).map(|r| {
-        r.and_then(|(m, c, t)| {
-            validate_probe_paths(&m, &c, &t)?;
-            Ok((m, c, t))
-        })
-        .map(|(m, c, t)| CandidateArtifacts::from_paths(m, c, t))
-    })
-}
-
-fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, RerankerInitError> {
+fn probe_via_subprocess(artifacts: &Artifacts) -> Result<ProbeStatus, ModelInitError> {
     probe_paths_via_subprocess(
         &artifacts.paths,
         PROBE_ENV_MODEL,

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -231,9 +231,13 @@ impl Reranker {
     }
 
     fn lock_inner(&self) -> Result<MutexGuard<'_, RerankerInner>, RerankerError> {
-        self.inner
-            .lock()
-            .map_err(|_| RerankerError::inference("reranker lock poisoned"))
+        self.inner.lock().map_err(|e| {
+            tracing::error!(
+                error = %e,
+                "reranker: mutex poisoned (prior panic in critical section)"
+            );
+            RerankerError::inference("reranker lock poisoned")
+        })
     }
 }
 

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -1,4 +1,4 @@
-use super::{Artifacts, RerankerError, RerankerInitError};
+use super::{Artifacts, ModelInitError, RerankerError};
 use crate::mlx_cache::release_inference_output;
 use crate::model_io::{
     BUCKET_BOUNDS, MAX_SEQ_LEN, assign_bucket, pad_sequences, truncate_with_eos,
@@ -22,12 +22,12 @@ pub(super) struct RerankerInner {
 }
 
 impl RerankerInner {
-    pub(super) fn new(artifacts: &Artifacts) -> Result<Self, RerankerInitError> {
+    pub(super) fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let config = &artifacts.config;
         let tokenizer = artifacts.tokenizer.clone();
 
-        let model = RerankerModel::load(&artifacts.paths.model, config)
-            .map_err(RerankerInitError::backend)?;
+        let model =
+            RerankerModel::load(&artifacts.paths.model, config).map_err(ModelInitError::backend)?;
 
         Ok(Self { model, tokenizer })
     }

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -29,6 +29,7 @@ impl RerankerInner {
         let model =
             RerankerModel::load(&artifacts.paths.model, config).map_err(ModelInitError::backend)?;
 
+        tracing::info!(hidden_size = config.hidden_size, "reranker: model loaded");
         Ok(Self { model, tokenizer })
     }
 

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -1,11 +1,14 @@
 use super::mlx::truncate_pair;
 use super::*;
 use crate::artifacts::RerankerKind;
-use crate::model_io::artifacts_from_cache;
 use crate::model_lifecycle::probe_env_to_paths;
 #[cfg(unix)]
 use crate::test_support::setup_fake_hf_cache_with_symlinks;
-use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
+use crate::test_support::{
+    VALID_CONFIG_JSON, assert_cache_lookup_returns_none_when_empty,
+    assert_cache_lookup_returns_some_when_all_files_present,
+    assert_from_probe_error_maps_correctly,
+};
 use std::fs;
 
 #[test]
@@ -67,32 +70,12 @@ fn t_007b_sort_results_ties_break_by_original_index() {
 
 #[test]
 fn t_013_cache_lookup_returns_some_when_all_files_present() {
-    let dir = tempfile::tempdir().unwrap();
-    let model = RerankerModelId::RuriV3Reranker310m;
-    setup_fake_hf_cache(
-        dir.path(),
-        model.repo_id(),
-        model.revision(),
-        &[
-            ("model.safetensors", b"fake"),
-            ("config.json", b"{}"),
-            ("tokenizer.json", b"{}"),
-        ],
-    );
-    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = artifacts_from_cache(&cache, model).unwrap();
-    let paths = result.expect("should be Some");
-    assert!(paths.model.ends_with("model.safetensors"));
-    assert!(paths.config.ends_with("config.json"));
-    assert!(paths.tokenizer.ends_with("tokenizer.json"));
+    assert_cache_lookup_returns_some_when_all_files_present(RerankerModelId::RuriV3Reranker310m);
 }
 
 #[test]
 fn t_021_cache_lookup_returns_none_when_cache_empty() {
-    let dir = tempfile::tempdir().unwrap();
-    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
-    let result = artifacts_from_cache(&cache, RerankerModelId::default()).unwrap();
-    assert!(result.is_none());
+    assert_cache_lookup_returns_none_when_empty(RerankerModelId::default());
 }
 
 #[test]
@@ -245,28 +228,7 @@ fn sort_results_handles_nan_without_panic() {
 
 #[test]
 fn from_probe_error_maps_correctly() {
-    use crate::model_probe::ProbeError;
-
-    let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
-    assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
-        "{err}"
-    );
-
-    let err: ModelInitError = ProbeError::ModelLoadFailed {
-        reason: "bad weights".into(),
-    }
-    .into();
-    assert!(
-        matches!(err, ModelInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
-        "{err}"
-    );
-
-    let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
-    assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
-        "{err}"
-    );
+    assert_from_probe_error_maps_correctly();
 }
 
 use super::mlx::sigmoid;

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -1,6 +1,8 @@
 use super::mlx::truncate_pair;
 use super::*;
+use crate::artifacts::RerankerKind;
 use crate::model_io::artifacts_from_cache;
+use crate::model_lifecycle::probe_env_to_paths;
 #[cfg(unix)]
 use crate::test_support::setup_fake_hf_cache_with_symlinks;
 use crate::test_support::{VALID_CONFIG_JSON, setup_fake_hf_cache};
@@ -145,7 +147,7 @@ fn t_019_probe_env_to_paths_preserves_snapshot_symlink_filename() {
 
     let hf_home_path = hf_home.path().to_path_buf();
     temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = super::probe_env_to_paths(
+        let candidate = probe_env_to_paths::<RerankerKind>(
             Some(m.to_string_lossy().into_owned()),
             Some(c.to_string_lossy().into_owned()),
             Some(t.to_string_lossy().into_owned()),
@@ -186,7 +188,7 @@ fn probe_env_to_paths_returns_ok_when_all_present() {
 
     let hf_home_path = hf_home.path().to_path_buf();
     temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let result = super::probe_env_to_paths(
+        let result = probe_env_to_paths::<RerankerKind>(
             Some(m.to_string_lossy().into_owned()),
             Some(c.to_string_lossy().into_owned()),
             Some(t.to_string_lossy().into_owned()),
@@ -245,24 +247,24 @@ fn sort_results_handles_nan_without_panic() {
 fn from_probe_error_maps_correctly() {
     use crate::model_probe::ProbeError;
 
-    let err: RerankerInitError = ProbeError::HandlerNotInstalled.into();
+    let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
     assert!(
-        matches!(err, RerankerInitError::Backend(ref m) if m.contains("probe handler not installed")),
+        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
         "{err}"
     );
 
-    let err: RerankerInitError = ProbeError::ModelLoadFailed {
+    let err: ModelInitError = ProbeError::ModelLoadFailed {
         reason: "bad weights".into(),
     }
     .into();
     assert!(
-        matches!(err, RerankerInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
+        matches!(err, ModelInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
         "{err}"
     );
 
-    let err: RerankerInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
+    let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
     assert!(
-        matches!(err, RerankerInitError::Backend(ref m) if m == "spawn failed"),
+        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
         "{err}"
     );
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -27,6 +27,56 @@ pub(crate) const VALID_CONFIG_JSON: &str = r#"{
     "local_rope_theta": 10000.0
 }"#;
 
+/// Minimal BPE tokenizer JSON accepted by tokenizers 0.22+.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const MINIMAL_TOKENIZER_JSON: &str = r#"{
+    "version": "1.0",
+    "model": {"type": "BPE", "vocab": {}, "merges": []},
+    "added_tokens": [],
+    "normalizer": null,
+    "pre_tokenizer": null,
+    "post_processor": null,
+    "decoder": null,
+    "truncation": null,
+    "padding": null
+}"#;
+
+/// Representative backbone tensor key satisfying the `MODERNBERT_KEY_PREFIXES`
+/// any-of check in [`crate::artifacts`].
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) const FAKE_BACKBONE_KEY: &str = "layers.0.attn.Wo.weight";
+
+/// Write a minimal but structurally valid safetensors file containing the given
+/// tensor keys. Each tensor has one `f32` element of weight data.
+#[cfg(any(test, feature = "test-support"))]
+pub(crate) fn write_fake_safetensors(path: &Path, tensor_keys: &[&str]) {
+    let mut header_obj = serde_json::Map::new();
+    header_obj.insert("__metadata__".to_owned(), serde_json::json!({}));
+    let mut offset = 0usize;
+    for &key in tensor_keys {
+        let end = offset + 4;
+        header_obj.insert(
+            key.to_owned(),
+            serde_json::json!({
+                "dtype": "F32",
+                "shape": [1],
+                "data_offsets": [offset, end]
+            }),
+        );
+        offset = end;
+    }
+    let header_json = serde_json::to_vec(&header_obj).unwrap();
+    let header_len = header_json.len() as u64;
+
+    let mut data = Vec::new();
+    data.extend_from_slice(&header_len.to_le_bytes());
+    data.extend_from_slice(&header_json);
+    for _ in tensor_keys {
+        data.extend_from_slice(&0f32.to_le_bytes());
+    }
+    fs::write(path, data).unwrap();
+}
+
 /// Create a fake HuggingFace Hub cache directory structure.
 ///
 /// Builds the `models--{repo_slug}/refs/{revision}` → `snapshots/{hash}/`
@@ -116,9 +166,21 @@ pub(crate) fn assert_cache_lookup_returns_some_when_all_files_present<Id: ModelA
     let cache = hf_hub::Cache::new(dir.path().to_path_buf());
     let result = artifacts_from_cache(&cache, model).unwrap();
     let paths = result.expect("should return Some when all files cached");
-    assert!(paths.model.ends_with("model.safetensors"));
-    assert!(paths.config.ends_with("config.json"));
-    assert!(paths.tokenizer.ends_with("tokenizer.json"));
+    assert!(
+        paths.model.ends_with("model.safetensors"),
+        "model path: {}",
+        paths.model.display()
+    );
+    assert!(
+        paths.config.ends_with("config.json"),
+        "config path: {}",
+        paths.config.display()
+    );
+    assert!(
+        paths.tokenizer.ends_with("tokenizer.json"),
+        "tokenizer path: {}",
+        paths.tokenizer.display()
+    );
 }
 
 /// Generic helper for `cache_lookup_returns_none_when_empty`.

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3,6 +3,10 @@
 use std::fs;
 use std::path::Path;
 
+use crate::model_init::ModelInitError;
+use crate::model_io::{ModelArtifact, artifacts_from_cache};
+use crate::model_probe::ProbeError;
+
 /// Valid ModernBERT config JSON with all required fields, for use in tests
 /// that need to bypass config parsing errors and reach later verification stages.
 ///
@@ -83,6 +87,75 @@ pub(crate) fn setup_fake_hf_cache_with_symlinks(
         // Relative symlink target: snapshots/<commit>/X -> ../../blobs/<etag>
         symlink(format!("../../blobs/{etag}"), &snapshot_link).unwrap();
     }
+}
+
+// ── Generic lifecycle test helpers (Phase 2 / FR-009 / FR-010) ─────────────
+
+/// Generic helper for `cache_lookup_returns_some_when_all_files_present`.
+///
+/// Stages a fake HF cache with the three artifact files (placeholder content),
+/// invokes [`artifacts_from_cache`](artifacts_from_cache), and
+/// asserts that the returned paths end with the standard filenames.
+///
+/// Callable for any kind whose ID type implements
+/// [`ModelArtifact`](crate::model_io::ModelArtifact).
+pub(crate) fn assert_cache_lookup_returns_some_when_all_files_present<Id: ModelArtifact>(
+    model: Id,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    setup_fake_hf_cache(
+        dir.path(),
+        model.repo_id(),
+        model.revision(),
+        &[
+            ("model.safetensors", b"fake"),
+            ("config.json", b"{}"),
+            ("tokenizer.json", b"{}"),
+        ],
+    );
+    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
+    let result = artifacts_from_cache(&cache, model).unwrap();
+    let paths = result.expect("should return Some when all files cached");
+    assert!(paths.model.ends_with("model.safetensors"));
+    assert!(paths.config.ends_with("config.json"));
+    assert!(paths.tokenizer.ends_with("tokenizer.json"));
+}
+
+/// Generic helper for `cache_lookup_returns_none_when_empty`.
+pub(crate) fn assert_cache_lookup_returns_none_when_empty<Id: ModelArtifact>(model: Id) {
+    let dir = tempfile::tempdir().unwrap();
+    let cache = hf_hub::Cache::new(dir.path().to_path_buf());
+    let result = artifacts_from_cache(&cache, model).unwrap();
+    assert!(result.is_none());
+}
+
+/// Generic helper for `from_probe_error_maps_correctly`.
+///
+/// Asserts that all four [`ProbeError`](crate::model_probe::ProbeError) variants
+/// map to the expected [`ModelInitError`](crate::model_init::ModelInitError)
+/// variant. Kind-agnostic because `ModelInitError` is unified across embed and
+/// reranker (FR-002).
+pub(crate) fn assert_from_probe_error_maps_correctly() {
+    let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
+    assert!(
+        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
+        "{err}"
+    );
+
+    let err: ModelInitError = ProbeError::ModelLoadFailed {
+        reason: "bad weights".into(),
+    }
+    .into();
+    assert!(
+        matches!(err, ModelInitError::ModelCorrupt { ref reason } if reason == "bad weights"),
+        "{err}"
+    );
+
+    let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
+    assert!(
+        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
+        "{err}"
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要と目的

embed と reranker が copy-paste で並行進化していた問題を解消。`ModelKind<T>` generics で lifecycle (download / cache / probe / verify / init error) を統一し、kind binding は `ModelArtifact::Kind` associated type で型レベル enforce。Issue #93 の outcome を達成。

audit (2026-05-06) で検出された scope 内の改善も同 PR で対処: production stability (download timeout)、observability (lifecycle tracing + Mutex poison logging)、test fixture consolidation。

## 変更内容

3 commits:

**`187a8c8` refactor(model)!: unify embed/reranker lifecycle into ModelKind generics**
- `CandidateArtifacts<K>` / `VerifiedArtifacts<K>` を `artifacts.rs` に集約 (DUP-001)
- `EmbedInitError` / `RerankerInitError` を unified `ModelInitError` に統合 (DUP-002, FR-002)
- `download_model<Id: ModelArtifact>` / `cached_artifacts` / `probe_env_to_paths<K>` を `model_lifecycle.rs` に generic 化 (DUP-003, DUP-004)
- `embed::download_model` 等は `pub use` re-export として既存 caller を維持
- `mlx` Cargo feature 削除 (常時 MLX backend)、MSRV bump 1.95

**`4da7acf` refactor(model): consolidate lifecycle tests + document breaking changes**
- 共有 test helper を `test_support.rs` に追加 (`assert_cache_lookup_returns_*`, `assert_from_probe_error_maps_correctly`)
- `model_lifecycle::tests` に generic dispatch の sig assertion (T-010〜T-015)
- CHANGELOG に Breaking Changes 列挙

**`ccd2158` refactor(model): consolidate test fixtures + add download timeout/tracing**
- audit 2026-05-06 の PR scope 内 fix:
  - test fixture (`MINIMAL_TOKENIZER_JSON` / `FAKE_BACKBONE_KEY` / `write_fake_safetensors`) を `test_support.rs` に集約 (RC-006)
  - `#[allow(dead_code)]` phase marker 削除 (DES-005, OPS-011)
  - `download_artifacts` に 5 分 hard cap timeout 追加 (RES-004)
  - lifecycle tracing (`info!`/`debug!`) 追加 (OPS-002, RC-009 一部)
  - Mutex poison `tracing::error!` 追加 (OPS-005, OPS-006)
  - CHANGELOG accuracy 修正 (RC-013 / DOC-001-003/005 / PRM-001/003/007/008)
- /polish 改善: `make_repo` helper / `mpsc::sync_channel(1)` / `RecvTimeoutError::Disconnected` を別 error 文字列に区別

## スコープ

**含めない (別 issue 化済):**
- RC-001 `ModelArtifact` visibility refactor → #103 にコメント追記
- RC-002 probe IPC contract v2 (drain thread join + stderr flush) → **#124 新規作成**
- RC-003 reranker `score_batch` sub-batching (10k pairs OOM) → **#123 新規作成**
- RC-004 `expect` panic root fix (Mutex poison 構造) → #99 にコメント追記
- RC-005 `dispatch_probe` error chain erasure → **#125 新規作成**
- 残 observability (OPS-001/007/008/009) → #102 にコメント追記
- `download_artifacts` の thread-per-call leak (timeout 副作用) → 別 issue 推奨

## 設計判断

- **`ModelKind` を `pub trait` (open) で実装 — closed `enum` ではない**: refactor 中、`VerifiedArtifacts<K>` の generic 化に必要。external implementer は kind verify を呼べない (`verify_as_embed`/`verify_as_reranker` が `pub(crate)`) ため実質 closed set。RC-011 として再検討対象 (#103)
- **`ModelArtifact` を `pub trait` in `pub(crate) mod model_io`**: `download_model<Id: ModelArtifact>` の bound に使うため。`pub(crate) trait` だと private_in_public で使えない技術制約。CHANGELOG で「Internal: ...」と明記し外部 impl 不可を documentation 面で対処
- **download timeout を thread + `sync_channel(1)` で実装**: hf-hub 0.5 sync API は timeout 設定不可、`tokio::time::timeout` は async 化必須で大幅変更。thread-per-call detached leak の trade-off はあるが、HF unreachable 時の永久 hang を防ぐ outcome を優先。leak の根本対処は別 issue

## 動作確認

\`\`\`sh
cargo test --workspace
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo fmt --check
\`\`\`

期待: 308/311 pass (3 ignored は MLX real-model smoke、変化なし)。clippy/fmt clean。

Breaking Changes は \`CHANGELOG.md\` の \`[Unreleased] > Breaking Changes\` 参照。downstream (amici / yomu / sae) の追従は merge 後に各リポで rev bump + match arm 更新の追従 issue を作成。

## 関連

- Closes #93
- audit 2026-05-06 snapshot: \`~/.claude/workspace/history/audit-2026-05-06-084602.json\`
- 関連 issue: #94 (closed, IPC IO failure 一部解決) / #99 / #102 / #103 / **#123** / **#124** / **#125**