### PR TITLE
fix(reranker): score_batch に sub-batching 追加して unbounded OOM を防ぐ (RC-003)

### DIFF
--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -10,7 +10,7 @@ use super::{
     tokenize_with_prefix, truncate_for_query,
 };
 use crate::mlx_cache::{clear_inference_cache, release_inference_output};
-use crate::model_io::{BUCKET_BOUNDS, assign_bucket, pad_sequences};
+use crate::model_io::{BUCKET_BOUNDS, assign_bucket, compute_sub_batch_size, pad_sequences};
 use crate::modernbert::ModernBert;
 
 /// Per-chunk metadata carried through bucket forward so the flat output can be
@@ -85,10 +85,6 @@ fn build_indexed_chunks(
     );
     result
 }
-
-/// Token-count ceiling for a single forward pass. Matches the pre-bucketing
-/// value so the memory budget is unchanged by bucketing.
-const TOKEN_BUDGET: usize = 256_000;
 
 pub(super) struct EmbedderInner {
     model: ModernBert,
@@ -266,7 +262,7 @@ impl EmbedderInner {
             // sub_batch_size against the bucket ceiling keeps every possible
             // sub-batch under TOKEN_BUDGET even when every chunk is at the
             // bucket_max boundary, matching the pre-bucketing OOM guarantee.
-            let sub_batch_size = (TOKEN_BUDGET / BUCKET_BOUNDS[bucket_idx]).max(1);
+            let sub_batch_size = compute_sub_batch_size(BUCKET_BOUNDS[bucket_idx]);
             for sub_batch in bucket.chunks(sub_batch_size) {
                 self.forward_sub_batch(sub_batch, bucket_idx, &mut out, &mut metrics)?;
             }

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -251,15 +251,10 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
 /// path drives a given call.
 pub(crate) const TOKEN_BUDGET: usize = 256_000;
 
-/// Compute the sub-batch size for a bucket of length `bucket_len`.
-///
-/// Returns `(TOKEN_BUDGET / bucket_len).max(1)`. Callers iterate
-/// `items.chunks(sub_batch_size)` so each forward pass stays under the
-/// [`TOKEN_BUDGET`] ceiling even when every item sits at the bucket boundary.
-/// The `max(1)` floor keeps the loop progressing if a future widening of
-/// [`BUCKET_BOUNDS`] makes a bucket exceed [`TOKEN_BUDGET`]; production
-/// callers always pass `BUCKET_BOUNDS[i]` (≤ 8192) so that branch never
-/// fires today.
+/// Sub-batch size that keeps each forward pass under [`TOKEN_BUDGET`] when
+/// every item sits at the bucket boundary. Callers iterate
+/// `items.chunks(sub_batch_size)`. Floors at 1 so the loop progresses for
+/// `bucket_len > TOKEN_BUDGET`.
 pub(crate) fn compute_sub_batch_size(bucket_len: usize) -> usize {
     (TOKEN_BUDGET / bucket_len).max(1)
 }
@@ -419,10 +414,10 @@ mod tests {
 
     // ── compute_sub_batch_size tests ────────────────────────────────────────
 
-    // Pin the embed-side sub-batch formula `(TOKEN_BUDGET / bucket_len).max(1)`
-    // so any second caller cannot drift from embed silently.
+    // Pin the canonical sub-batch formula `(TOKEN_BUDGET / bucket_len).max(1)`
+    // so embed and reranker callers cannot drift apart silently.
     #[test]
-    fn compute_sub_batch_size_matches_embed_formula_per_bucket() {
+    fn compute_sub_batch_size_matches_formula_per_bucket() {
         assert_eq!(
             compute_sub_batch_size(BUCKET_BOUNDS[0]),
             TOKEN_BUDGET / BUCKET_BOUNDS[0],

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -243,6 +243,27 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
     }))
 }
 
+/// Token-count ceiling for a single forward pass through the bucketed
+/// inference path.
+///
+/// Embed and reranker callers both size their sub-batches against this budget
+/// so memory consumption is bounded by the same ceiling regardless of which
+/// path drives a given call.
+pub(crate) const TOKEN_BUDGET: usize = 256_000;
+
+/// Compute the sub-batch size for a bucket of length `bucket_len`.
+///
+/// Returns `(TOKEN_BUDGET / bucket_len).max(1)`. Callers iterate
+/// `items.chunks(sub_batch_size)` so each forward pass stays under the
+/// [`TOKEN_BUDGET`] ceiling even when every item sits at the bucket boundary.
+/// The `max(1)` floor keeps the loop progressing if a future widening of
+/// [`BUCKET_BOUNDS`] makes a bucket exceed [`TOKEN_BUDGET`]; production
+/// callers always pass `BUCKET_BOUNDS[i]` (≤ 8192) so that branch never
+/// fires today.
+pub(crate) fn compute_sub_batch_size(bucket_len: usize) -> usize {
+    (TOKEN_BUDGET / bucket_len).max(1)
+}
+
 /// Pad variable-length token sequences into contiguous flat arrays for batched inference.
 ///
 /// Zero-pads shorter sequences to `max_len`. When `target_len` is `None`,
@@ -394,6 +415,39 @@ mod tests {
         );
         assert_eq!(flat_ids, vec![1, 2, 3, 4, 5, 6, 0, 0]);
         assert_eq!(flat_mask, vec![1, 1, 1, 1, 1, 1, 0, 0]);
+    }
+
+    // ── compute_sub_batch_size tests ────────────────────────────────────────
+
+    // Pin the embed-side sub-batch formula `(TOKEN_BUDGET / bucket_len).max(1)`
+    // so any second caller cannot drift from embed silently.
+    #[test]
+    fn compute_sub_batch_size_matches_embed_formula_per_bucket() {
+        assert_eq!(
+            compute_sub_batch_size(BUCKET_BOUNDS[0]),
+            TOKEN_BUDGET / BUCKET_BOUNDS[0],
+        );
+        assert_eq!(
+            compute_sub_batch_size(BUCKET_BOUNDS[1]),
+            TOKEN_BUDGET / BUCKET_BOUNDS[1],
+        );
+        assert_eq!(
+            compute_sub_batch_size(BUCKET_BOUNDS[2]),
+            TOKEN_BUDGET / BUCKET_BOUNDS[2],
+        );
+        assert_eq!(
+            compute_sub_batch_size(BUCKET_BOUNDS[3]),
+            TOKEN_BUDGET / BUCKET_BOUNDS[3],
+        );
+    }
+
+    // `max(1)` floor: pathological bucket_len > TOKEN_BUDGET cannot happen in
+    // production (BUCKET_BOUNDS[3]=8192 < 256_000), but the guard keeps callers
+    // from looping over zero-sized chunks if BUCKET_BOUNDS is later widened.
+    #[test]
+    fn compute_sub_batch_size_returns_one_when_bucket_exceeds_token_budget() {
+        assert_eq!(compute_sub_batch_size(TOKEN_BUDGET + 1), 1);
+        assert_eq!(compute_sub_batch_size(usize::MAX), 1);
     }
 
     // ── ModelArtifact::Kind associated type ─────────────────────────────────

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -72,7 +72,6 @@ impl RerankerInner {
             sub_batch_count,
             sub_batch_size,
             bucket_len,
-            bucket_idx,
             "reranker score_batch dispatch",
         );
 
@@ -87,11 +86,7 @@ impl RerankerInner {
         Ok(all_scores)
     }
 
-    /// Forward a single sub-batch and produce per-pair sigmoid scores.
-    ///
-    /// Caller pre-bucketed and pre-sized the chunk against
-    /// [`compute_sub_batch_size`] so this pass stays within the shared
-    /// `TOKEN_BUDGET`. The pair count returned matches `ids_chunk.len()`.
+    /// Forward one sub-batch and map logits to `[0, 1]` via sigmoid.
     fn forward_sub_batch(
         &mut self,
         ids_chunk: &[Vec<u32>],

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -1,7 +1,8 @@
 use super::{Artifacts, ModelInitError, RerankerError};
 use crate::mlx_cache::release_inference_output;
 use crate::model_io::{
-    BUCKET_BOUNDS, MAX_SEQ_LEN, assign_bucket, pad_sequences, truncate_with_eos,
+    BUCKET_BOUNDS, MAX_SEQ_LEN, assign_bucket, compute_sub_batch_size, pad_sequences,
+    truncate_with_eos,
 };
 use crate::modernbert::{Config, ModernBert, layer_norm_eps_f32};
 
@@ -33,6 +34,13 @@ impl RerankerInner {
         Ok(Self { model, tokenizer })
     }
 
+    /// Score every `(query, document)` pair in `pairs`.
+    ///
+    /// Pairs are tokenised and bucketed by maximum length, then forwarded in
+    /// sub-batches sized so each forward pass stays under the shared
+    /// [`crate::model_io::TOKEN_BUDGET`] ceiling. Sub-batching mirrors the
+    /// embed path so a large `pairs.len()` cannot allocate an unbounded
+    /// `[N × bucket_len]` flat tensor.
     pub(super) fn score_batch(
         &mut self,
         pairs: &[(&str, &str)],
@@ -54,8 +62,44 @@ impl RerankerInner {
 
         let raw_max = all_ids.iter().map(Vec::len).max().unwrap_or(0);
         let bucket_idx = assign_bucket(raw_max);
+        let bucket_len = BUCKET_BOUNDS[bucket_idx];
+        let sub_batch_size = compute_sub_batch_size(bucket_len);
+
+        let total_pairs = pairs.len();
+        let sub_batch_count = total_pairs.div_ceil(sub_batch_size);
+        tracing::debug!(
+            batch_size = total_pairs,
+            sub_batch_count,
+            sub_batch_size,
+            bucket_len,
+            bucket_idx,
+            "reranker score_batch dispatch",
+        );
+
+        let mut all_scores = Vec::with_capacity(total_pairs);
+        for (ids_chunk, masks_chunk) in all_ids
+            .chunks(sub_batch_size)
+            .zip(all_masks.chunks(sub_batch_size))
+        {
+            let sub_scores = self.forward_sub_batch(ids_chunk, masks_chunk, bucket_len)?;
+            all_scores.extend(sub_scores);
+        }
+        Ok(all_scores)
+    }
+
+    /// Forward a single sub-batch and produce per-pair sigmoid scores.
+    ///
+    /// Caller pre-bucketed and pre-sized the chunk against
+    /// [`compute_sub_batch_size`] so this pass stays within the shared
+    /// `TOKEN_BUDGET`. The pair count returned matches `ids_chunk.len()`.
+    fn forward_sub_batch(
+        &mut self,
+        ids_chunk: &[Vec<u32>],
+        masks_chunk: &[Vec<u32>],
+        bucket_len: usize,
+    ) -> Result<Vec<f32>, RerankerError> {
         let (flat_ids, flat_mask, batch_size, max_len) =
-            pad_sequences(&all_ids, Some(&all_masks), Some(BUCKET_BOUNDS[bucket_idx]));
+            pad_sequences(ids_chunk, Some(masks_chunk), Some(bucket_len));
 
         let batch_size_i32 = i32::try_from(batch_size).expect("batch_size fits in i32");
         let max_len_i32 = i32::try_from(max_len).expect("max_len fits in i32");

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -270,7 +270,10 @@ fn mock_reranker_score_returns_configured_value() {
 /// outside Codex seatbelt.
 #[cfg(feature = "test-mlx")]
 mod mlx_runtime_tests {
+    use std::time::Instant;
+
     use serial_test::serial;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::sandbox::require_unsandboxed_mlx_runtime;
@@ -365,6 +368,108 @@ mod mlx_runtime_tests {
             result.is_ok(),
             "Reranker::new should succeed: {:?}",
             result.err()
+        );
+    }
+
+    // Large-batch score_batch must not OOM.
+    //
+    // Without sub-batching, `RerankerInner::score_batch` would build a single
+    // `[N × bucket_len]` flat tensor and forward it in one pass. With N=5000
+    // short pairs that land in bucket 0 (≤128 tokens), the resulting
+    // `5000 × 128 = 640_000` token matrix exhausts GPU memory on most M-series
+    // devices.
+    //
+    // Sub-batching fans the same input out to `compute_sub_batch_size(128) =
+    // 2000` pairs per forward, so each pass stays under the
+    // `TOKEN_BUDGET = 256_000` ceiling shared with the embed path.
+    #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
+    #[serial]
+    fn t_score_batch_5000_pairs_short_docs_completes_without_oom() {
+        require_unsandboxed_mlx_runtime();
+        let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
+
+        let pairs: Vec<(&str, &str)> = (0..5000).map(|_| ("query", "doc")).collect();
+        let scores = reranker
+            .score_batch(&pairs)
+            .expect("5000 short pairs must not OOM after sub-batching");
+
+        assert_eq!(scores.len(), 5000, "one score per input pair");
+        for (i, &s) in scores.iter().enumerate() {
+            assert!(s.is_finite(), "score[{i}] = {s} must be finite");
+            assert!(
+                (0.0..=1.0).contains(&s),
+                "score[{i}] = {s} must be in [0,1]"
+            );
+        }
+    }
+
+    // 50 pairs (bucket 0) latency observation.
+    //
+    // At sub_batch_size = compute_sub_batch_size(128) = 2000, the post-fix
+    // chunks(2000) loop produces exactly one iteration. The forward path is
+    // therefore identical to the pre-fix single-pass behaviour; added cost is
+    // bounded by one tracing::debug! line plus one extra function-call frame.
+    // The observation here pins the small-N path's latency floor so a future
+    // refactor that introduces real per-call work shows up immediately.
+    //
+    // Median of `RUNS` runs is printed via `--nocapture` for human inspection;
+    // device-dependent absolute thresholds are intentionally not asserted.
+    #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
+    #[serial]
+    fn t_score_batch_50_pairs_small_n_latency_smoke() {
+        require_unsandboxed_mlx_runtime();
+        let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
+
+        let pairs: Vec<(&str, &str)> = (0..50).map(|_| ("query", "doc")).collect();
+
+        const WARMUP: usize = 3;
+        const RUNS: usize = 30;
+        for _ in 0..WARMUP {
+            reranker.score_batch(&pairs).unwrap();
+        }
+
+        let mut times_us: Vec<u128> = Vec::with_capacity(RUNS);
+        for _ in 0..RUNS {
+            let t0 = Instant::now();
+            reranker.score_batch(&pairs).unwrap();
+            times_us.push(t0.elapsed().as_micros());
+        }
+        times_us.sort_unstable();
+        let p50 = times_us[RUNS / 2];
+        let p95 = times_us[(RUNS * 95) / 100];
+
+        println!("score_batch(50 pairs, bucket=128) p50={p50}µs p95={p95}µs over {RUNS} runs",);
+        assert!(p50 > 0, "timing must be non-zero (sanity)");
+    }
+
+    // Pin the dispatch log emission so a future refactor cannot silently drop
+    // the per-call sub-batching telemetry. Field names are part of the
+    // contract subscribers consume; renaming them must update this assertion.
+    #[traced_test]
+    #[test]
+    #[ignore = "requires unsandboxed MLX runtime"]
+    #[serial]
+    fn t_score_batch_emits_dispatch_log_with_structured_fields() {
+        require_unsandboxed_mlx_runtime();
+        let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
+
+        let pairs: Vec<(&str, &str)> = vec![("query", "doc"); 3];
+        reranker.score_batch(&pairs).unwrap();
+
+        assert!(
+            logs_contain("reranker score_batch dispatch"),
+            "dispatch log message must be emitted",
+        );
+        assert!(logs_contain("batch_size=3"), "batch_size field must be 3");
+        assert!(
+            logs_contain("sub_batch_count=1"),
+            "3 pairs in bucket 0 fit a single sub-batch",
+        );
+        assert!(
+            logs_contain("bucket_len=128"),
+            "short pairs must land in bucket 0 (len=128)",
         );
     }
 }

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -371,17 +371,9 @@ mod mlx_runtime_tests {
         );
     }
 
-    // Large-batch score_batch must not OOM.
-    //
-    // Without sub-batching, `RerankerInner::score_batch` would build a single
-    // `[N × bucket_len]` flat tensor and forward it in one pass. With N=5000
-    // short pairs that land in bucket 0 (≤128 tokens), the resulting
-    // `5000 × 128 = 640_000` token matrix exhausts GPU memory on most M-series
-    // devices.
-    //
-    // Sub-batching fans the same input out to `compute_sub_batch_size(128) =
-    // 2000` pairs per forward, so each pass stays under the
-    // `TOKEN_BUDGET = 256_000` ceiling shared with the embed path.
+    // Without sub-batching, 5000 short pairs in bucket 0 build a single
+    // `5000 × 128 = 640_000` token matrix that exhausts GPU memory on most
+    // M-series devices. Pins the OOM regression that motivated sub-batching.
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
@@ -404,17 +396,10 @@ mod mlx_runtime_tests {
         }
     }
 
-    // 50 pairs (bucket 0) latency observation.
-    //
-    // At sub_batch_size = compute_sub_batch_size(128) = 2000, the post-fix
-    // chunks(2000) loop produces exactly one iteration. The forward path is
-    // therefore identical to the pre-fix single-pass behaviour; added cost is
-    // bounded by one tracing::debug! line plus one extra function-call frame.
-    // The observation here pins the small-N path's latency floor so a future
-    // refactor that introduces real per-call work shows up immediately.
-    //
-    // Median of `RUNS` runs is printed via `--nocapture` for human inspection;
-    // device-dependent absolute thresholds are intentionally not asserted.
+    // Pin small-N (50 pairs, single sub-batch) latency floor as a smoke signal.
+    // A future refactor that introduces real per-call work in score_batch shows
+    // up here. Median printed via --nocapture; thresholds intentionally not
+    // asserted (device-dependent).
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
@@ -451,18 +436,15 @@ mod mlx_runtime_tests {
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_score_batch_emits_dispatch_log_with_structured_fields() {
+    fn t_score_batch_emits_dispatch_log() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
 
         let pairs: Vec<(&str, &str)> = vec![("query", "doc"); 3];
         reranker.score_batch(&pairs).unwrap();
 
-        assert!(
-            logs_contain("reranker score_batch dispatch"),
-            "dispatch log message must be emitted",
-        );
-        assert!(logs_contain("batch_size=3"), "batch_size field must be 3");
+        assert!(logs_contain("reranker score_batch dispatch"));
+        assert!(logs_contain("batch_size=3"));
         assert!(
             logs_contain("sub_batch_count=1"),
             "3 pairs in bucket 0 fit a single sub-batch",


### PR DESCRIPTION
## 概要と目的

Closes #123

`RerankerInner::score_batch` は N pairs を 1 つの `[N × bucket_len]` flat tensor で
一括 forward するため、N=10000 / bucket=8192 で ~40GB GPU を要求し確実に OOM crash する。
embed 側 (`embed/mlx.rs:269-273`) と同等の sub-batching を導入し、両 path の対称性を回復。

## 変更内容

2 commits:

**`fbf2316` fix(reranker): add sub-batching to score_batch to prevent unbounded OOM**
- `compute_sub_batch_size(bucket_len)` を `model_io.rs` に追加 (embed/reranker 共通の `TOKEN_BUDGET = 256_000`)
- `embed::mlx.rs` の inline 定数 / 計算を共有 helper 呼び出しに置換 (DRY 化)
- `RerankerInner::score_batch` を `forward_sub_batch` に分割、`all_ids.chunks(sub_batch_size)` で iterate
- `tracing::debug!(batch_size, sub_batch_count, sub_batch_size, bucket_len)` で per-call instrumentation 追加 (OPS-009)
- MLX runtime tests 追加 (`#[cfg(feature="test-mlx")]`, `#[ignore]`, `#[serial]`):
  - `t_score_batch_5000_pairs_short_docs_completes_without_oom`: 5000 pairs (bucket=128) が OOM せず完走
  - `t_score_batch_50_pairs_small_n_latency_smoke`: 50 pairs single-chunk path の latency floor pin
  - `t_score_batch_emits_dispatch_log`: tracing emit の structured field 検証

**`7bf5012` polish(reranker): compress docs, consolidate test names**
- `compute_sub_batch_size` doc を 10 行 → 4 行に圧縮
- test rename: `…matches_embed_formula_per_bucket` → `…matches_formula_per_bucket`
- 5000-pair / 50-pair test の comment 簡潔化
- tracing emit から `bucket_idx` field を削除 (`bucket_len` で 1:1 mapping 取れる)

## スコープ

**含めない (issue AC で deferred):**
- amici / yomu / recall / sae の downstream rev bump → merge 後に各リポで個別 issue 化

## 設計判断

- **`compute_sub_batch_size` を `model_io.rs` に集約**: embed と reranker で同じ formula
  `(TOKEN_BUDGET / bucket_len).max(1)` を使うため。call sites が 2 で domain-obvious
  (model I/O batching) なため YAGNI Boundary を満たす
- **issue 提案の `RERANKER_TOKEN_BUDGET` const を採用せず、共有 `TOKEN_BUDGET` を使用**:
  embed と同じ値なら別名にする利点なし。差分が必要になったら分離
- **MLX runtime tests を `#[ignore]` 付きで追加**: sandbox 環境では Metal device に
  アクセスできないため、CI default では skip。`cargo test --features test-mlx -- --ignored`
  で実行する設計 (既存 lifecycle test と同じ方針)

## 動作確認

- `cargo test --workspace --all-targets` 全 pass (310 tests)
- MLX runtime tests (`cargo test --features test-mlx -- --ignored mlx_runtime_tests`) 全 pass:
  - 5000-pair (bucket=128): 305s で完走、OOM なし
  - 50-pair (bucket=128): p50=1.72s (30 runs)
  - dispatch log: `batch_size=3 sub_batch_count=1 bucket_len=128` 確認
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all -- --check` clean
