### PR TITLE
chore(workspace): workspace.dependencies/lints 移行と deny.toml 厳格化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,53 @@
 [workspace]
 members = [".", "crates/rurico-ffi"]
 
+[workspace.dependencies]
+bytemuck = "1"
+hf-hub = "0.5"
+mlx-rs = "0.25"
+mlx-sys = "0.2"
+rand = "0.10"
+rand_chacha = "0.10"
+rusqlite = { version = "0.39", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlite-vec = "0.1.9"
+thiserror = "2"
+tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+unicode-normalization = "0.1"
+
+# dev-only (members consume under [dev-dependencies])
+serial_test = "3"
+temp-env = "0.3"
+tempfile = "3"
+tracing-test = "0.2"
+
+[workspace.lints.rust]
+# `deny` (not `forbid`) so the FFI crate can keep `#[allow(unsafe_code)]` on
+# the few `unsafe extern` blocks it owns, while `unsafe` written in any other
+# member fails the build.
+unsafe_code = "deny"
+
+[workspace.lints.clippy]
+# absolute paths
+absolute_paths = "deny"
+# idiomatic iterators
+cast_possible_truncation = "deny"
+redundant_closure_for_method_calls = "deny"
+filter_map_next = "deny"
+flat_map_option = "deny"
+manual_filter_map = "deny"
+manual_find_map = "deny"
+# imports
+wildcard_imports = "deny"
+enum_glob_use = "deny"
+# strings
+str_to_string = "deny"
+# arguments
+needless_pass_by_value = "deny"
+
 [package]
 name = "rurico"
 version = "0.2.0"
@@ -29,47 +76,29 @@ name = "mlx_smoke"
 required-features = ["smoke"]
 
 [dependencies]
-bytemuck = "1"
-hf-hub = "0.5"
-mlx-rs = "0.25"
-rand = "0.10"
-rand_chacha = "0.10"
-rusqlite = { version = "0.39", features = ["bundled"] }
+bytemuck = { workspace = true }
+hf-hub = { workspace = true }
+mlx-rs = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+rusqlite = { workspace = true }
 rurico-ffi = { path = "crates/rurico-ffi" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
-tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
-unicode-normalization = "0.1"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokenizers = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
+unicode-normalization = { workspace = true }
 
 [dev-dependencies]
-serial_test = "3"
-temp-env = "0.3"
-tempfile = "3"
-tracing-test = "0.2"
+serial_test = { workspace = true }
+temp-env = { workspace = true }
+tempfile = { workspace = true }
+tracing-test = { workspace = true }
 
-[lints.rust]
-unsafe_code = "forbid"
-
-[lints.clippy]
-# absolute paths
-absolute_paths = "deny"
-# idiomatic iterators
-cast_possible_truncation = "deny"
-redundant_closure_for_method_calls = "deny"
-filter_map_next = "deny"
-flat_map_option = "deny"
-manual_filter_map = "deny"
-manual_find_map = "deny"
-# imports
-wildcard_imports = "deny"
-enum_glob_use = "deny"
-# strings
-str_to_string = "deny"
-# arguments
-needless_pass_by_value = "deny"
+[lints]
+workspace = true
 
 [profile.release]
 opt-level = 3

--- a/crates/rurico-ffi/Cargo.toml
+++ b/crates/rurico-ffi/Cargo.toml
@@ -7,10 +7,10 @@ description = "Safe FFI wrappers for rurico (mlx-sys, sqlite-vec)"
 license = "MIT"
 publish = false
 
-[lints.rust]
-unsafe_code = "deny"
-
 [dependencies]
-mlx-sys = "0.2"
-rusqlite = { version = "0.39", features = ["bundled"] }
-sqlite-vec = "0.1.9"
+mlx-sys = { workspace = true }
+rusqlite = { workspace = true }
+sqlite-vec = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/rurico-ffi/src/storage.rs
+++ b/crates/rurico-ffi/src/storage.rs
@@ -1,6 +1,9 @@
 //! Safe wrapper for sqlite-vec FFI registration.
 
-use rusqlite::ffi::sqlite3_auto_extension;
+use std::mem::transmute;
+use std::os::raw::{c_char, c_int};
+
+use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
 use sqlite_vec::sqlite3_vec_init;
 
 /// Register sqlite-vec as a process-global SQLite auto-extension.
@@ -17,13 +20,13 @@ pub fn sqlite_vec_register() -> i32 {
     // are C fn pointers with compatible calling conventions; SQLite calls the
     // function with the correct arguments at connection open time.
     unsafe {
-        sqlite3_auto_extension(Some(std::mem::transmute::<
+        sqlite3_auto_extension(Some(transmute::<
             unsafe extern "C" fn(),
             unsafe extern "C" fn(
-                *mut rusqlite::ffi::sqlite3,
-                *mut *mut std::os::raw::c_char,
-                *const rusqlite::ffi::sqlite3_api_routines,
-            ) -> std::os::raw::c_int,
+                *mut sqlite3,
+                *mut *mut c_char,
+                *const sqlite3_api_routines,
+            ) -> c_int,
         >(sqlite3_vec_init)))
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,8 @@
 [advisories]
 version = 2
 ignore = [
-    # paste is archived (no safe upgrade); used transitively by tokenizers and mlx-rs.
-    # Suppress until upstream crates migrate away from it.
+    # paste archived (no safe upgrade); transitive via tokenizers and mlx-rs.
+    # Review by: 2026-11-07.
     "RUSTSEC-2024-0436",
 ]
 
@@ -25,8 +25,12 @@ allow = [
 ]
 
 [bans]
+# Warn, not deny: dedup blocked on upstream consolidation
+# (tokenizers / hf-hub / mlx-rs). Tracked: #95 follow-up.
 multiple-versions = "warn"
-wildcards = "allow"
+wildcards = "deny"
+# Path deps omit a version field; keeps `wildcards = "deny"` scoped to crates.io.
+allow-wildcard-paths = true
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
## What & Why

`Cargo.toml` の共有 dep / clippy lint set / `unsafe_code` が root と `rurico-ffi` で個別宣言されており、bump 漏れや lint strictness の drift が起きうる構造だった。今回 `[workspace.dependencies]` / `[workspace.lints]` に集約して member は継承する形に揃え、新 child crate を追加した時にも自動で同じ strictness が適用されるようにした。

## Changes

- `Cargo.toml`: 共有 dep 19 件を `[workspace.dependencies]` に集約。clippy canonical set + `unsafe_code = "deny"` を `[workspace.lints]` に移行。member は `dep = { workspace = true }` / `[lints] workspace = true` で継承。
- `crates/rurico-ffi/Cargo.toml`: dep を workspace 継承形式に切替、`[lints]` も workspace 継承。
- `crates/rurico-ffi/src/storage.rs`: 上記 lint 継承で FFI にも `clippy::absolute_paths = "deny"` が初めて適用された結果、`std::mem::transmute` / `std::os::raw::{c_char, c_int}` / `rusqlite::ffi::{sqlite3, sqlite3_api_routines}` を `use` で scope に持ってきた。
- `deny.toml`: `wildcards = "deny"` (workspace path dep は `allow-wildcard-paths = true` で例外)。`RUSTSEC-2024-0436` suppression に review 期限 (2026-11-07) と tracking 注を追加。

## Scope

- **含めない**: features の `default-features = false` 化 + 個別 features 列挙。default のまま workspace 集約だけに留めた (機能変更ゼロを優先)。
- **含めない**: `multiple-versions = "deny"` 化。transitive で 14 重複あり、`[[bans.skip-tree]]` 列挙が大規模。上流 (tokenizers/hf-hub/mlx-rs) の収束待ちで本 PR では `warn` 維持。

## Design Decisions

- **`unsafe_code` を workspace で `deny` に統一 (root の `forbid` から微緩和)**: Cargo の `[lints] workspace = true` は member 側の `[lints.rust]` 併記が不可、かつ `forbid` は member override 不可。「root forbid + FFI deny」を Cargo 設定だけで両立できないため、新 child crate 追加時に自動で同 strictness が適用される A 案 (workspace deny 統一) を選んだ。理論的に root 側で `#[allow(unsafe_code)]` の局所 unblock が可能になるが、PR review + cargo-deny / clippy で catch 可能、root に unsafe を書く動機もほぼ無いため実害は限定的。
- **`multiple-versions = "warn"` 維持**: 14 件全て transitive で上流 (tokenizers/hf-hub/mlx-rs) の収束待ち。`deny` 化には skip-tree 列挙が必要だが drift 主体は上流なので、警告のみで track。
- **`allow-wildcard-paths = true` を追加**: `rurico-ffi = { path = ... }` を `wildcards = "deny"` の対象外にし、`crates.io` 由来の wildcard だけ block する。

## How to Test

```bash
cargo build --workspace
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace
cargo fmt --check
cargo deny check
```

全コマンドが pass することを確認 (advisories ok, bans ok, licenses ok, sources ok)。

## Related

- Closes #95
