### PR TITLE
fix(types): as cast を try_from / checked_mul に置換

### DIFF
--- a/src/embed/fixtures.rs
+++ b/src/embed/fixtures.rs
@@ -118,13 +118,14 @@ pub fn load<R: Read>(r: &mut R) -> io::Result<Vec<ChunkedEmbedding>> {
         let mut chunks = Vec::with_capacity(num_chunks);
         for _ in 0..num_chunks {
             let dim = u32_to_usize(read_u32(r)?, "hidden_dim")?;
-            // `dim * 4` (bytes per chunk) overflows `usize` on 32-bit targets when
-            // `dim > usize::MAX / 4`; `checked_mul` surfaces a clear error instead
-            // of panicking. On 64-bit targets the check is effectively unreachable.
-            let bytes_len = dim.checked_mul(4).ok_or_else(|| {
+            // `dim * size_of::<f32>()` (bytes per chunk) overflows `usize` on
+            // 32-bit targets when `dim > usize::MAX / 4`; `checked_mul` surfaces a
+            // clear error instead of panicking. Unreachable on 64-bit.
+            const BYTES_PER_F32: usize = size_of::<f32>();
+            let bytes_len = dim.checked_mul(BYTES_PER_F32).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("hidden_dim ({dim}) * 4 overflows usize"),
+                    format!("hidden_dim ({dim}) * {BYTES_PER_F32} overflows usize"),
                 )
             })?;
             let mut bytes = vec![0u8; bytes_len];
@@ -138,8 +139,9 @@ pub fn load<R: Read>(r: &mut R) -> io::Result<Vec<ChunkedEmbedding>> {
 }
 
 /// Convert a `u32` header field to `usize`, returning a structured `InvalidData`
-/// error on platforms where the value would not fit (16-bit `usize` only;
-/// fail closed on 32/64-bit by virtue of `From<u32> for usize`).
+/// error if the value cannot fit. Only fails on 16-bit `usize` targets; on
+/// 32/64-bit, `From<u32> for usize` makes the conversion infallible — the
+/// `Err` arm exists for type-system completeness, not as a runtime guard.
 fn u32_to_usize(value: u32, field: &'static str) -> io::Result<usize> {
     usize::try_from(value).map_err(|_| {
         io::Error::new(
@@ -363,22 +365,32 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
-    // Corrupt header: a chunk claims `dim = u32::MAX` but the payload is
-    // empty. `usize::try_from` succeeds (u32 always fits in usize on
-    // 64-bit), and `dim.checked_mul(4)` succeeds (`4 * u32::MAX < usize::MAX`
-    // on 64-bit), so allocation proceeds and `read_exact` fails with
-    // `UnexpectedEof` rather than over-allocating undetected.
+    // Corrupt header: a chunk declares `dim` but the f32 payload is shorter
+    // than `dim * 4` bytes, so `read_exact` fails with `UnexpectedEof` after
+    // a small bounded allocation. Uses a small `dim` to avoid the 16 GiB
+    // allocation that `dim = u32::MAX` would force on 64-bit hosts.
     #[test]
-    fn load_rejects_chunk_with_oversize_dim_and_empty_payload() {
+    fn load_rejects_chunk_with_truncated_payload() {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(&1u32.to_le_bytes()); // num_docs = 1
         bytes.extend_from_slice(&1u32.to_le_bytes()); // num_chunks = 1
-        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // dim = u32::MAX, payload missing
-        let err = load(&mut Cursor::new(&bytes)).expect_err("oversize dim with no payload errors");
-        // 64-bit: allocation succeeds, read_exact hits EOF; 32-bit: checked_mul rejects.
-        assert!(matches!(
-            err.kind(),
-            io::ErrorKind::UnexpectedEof | io::ErrorKind::InvalidData
-        ));
+        bytes.extend_from_slice(&64u32.to_le_bytes()); // dim = 64 → expects 256 payload bytes
+        bytes.extend_from_slice(&[0u8; 16]); // only 16 bytes of payload
+        let err = load(&mut Cursor::new(&bytes)).expect_err("truncated payload must error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    // 32-bit-only: `dim.checked_mul(4)` overflows `usize` on 32-bit targets
+    // when `dim > usize::MAX / 4`. Gated to avoid the 16 GiB allocation that
+    // would happen on 64-bit hosts before `read_exact` could return.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn load_rejects_dim_times_4_overflow_on_32bit() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_docs = 1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_chunks = 1
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // dim = u32::MAX → dim * 4 overflows usize
+        let err = load(&mut Cursor::new(&bytes)).expect_err("dim * 4 overflow must error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/src/embed/fixtures.rs
+++ b/src/embed/fixtures.rs
@@ -111,14 +111,23 @@ pub fn save<W: Write>(w: &mut W, docs: &[ChunkedEmbedding]) -> io::Result<()> {
 /// Uses buffered reads per chunk. Callers reading from a [`std::fs::File`]
 /// should wrap it in a [`std::io::BufReader`] to avoid one syscall per chunk.
 pub fn load<R: Read>(r: &mut R) -> io::Result<Vec<ChunkedEmbedding>> {
-    let num_docs = read_u32(r)? as usize;
+    let num_docs = u32_to_usize(read_u32(r)?, "num_docs")?;
     let mut docs = Vec::with_capacity(num_docs);
     for _ in 0..num_docs {
-        let num_chunks = read_u32(r)? as usize;
+        let num_chunks = u32_to_usize(read_u32(r)?, "num_chunks")?;
         let mut chunks = Vec::with_capacity(num_chunks);
         for _ in 0..num_chunks {
-            let dim = read_u32(r)? as usize;
-            let mut bytes = vec![0u8; dim * 4];
+            let dim = u32_to_usize(read_u32(r)?, "hidden_dim")?;
+            // `dim * 4` (bytes per chunk) overflows `usize` on 32-bit targets when
+            // `dim > usize::MAX / 4`; `checked_mul` surfaces a clear error instead
+            // of panicking. On 64-bit targets the check is effectively unreachable.
+            let bytes_len = dim.checked_mul(4).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("hidden_dim ({dim}) * 4 overflows usize"),
+                )
+            })?;
+            let mut bytes = vec![0u8; bytes_len];
             r.read_exact(&mut bytes)?;
             let vec: Vec<f32> = bytemuck::cast_slice::<u8, f32>(&bytes).to_vec();
             chunks.push(vec);
@@ -126,6 +135,18 @@ pub fn load<R: Read>(r: &mut R) -> io::Result<Vec<ChunkedEmbedding>> {
         docs.push(ChunkedEmbedding::new(chunks));
     }
     Ok(docs)
+}
+
+/// Convert a `u32` header field to `usize`, returning a structured `InvalidData`
+/// error on platforms where the value would not fit (16-bit `usize` only;
+/// fail closed on 32/64-bit by virtue of `From<u32> for usize`).
+fn u32_to_usize(value: u32, field: &'static str) -> io::Result<usize> {
+    usize::try_from(value).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("{field} ({value}) exceeds usize"),
+        )
+    })
 }
 
 /// Compare two fixtures element-wise.
@@ -329,5 +350,35 @@ mod tests {
     fn default_tolerances_match_spec_nfr_001() {
         assert!((DEFAULT_COSINE_MIN - 0.99999).abs() < f32::EPSILON);
         assert!((DEFAULT_MAX_ABS_DIFF - 1e-5).abs() < f32::EPSILON);
+    }
+
+    // Corrupt header: stream ends after `num_docs = 1` so reading the
+    // first `num_chunks` u32 fails with `UnexpectedEof`. The previous
+    // `as usize` cast read whatever the partial buffer happened to contain
+    // and could trigger a multi-GB `Vec::with_capacity` on hostile input.
+    #[test]
+    fn load_rejects_truncated_header_after_num_docs() {
+        let bytes = (1u32).to_le_bytes().to_vec();
+        let err = load(&mut Cursor::new(&bytes)).expect_err("truncated header must error");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    // Corrupt header: a chunk claims `dim = u32::MAX` but the payload is
+    // empty. `usize::try_from` succeeds (u32 always fits in usize on
+    // 64-bit), and `dim.checked_mul(4)` succeeds (`4 * u32::MAX < usize::MAX`
+    // on 64-bit), so allocation proceeds and `read_exact` fails with
+    // `UnexpectedEof` rather than over-allocating undetected.
+    #[test]
+    fn load_rejects_chunk_with_oversize_dim_and_empty_payload() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_docs = 1
+        bytes.extend_from_slice(&1u32.to_le_bytes()); // num_chunks = 1
+        bytes.extend_from_slice(&u32::MAX.to_le_bytes()); // dim = u32::MAX, payload missing
+        let err = load(&mut Cursor::new(&bytes)).expect_err("oversize dim with no payload errors");
+        // 64-bit: allocation succeeds, read_exact hits EOF; 32-bit: checked_mul rejects.
+        assert!(matches!(
+            err.kind(),
+            io::ErrorKind::UnexpectedEof | io::ErrorKind::InvalidData
+        ));
     }
 }

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -130,11 +130,17 @@ impl PhaseMetrics {
 }
 
 /// `padded / real`. Returns `0.0` when `real == 0` to avoid division by zero.
+///
+/// Computed in f64 to preserve precision when token counts exceed 2^24
+/// (production batches at MAX_SEQ_LEN × TOKEN_BUDGET approach this range);
+/// the f64→f32 narrowing is safe because the ratio is bounded near 1.0–10.0.
+#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 pub(super) fn padding_ratio(real: usize, padded: usize) -> f32 {
     if real == 0 {
         return 0.0;
     }
-    padded as f32 / real as f32
+    let ratio = padded as f64 / real as f64;
+    ratio as f32
 }
 
 #[cfg(test)]

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -63,14 +63,17 @@ pub(super) fn distribute_into_buckets(chunks: Vec<IndexedChunk>) -> [Vec<Indexed
 fn build_indexed_chunks(
     all_chunk_tokens: Vec<Vec<u32>>,
     chunks_per_doc: &[usize],
-) -> Vec<IndexedChunk> {
+) -> Result<Vec<IndexedChunk>, EmbedError> {
     let mut result = Vec::with_capacity(all_chunk_tokens.len());
     let mut tokens_iter = all_chunk_tokens.into_iter();
     for (doc_idx, &count) in chunks_per_doc.iter().enumerate() {
         for chunk_in_doc in 0..count {
-            let tokens = tokens_iter
-                .next()
-                .expect("chunks_per_doc total must match all_chunk_tokens length");
+            let tokens = tokens_iter.next().ok_or_else(|| {
+                EmbedError::inference(format!(
+                    "chunks_per_doc total exceeds all_chunk_tokens length \
+                     (doc_idx={doc_idx}, chunk_in_doc={chunk_in_doc})"
+                ))
+            })?;
             result.push(IndexedChunk {
                 global_idx: result.len(),
                 doc_idx,
@@ -79,11 +82,12 @@ fn build_indexed_chunks(
             });
         }
     }
-    debug_assert!(
-        tokens_iter.next().is_none(),
-        "chunks_per_doc total must match all_chunk_tokens length"
-    );
-    result
+    if tokens_iter.next().is_some() {
+        return Err(EmbedError::inference(
+            "all_chunk_tokens length exceeds chunks_per_doc total",
+        ));
+    }
+    Ok(result)
 }
 
 pub(super) struct EmbedderInner {
@@ -246,7 +250,7 @@ impl EmbedderInner {
         metrics.num_chunks = total_chunks;
 
         let buckets =
-            distribute_into_buckets(build_indexed_chunks(all_chunk_tokens, &chunks_per_doc));
+            distribute_into_buckets(build_indexed_chunks(all_chunk_tokens, &chunks_per_doc)?);
 
         let mut out: Vec<Option<Vec<f32>>> = (0..total_chunks).map(|_| None).collect();
 
@@ -272,11 +276,19 @@ impl EmbedderInner {
         let batch_metrics = BatchMetrics::from(&metrics);
 
         // Invariant: each global_idx was written exactly once across all bucket
-        // forwards. None here signals a distribution or unpack bug, not input.
+        // forwards. None here signals a distribution or unpack bug, not input —
+        // surfaced as `Inference` so a regression cannot panic in production.
         let all_embeddings: Vec<Vec<f32>> = out
             .into_iter()
-            .map(|slot| slot.expect("every chunk slot must be filled by bucket forward"))
-            .collect();
+            .enumerate()
+            .map(|(idx, slot)| {
+                slot.ok_or_else(|| {
+                    EmbedError::inference(format!(
+                        "chunk slot {idx} not filled by any bucket forward (distribution bug)"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let mut results = Vec::with_capacity(texts.len());
         let mut iter = all_embeddings.into_iter();
@@ -684,7 +696,8 @@ mod tests {
     fn build_indexed_chunks_tracks_doc_structure() {
         // doc 0 has 2 chunks, doc 1 has 1 chunk → chunks_per_doc = [2, 1]
         let all_chunks = vec![vec![1u32; 10], vec![2u32; 20], vec![3u32; 30]];
-        let indexed = build_indexed_chunks(all_chunks, &[2, 1]);
+        let indexed = build_indexed_chunks(all_chunks, &[2, 1])
+            .expect("balanced chunks_per_doc and all_chunk_tokens must build ok");
         let shape: Vec<(usize, usize, usize, usize)> = indexed
             .iter()
             .map(|c| (c.global_idx, c.doc_idx, c.chunk_in_doc, c.tokens.len()))
@@ -694,6 +707,26 @@ mod tests {
             vec![(0, 0, 0, 10), (1, 0, 1, 20), (2, 1, 0, 30)],
             "global_idx runs 0..N while doc_idx + chunk_in_doc track doc layout"
         );
+    }
+
+    // Defense-in-depth: a regression that emits more `chunks_per_doc` than
+    // chunks (e.g., wrong loop bound) previously panicked via
+    // `expect("chunks_per_doc total must match all_chunk_tokens length")`.
+    // The Result variant surfaces it as a structured EmbedError instead.
+    #[test]
+    fn build_indexed_chunks_rejects_chunks_per_doc_excess() {
+        let all_chunks = vec![vec![1u32; 10]];
+        let err = build_indexed_chunks(all_chunks, &[2])
+            .expect_err("chunks_per_doc total > all_chunk_tokens length must error");
+        assert!(matches!(err, EmbedError::Inference(_)));
+    }
+
+    #[test]
+    fn build_indexed_chunks_rejects_all_chunk_tokens_excess() {
+        let all_chunks = vec![vec![1u32; 10], vec![2u32; 20]];
+        let err = build_indexed_chunks(all_chunks, &[1])
+            .expect_err("all_chunk_tokens length > chunks_per_doc total must error");
+        assert!(matches!(err, EmbedError::Inference(_)));
     }
 
     // T-BKT-007: 10 chunks spanning all 4 buckets round-trip in original order
@@ -745,7 +778,7 @@ mod tests {
     // collect to `Vec::new()`. MLX-free proxy for the end-to-end contract.
     #[test]
     fn t_bkt_009_empty_input_zero_subbatches() {
-        let indexed = build_indexed_chunks(Vec::new(), &[]);
+        let indexed = build_indexed_chunks(Vec::new(), &[]).expect("empty inputs must build ok");
         assert!(
             indexed.is_empty(),
             "empty chunk tokens → empty IndexedChunk vec"

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -83,9 +83,10 @@ fn build_indexed_chunks(
         }
     }
     if tokens_iter.next().is_some() {
-        return Err(EmbedError::inference(
-            "all_chunk_tokens length exceeds chunks_per_doc total",
-        ));
+        let extras = tokens_iter.count() + 1;
+        return Err(EmbedError::inference(format!(
+            "all_chunk_tokens has {extras} more entries than chunks_per_doc total"
+        )));
     }
     Ok(result)
 }
@@ -718,7 +719,13 @@ mod tests {
         let all_chunks = vec![vec![1u32; 10]];
         let err = build_indexed_chunks(all_chunks, &[2])
             .expect_err("chunks_per_doc total > all_chunk_tokens length must error");
-        assert!(matches!(err, EmbedError::Inference(_)));
+        match err {
+            EmbedError::Inference(msg) => assert!(
+                msg.contains("chunks_per_doc total exceeds"),
+                "expected chunks_per_doc-side error wording, got: {msg}"
+            ),
+            other => panic!("expected Inference, got {other:?}"),
+        }
     }
 
     #[test]
@@ -726,7 +733,13 @@ mod tests {
         let all_chunks = vec![vec![1u32; 10], vec![2u32; 20]];
         let err = build_indexed_chunks(all_chunks, &[1])
             .expect_err("all_chunk_tokens length > chunks_per_doc total must error");
-        assert!(matches!(err, EmbedError::Inference(_)));
+        match err {
+            EmbedError::Inference(msg) => assert!(
+                msg.contains("all_chunk_tokens has 1 more"),
+                "expected extras count in surplus-side error wording, got: {msg}"
+            ),
+            other => panic!("expected Inference, got {other:?}"),
+        }
     }
 
     // T-BKT-007: 10 chunks spanning all 4 buckets round-trip in original order

--- a/src/modernbert/config.rs
+++ b/src/modernbert/config.rs
@@ -77,8 +77,11 @@ impl Config {
             return Err("max_position_embeddings must be > 0".into());
         }
         // `local_attention / 2` is cast to i32 when building the local-attention mask.
-        let max_local = (i32::MAX as usize).saturating_mul(2).saturating_add(1);
-        if self.local_attention > max_local {
+        // Compute the bound in u64 so the check stays correct on 32-bit `usize`
+        // targets, where `(i32::MAX as usize).saturating_mul(2)` would clamp to
+        // `usize::MAX` and silently widen the accepted range.
+        let max_local: u64 = (i32::MAX as u64) * 2 + 1;
+        if self.local_attention as u64 > max_local {
             return Err(format!(
                 "local_attention must be <= {max_local} (local_attention / 2 must fit in i32)"
             ));

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -35,8 +35,8 @@ impl Attention {
         rope_theta: f32,
         uses_local_attention: bool,
     ) -> Result<Self, Exception> {
-        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
-        let num_heads = i32::try_from(config.num_attention_heads).expect("bounded by model config");
+        let h = config_dim_to_i32("hidden_size", config.hidden_size)?;
+        let num_heads = config_dim_to_i32("num_attention_heads", config.num_attention_heads)?;
         let head_dim = h / num_heads;
 
         #[allow(non_snake_case)]
@@ -110,8 +110,8 @@ struct Mlp {
 
 impl Mlp {
     fn new(config: &Config) -> Result<Self, Exception> {
-        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
-        let inter = i32::try_from(config.intermediate_size).expect("bounded by model config");
+        let h = config_dim_to_i32("hidden_size", config.hidden_size)?;
+        let inter = config_dim_to_i32("intermediate_size", config.intermediate_size)?;
         #[allow(non_snake_case)]
         let Wi = nn::LinearBuilder::new(h, inter * 2).bias(false).build()?;
         #[allow(non_snake_case)]
@@ -145,7 +145,7 @@ impl TransformerLayer {
     fn new(config: &Config, layer_id: usize) -> Result<Self, Exception> {
         let uses_local = !layer_id.is_multiple_of(config.global_attn_every_n_layers);
         let rope_theta = rope_theta_f32(config, uses_local);
-        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let h = config_dim_to_i32("hidden_size", config.hidden_size)?;
         let eps = layer_norm_eps_f32(config);
 
         let attn_norm = nn::LayerNormBuilder::new(h).eps(eps).build()?;
@@ -226,9 +226,9 @@ impl ModernBert {
         config
             .validate()
             .map_err(|e| Exception::custom(format!("invalid config: {e}")))?;
-        let h = i32::try_from(config.hidden_size).expect("bounded by model config");
+        let h = config_dim_to_i32("hidden_size", config.hidden_size)?;
         let eps = layer_norm_eps_f32(config);
-        let vocab_size = i32::try_from(config.vocab_size).expect("bounded by model config");
+        let vocab_size = config_dim_to_i32("vocab_size", config.vocab_size)?;
 
         let tok_embeddings = nn::Embedding::new(vocab_size, h)?;
         let emb_norm = nn::LayerNormBuilder::new(h).eps(eps).build()?;
@@ -320,7 +320,7 @@ impl ModernBert {
         assert_len("input_ids", input_ids)?;
         assert_len("attention_mask", attention_mask)?;
 
-        let max_seq = i32::try_from(self.max_seq_len).expect("bounded by model config");
+        let max_seq = config_dim_to_i32("max_seq_len", self.max_seq_len)?;
         if seq_len > max_seq {
             // Defense-in-depth: truncate oversize inputs, validating only the effective prefix.
             tracing::warn!(
@@ -364,7 +364,7 @@ impl ModernBert {
         let local_mask = if let Some(cached) = self.local_mask_cache.get(&seq_len) {
             cached.clone()
         } else {
-            let half = i32::try_from(self.local_attention_half).expect("bounded by model config");
+            let half = config_dim_to_i32("local_attention_half", self.local_attention_half)?;
             let m = get_local_attention_mask(seq_len, half)?;
             self.local_mask_cache.insert(seq_len, m.clone());
             m
@@ -381,6 +381,18 @@ impl ModernBert {
 // Use a large negative instead of -inf to avoid 0.0 * (-inf) = NaN on Metal kernels
 // for certain sequence lengths (threshold ~9 tokens on Apple Silicon).
 const MASK_FILL: f32 = -1e9;
+
+/// Cast a `usize` config-derived dimension to `i32`, returning a structured
+/// error when it exceeds `i32::MAX`. [`Config::validate`] already enforces the
+/// bound for every field passed here; the `Err` arm is defense-in-depth against
+/// a regression that constructs a `Config` without going through `validate`.
+fn config_dim_to_i32(name: &str, value: usize) -> Result<i32, Exception> {
+    i32::try_from(value).map_err(|_| {
+        Exception::custom(format!(
+            "{name} ({value}) exceeds i32::MAX (config invariant violation)"
+        ))
+    })
+}
 
 // Model config constant; layer norm epsilon fits in f32.
 #[allow(clippy::cast_possible_truncation)]
@@ -438,11 +450,20 @@ fn validate_attention_mask(mask: &[u32], seq_len: usize) -> Result<(), Exception
 }
 
 fn get_local_attention_mask(seq_len: i32, half_window: i32) -> Result<Array, Exception> {
-    let n = seq_len as usize;
-    let hw = half_window as usize;
+    let n = usize::try_from(seq_len)
+        .map_err(|_| Exception::custom(format!("seq_len ({seq_len}) must be non-negative")))?;
+    let hw = usize::try_from(half_window).map_err(|_| {
+        Exception::custom(format!("half_window ({half_window}) must be non-negative"))
+    })?;
+    // `n * n` allocation is bounded by callers (`run_forward` passes `seq_len <=
+    // max_position_embeddings`); `checked_mul` is defense-in-depth against a
+    // regression that bypasses that gate.
+    let n_squared = n
+        .checked_mul(n)
+        .ok_or_else(|| Exception::custom(format!("seq_len ({n}) squared overflows usize")))?;
     // NEG_INFINITY is safe here: values are written directly, never multiplied by a mask array,
     // so the 0.0 * (-inf) = NaN Metal hazard (see MASK_FILL) does not apply.
-    let mut data = vec![f32::NEG_INFINITY; n * n];
+    let mut data = vec![f32::NEG_INFINITY; n_squared];
     for i in 0..n {
         let lo = i.saturating_sub(hw);
         let hi = (i + hw + 1).min(n);
@@ -539,6 +560,52 @@ mod tests {
         assert!(validate_attention_mask(&[1, 1, 1], 3).is_ok());
         // multi-row valid batch: row 0 = [1,1,0], row 1 = [1,0,1]
         assert!(validate_attention_mask(&[1, 1, 0, 1, 0, 1], 3).is_ok());
+    }
+
+    // Defense-in-depth: a negative `seq_len` previously produced a giant
+    // `usize` via `as` cast, allocating gigabytes before `Array::from_slice`
+    // ever ran. `usize::try_from` now rejects it as a structured Exception.
+    #[test]
+    fn get_local_attention_mask_rejects_negative_seq_len() {
+        let err = get_local_attention_mask(-1, 1).expect_err("negative seq_len must error");
+        assert!(
+            err.what().contains("seq_len"),
+            "error message should reference seq_len, got: {}",
+            err.what()
+        );
+    }
+
+    #[test]
+    fn get_local_attention_mask_rejects_negative_half_window() {
+        let err = get_local_attention_mask(8, -1).expect_err("negative half_window must error");
+        assert!(
+            err.what().contains("half_window"),
+            "error message should reference half_window, got: {}",
+            err.what()
+        );
+    }
+
+    // Defense-in-depth: `config_dim_to_i32` Err path is unreachable after a
+    // valid `Config::validate()` since `validate` already enforces the i32
+    // bound. The test exercises the helper directly so a regression that
+    // skips `validate` cannot panic in a hot forward.
+    #[test]
+    fn config_dim_to_i32_rejects_value_above_i32_max() {
+        let err = config_dim_to_i32("hidden_size", (i32::MAX as usize) + 1)
+            .expect_err("value above i32::MAX must error");
+        assert!(
+            err.what().contains("hidden_size"),
+            "error message should reference field name, got: {}",
+            err.what()
+        );
+    }
+
+    #[test]
+    fn config_dim_to_i32_accepts_value_at_i32_max() {
+        assert_eq!(
+            config_dim_to_i32("hidden_size", i32::MAX as usize).unwrap(),
+            i32::MAX
+        );
     }
 
     /// MLX runtime tests — may abort due to foreign exceptions from mlx-rs FFI.


### PR DESCRIPTION
## 概要

- `as` cast と production の `expect` を構造化エラーに昇格、config invariant regression が embed hot path で panic しないように
- `model.rs` の `i32::try_from(...).expect("bounded by model config")` 9 箇所を `config_dim_to_i32` helper で置換 (issue は 3 箇所指定、DRY hygiene として拡張)
- `build_indexed_chunks` を `expect` + `debug_assert!` から `Result<_, EmbedError>` に変更、production regression を panic でなく構造化エラーで surface
- fixture の `u32` header を `usize::try_from` + `checked_mul` で gate、32-bit 安全性確保
- `local_attention` の上限値を `u64` 経由で計算、32-bit `usize` でも正確
- `padding_ratio` を `f64` 計算に昇格、production token 数での精度を維持

## スコープ

Issue は `model.rs:223-225` の 3 箇所 (TYP-014) を指定。同パターン `bounded by model config` expect が production で計 9 箇所あり、`config_dim_to_i32` helper 1 個で全部 DRY 化 (3+ duplications threshold)。

## テスト計画

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — 318 passed, 0 failed
- [x] 防御テスト 8 件追加 (corrupt fixture / negative i32 / config bound / chunks_per_doc mismatch)
- [x] `/polish` review — codex P1 修正 (16 GiB test allocation)、simplify clean、coderabbit clean

## downstream 追従

API 影響なし (内部実装のみ)。merge 後、amici / yomu / recall / sae の 4 リポに `Cargo.toml` rev bump 追従 issue を作成。

Closes #99