### PR TITLE
refactor(observability): tracing emit site を構造化フィールドに統一

### DIFF
--- a/src/bin/mlx_smoke.rs
+++ b/src/bin/mlx_smoke.rs
@@ -44,13 +44,16 @@ use rurico::sandbox;
 /// visible when this binary runs, without forcing a subscriber on library
 /// consumers.
 fn init_tracing_subscriber() {
-    let _ = tracing_subscriber::fmt()
+    if let Err(e) = tracing_subscriber::fmt()
         .with_writer(stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug")),
         )
-        .try_init();
+        .try_init()
+    {
+        eprintln!("mlx_smoke: tracing subscriber init failed: {e}");
+    }
 }
 
 fn main() {

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -34,7 +34,11 @@ impl Embedder {
     pub fn new(artifacts: &Artifacts) -> Result<Self, ModelInitError> {
         let inner = EmbedderInner::new(artifacts)?;
         let embedding_dims = inner.embedding_dims();
-        tracing::info!(embedding_dims, "embedder: model loaded");
+        tracing::info!(
+            embedding_dims,
+            model_path = ?artifacts.paths.model,
+            "embedder: model loaded"
+        );
         Ok(Self {
             inner: Mutex::new(inner),
             embedding_dims,

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -96,36 +96,30 @@ impl PhaseMetrics {
         padding_ratio(self.real_tokens, self.padded_tokens)
     }
 
-    fn format_log(&self) -> String {
-        format!(
-            "embed[{kind}] \
-             tokenize_ms={tokenize} chunk_plan_ms={plan} forward_eval_ms={forward} \
-             readback_pool_ms={readback} cache_clear_ms={clear} \
-             real_tokens={real} padded_tokens={padded} padding_ratio={ratio:.3} \
-             num_chunks={chunks} batch_size={batch} max_seq_len={max_seq} \
-             bucket_hist=[{h0},{h1},{h2},{h3}]",
-            kind = self.kind,
-            tokenize = self.tokenize.as_millis(),
-            plan = self.chunk_plan.as_millis(),
-            forward = self.forward_eval.as_millis(),
-            readback = self.readback_pool.as_millis(),
-            clear = self.cache_clear.as_millis(),
-            real = self.real_tokens,
-            padded = self.padded_tokens,
-            ratio = self.padding_ratio(),
-            chunks = self.num_chunks,
-            batch = self.batch_size,
-            max_seq = self.max_seq_len,
-            h0 = self.bucket_hist[0],
-            h1 = self.bucket_hist[1],
-            h2 = self.bucket_hist[2],
-            h3 = self.bucket_hist[3],
-        )
-    }
-
-    /// Emit one structured debug line summarising this call.
+    /// Emit one structured debug record summarising this call.
+    ///
+    /// Each phase timing and counter is a named field so subscribers can
+    /// filter or aggregate without parsing a format string (ADR 0007).
     pub(super) fn log(&self) {
-        tracing::debug!("{}", self.format_log());
+        tracing::debug!(
+            kind = self.kind,
+            tokenize_ms = self.tokenize.as_millis(),
+            chunk_plan_ms = self.chunk_plan.as_millis(),
+            forward_eval_ms = self.forward_eval.as_millis(),
+            readback_pool_ms = self.readback_pool.as_millis(),
+            cache_clear_ms = self.cache_clear.as_millis(),
+            real_tokens = self.real_tokens,
+            padded_tokens = self.padded_tokens,
+            padding_ratio = self.padding_ratio(),
+            num_chunks = self.num_chunks,
+            batch_size = self.batch_size,
+            max_seq_len = self.max_seq_len,
+            bucket_hist_0 = self.bucket_hist[0],
+            bucket_hist_1 = self.bucket_hist[1],
+            bucket_hist_2 = self.bucket_hist[2],
+            bucket_hist_3 = self.bucket_hist[3],
+            "embed phase metrics",
+        );
     }
 }
 
@@ -145,6 +139,8 @@ pub(super) fn padding_ratio(real: usize, padded: usize) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    use tracing_test::traced_test;
+
     use super::*;
 
     // padding_ratio: safe on zero real, ratio = padded / real otherwise
@@ -188,17 +184,39 @@ mod tests {
         assert_eq!(m.padded_tokens, 0);
     }
 
-    // T-MET-001: format_log includes bucket_hist in the expected schema so
-    // smoke logs expose chunk-length distribution from a single line (AC-9).
+    // T-MET-001: log() emits named fields for the bucket histogram so
+    // subscribers can read per-bucket counts without parsing a format string
+    // (ADR 0007 / AC-9).
+    #[traced_test]
     #[test]
-    fn t_met_001_format_log_contains_bucket_hist() {
+    fn t_met_001_log_emits_named_bucket_hist_fields() {
         let mut m = PhaseMetrics::new("batch");
         m.bucket_hist = [3, 5, 2, 1];
         m.num_chunks = 11;
-        let line = m.format_log();
+        m.log();
         assert!(
-            line.contains("bucket_hist=[3,5,2,1]"),
-            "log line must match spec schema [N0,N1,N2,N3] (got: {line})"
+            logs_contain("bucket_hist_0=3"),
+            "expected named field bucket_hist_0=3 in subscriber output",
+        );
+        assert!(
+            logs_contain("bucket_hist_1=5"),
+            "expected named field bucket_hist_1=5 in subscriber output",
+        );
+        assert!(
+            logs_contain("bucket_hist_2=2"),
+            "expected named field bucket_hist_2=2 in subscriber output",
+        );
+        assert!(
+            logs_contain("bucket_hist_3=1"),
+            "expected named field bucket_hist_3=1 in subscriber output",
+        );
+        assert!(
+            logs_contain("num_chunks=11"),
+            "expected named field num_chunks=11 in subscriber output",
+        );
+        assert!(
+            logs_contain("embed phase metrics"),
+            "expected event message in subscriber output",
         );
     }
 

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -12,6 +12,23 @@
 
 use std::time::Duration;
 
+/// Identifies which embed entry point a phase record or warn emit came from.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) enum EmbedKind {
+    #[default]
+    Query,
+    Batch,
+}
+
+impl EmbedKind {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Query => "query",
+            Self::Batch => "batch",
+        }
+    }
+}
+
 /// Public batch-level metrics snapshot mirroring the `"batch"` [`PhaseMetrics`]
 /// record. Returned alongside embeddings by
 /// [`Embedder::embed_documents_batch_with_metrics`](super::Embedder::embed_documents_batch_with_metrics)
@@ -61,8 +78,8 @@ impl From<&PhaseMetrics> for BatchMetrics {
 /// Phase timings and batch counters for one `embed_*` call.
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct PhaseMetrics {
-    /// Identifies which entry point produced this record (e.g. `"query"`, `"batch"`).
-    pub kind: &'static str,
+    /// Identifies which entry point produced this record.
+    pub kind: EmbedKind,
     pub tokenize: Duration,
     pub chunk_plan: Duration,
     pub forward_eval: Duration,
@@ -84,7 +101,7 @@ pub(super) struct PhaseMetrics {
 }
 
 impl PhaseMetrics {
-    pub(super) fn new(kind: &'static str) -> Self {
+    pub(super) fn new(kind: EmbedKind) -> Self {
         Self {
             kind,
             ..Self::default()
@@ -99,10 +116,10 @@ impl PhaseMetrics {
     /// Emit one structured debug record summarising this call.
     ///
     /// Each phase timing and counter is a named field so subscribers can
-    /// filter or aggregate without parsing a format string (ADR 0007).
+    /// filter or aggregate without parsing a format string.
     pub(super) fn log(&self) {
         tracing::debug!(
-            kind = self.kind,
+            kind = self.kind.as_str(),
             tokenize_ms = self.tokenize.as_millis(),
             chunk_plan_ms = self.chunk_plan.as_millis(),
             forward_eval_ms = self.forward_eval.as_millis(),
@@ -179,18 +196,17 @@ mod tests {
 
     #[test]
     fn phase_metrics_new_sets_kind() {
-        let m = PhaseMetrics::new("query");
-        assert_eq!(m.kind, "query");
+        let m = PhaseMetrics::new(EmbedKind::Query);
+        assert_eq!(m.kind, EmbedKind::Query);
         assert_eq!(m.padded_tokens, 0);
     }
 
     // T-MET-001: log() emits named fields for the bucket histogram so
-    // subscribers can read per-bucket counts without parsing a format string
-    // (ADR 0007 / AC-9).
+    // subscribers can read per-bucket counts without parsing a format string.
     #[traced_test]
     #[test]
     fn t_met_001_log_emits_named_bucket_hist_fields() {
-        let mut m = PhaseMetrics::new("batch");
+        let mut m = PhaseMetrics::new(EmbedKind::Batch);
         m.bucket_hist = [3, 5, 2, 1];
         m.num_chunks = 11;
         m.log();

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -166,7 +166,7 @@ impl EmbedderInner {
 
             let t_readback = Instant::now();
             let flat: &[f32] = pooled.as_slice();
-            let pooled_vec = split_pooled(flat, 1, hidden_size)?
+            let pooled_vec = split_pooled(flat, 1, hidden_size, "query")?
                 .into_iter()
                 .next()
                 .expect("split_pooled(_, 1, _) yields one row");
@@ -177,12 +177,12 @@ impl EmbedderInner {
         let t_clear = Instant::now();
         let result = match outcome {
             Ok((pooled, pooled_vec)) => {
-                release_inference_output(pooled);
+                release_inference_output(pooled, "embed");
                 metrics.cache_clear = t_clear.elapsed();
                 Ok(pooled_vec)
             }
             Err(e) => {
-                clear_inference_cache();
+                clear_inference_cache("embed");
                 metrics.cache_clear = t_clear.elapsed();
                 Err(e)
             }
@@ -354,7 +354,7 @@ impl EmbedderInner {
 
             let t_readback = Instant::now();
             let flat: &[f32] = pooled.as_slice();
-            let unpacked = split_pooled(flat, batch_size, hidden_size)?;
+            let unpacked = split_pooled(flat, batch_size, hidden_size, "batch")?;
             metrics.readback_pool += t_readback.elapsed();
             Ok((pooled, unpacked))
         })();
@@ -362,12 +362,12 @@ impl EmbedderInner {
         let t_clear = Instant::now();
         let unpacked = match outcome {
             Ok((pooled, unpacked)) => {
-                release_inference_output(pooled);
+                release_inference_output(pooled, "embed");
                 metrics.cache_clear += t_clear.elapsed();
                 unpacked
             }
             Err(e) => {
-                clear_inference_cache();
+                clear_inference_cache("embed");
                 metrics.cache_clear += t_clear.elapsed();
                 return Err(e);
             }
@@ -470,6 +470,10 @@ pub(super) fn shrink_chunk_to_fit(
         if *end <= start {
             tracing::warn!(
                 start_token = start,
+                end_token = *end,
+                text_byte_start = byte_start,
+                text_total_bytes = text.len(),
+                total_offsets = offsets.len(),
                 "chunk cannot fit within MAX_SEQ_LEN after adaptive shrink"
             );
             return Err(EmbedError::inference(format!(
@@ -547,10 +551,12 @@ pub(super) fn split_pooled(
     flat: &[f32],
     batch_size: usize,
     hidden_size: usize,
+    call_site: &'static str,
 ) -> Result<Vec<Vec<f32>>, EmbedError> {
     let expected = batch_size.saturating_mul(hidden_size);
     if flat.len() != expected {
         tracing::warn!(
+            call_site,
             expected,
             actual = flat.len(),
             batch_size,
@@ -564,6 +570,7 @@ pub(super) fn split_pooled(
     }
     if !flat.iter().all(|v| v.is_finite()) {
         tracing::warn!(
+            call_site,
             batch_size,
             hidden_size,
             "split_pooled: non-finite output detected (NaN or Inf in pooled buffer)"
@@ -856,7 +863,7 @@ mod tests {
             0.0, 1.0, 2.0, 3.0, // row 0
             4.0, 5.0, 6.0, 7.0, // row 1
         ];
-        let split = split_pooled(&flat, 2, 4).expect("happy path must split ok");
+        let split = split_pooled(&flat, 2, 4, "test").expect("happy path must split ok");
 
         assert_eq!(split.len(), 2, "[T-012] outer Vec must have `batch` rows");
         assert_eq!(
@@ -880,7 +887,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_shape_mismatch_short_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // len 7
-        match split_pooled(&flat, 2, 4) {
+        match split_pooled(&flat, 2, 4, "test") {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
                 assert_eq!(expected, 8, "[T-012] expected = batch * hidden = 8");
                 assert_eq!(actual, 7, "[T-012] actual = flat.len() = 7");
@@ -901,7 +908,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_shape_mismatch_long_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 99.0]; // len 9
-        match split_pooled(&flat, 2, 4) {
+        match split_pooled(&flat, 2, 4, "test") {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
                 assert_eq!(expected, 8, "[T-012] expected = batch * hidden = 8");
                 assert_eq!(actual, 9, "[T-012] actual = flat.len() = 9");
@@ -923,7 +930,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_zero_batch_returns_empty_vec() {
         let flat: Vec<f32> = Vec::new();
-        let split = split_pooled(&flat, 0, 768).expect("zero-batch flat must split ok");
+        let split = split_pooled(&flat, 0, 768, "test").expect("zero-batch flat must split ok");
         assert!(
             split.is_empty(),
             "[T-012] batch=0 must yield an empty outer Vec, got {split:?}"
@@ -939,7 +946,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_single_batch_for_embed_query_path() {
         let flat: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.5];
-        let split = split_pooled(&flat, 1, 5).expect("single-batch must split ok");
+        let split = split_pooled(&flat, 1, 5, "test").expect("single-batch must split ok");
 
         assert_eq!(split.len(), 1, "[T-012] batch=1 yields a single inner row");
         assert_eq!(
@@ -980,7 +987,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_nan_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
-        match split_pooled(&flat, 1, 4) {
+        match split_pooled(&flat, 1, 4, "test") {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -995,7 +1002,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_positive_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, f32::INFINITY, 2.0, 3.0];
-        match split_pooled(&flat, 1, 4) {
+        match split_pooled(&flat, 1, 4, "test") {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -1010,7 +1017,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_negative_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, f32::NEG_INFINITY];
-        match split_pooled(&flat, 1, 4) {
+        match split_pooled(&flat, 1, 4, "test") {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -1021,10 +1028,14 @@ mod tests {
     #[test]
     fn t_012_split_pooled_emits_warn_on_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0; 7]; // expected 8
-        let _ = split_pooled(&flat, 2, 4);
+        let _ = split_pooled(&flat, 2, 4, "test");
         assert!(
             logs_contain("split_pooled: buffer shape mismatch"),
             "warn must be emitted on shape mismatch"
+        );
+        assert!(
+            logs_contain("call_site=\"test\""),
+            "call_site field must be emitted so query/batch paths are distinguishable",
         );
     }
 
@@ -1034,7 +1045,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_emits_warn_on_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
-        let _ = split_pooled(&flat, 1, 4);
+        let _ = split_pooled(&flat, 1, 4, "test");
         assert!(
             logs_contain("split_pooled: non-finite output"),
             "warn must be emitted on non-finite output"

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -3,13 +3,13 @@ use std::time::Instant;
 use mlx_rs::Array;
 
 use super::Artifacts;
-use super::metrics::{BatchMetrics, PhaseMetrics};
+use super::metrics::{BatchMetrics, EmbedKind, PhaseMetrics};
 use super::{
     CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, MAX_SEQ_LEN,
     ModelInitError, extract_prefix_tokens, gpu_pool_and_normalize, max_content,
     tokenize_with_prefix, truncate_for_query,
 };
-use crate::mlx_cache::{clear_inference_cache, release_inference_output};
+use crate::mlx_cache::{Component, clear_inference_cache, release_inference_output};
 use crate::model_io::{BUCKET_BOUNDS, assign_bucket, compute_sub_batch_size, pad_sequences};
 use crate::modernbert::ModernBert;
 
@@ -127,8 +127,8 @@ impl EmbedderInner {
     /// Phase 3b GPU-pool path mirrors `forward_sub_batch` with `batch = 1`:
     /// `pool_output` runs the GPU pool + `eval()` so the readback through
     /// `pooled.as_slice()` reads only `hidden_size` f32s (NFR-002), then
-    /// `split_pooled(flat, 1, hidden_size)` validates that shape and
-    /// rejects non-finite values before yielding the single row.
+    /// `split_pooled` validates that shape and rejects non-finite values
+    /// before yielding the single row.
     /// `release_inference_output` consumes the **pooled** Array; the
     /// original `output` was consumed by `pool_output` (NFR-005
     /// drop-before-clear). Error path: when post-forward ops fail,
@@ -139,7 +139,7 @@ impl EmbedderInner {
         text: &str,
         prefix: &str,
     ) -> Result<Vec<f32>, EmbedError> {
-        let mut metrics = PhaseMetrics::new("query");
+        let mut metrics = PhaseMetrics::new(EmbedKind::Query);
 
         let t_tok = Instant::now();
         let tok = tokenize_with_prefix(&self.tokenizer, text, prefix)?;
@@ -166,7 +166,7 @@ impl EmbedderInner {
 
             let t_readback = Instant::now();
             let flat: &[f32] = pooled.as_slice();
-            let pooled_vec = split_pooled(flat, 1, hidden_size, "query")?
+            let pooled_vec = split_pooled(flat, 1, hidden_size, EmbedKind::Query)?
                 .into_iter()
                 .next()
                 .expect("split_pooled(_, 1, _) yields one row");
@@ -177,12 +177,12 @@ impl EmbedderInner {
         let t_clear = Instant::now();
         let result = match outcome {
             Ok((pooled, pooled_vec)) => {
-                release_inference_output(pooled, "embed");
+                release_inference_output(pooled, Component::Embed);
                 metrics.cache_clear = t_clear.elapsed();
                 Ok(pooled_vec)
             }
             Err(e) => {
-                clear_inference_cache("embed");
+                clear_inference_cache(Component::Embed);
                 metrics.cache_clear = t_clear.elapsed();
                 Err(e)
             }
@@ -236,7 +236,7 @@ impl EmbedderInner {
             return Ok((Vec::new(), BatchMetrics::default()));
         }
 
-        let mut metrics = PhaseMetrics::new("batch");
+        let mut metrics = PhaseMetrics::new(EmbedKind::Batch);
 
         let t_plan = Instant::now();
         let max_content_tokens = max_content(self.doc_prefix_tokens.len());
@@ -354,7 +354,7 @@ impl EmbedderInner {
 
             let t_readback = Instant::now();
             let flat: &[f32] = pooled.as_slice();
-            let unpacked = split_pooled(flat, batch_size, hidden_size, "batch")?;
+            let unpacked = split_pooled(flat, batch_size, hidden_size, EmbedKind::Batch)?;
             metrics.readback_pool += t_readback.elapsed();
             Ok((pooled, unpacked))
         })();
@@ -362,12 +362,12 @@ impl EmbedderInner {
         let t_clear = Instant::now();
         let unpacked = match outcome {
             Ok((pooled, unpacked)) => {
-                release_inference_output(pooled, "embed");
+                release_inference_output(pooled, Component::Embed);
                 metrics.cache_clear += t_clear.elapsed();
                 unpacked
             }
             Err(e) => {
-                clear_inference_cache("embed");
+                clear_inference_cache(Component::Embed);
                 metrics.cache_clear += t_clear.elapsed();
                 return Err(e);
             }
@@ -551,8 +551,9 @@ pub(super) fn split_pooled(
     flat: &[f32],
     batch_size: usize,
     hidden_size: usize,
-    call_site: &'static str,
+    call_site: EmbedKind,
 ) -> Result<Vec<Vec<f32>>, EmbedError> {
+    let call_site = call_site.as_str();
     let expected = batch_size.saturating_mul(hidden_size);
     if flat.len() != expected {
         tracing::warn!(
@@ -597,6 +598,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::super::EmbedError;
+    use super::super::metrics::EmbedKind;
     use super::{
         IndexedChunk, build_indexed_chunks, distribute_into_buckets, pool_output, split_pooled,
     };
@@ -863,7 +865,7 @@ mod tests {
             0.0, 1.0, 2.0, 3.0, // row 0
             4.0, 5.0, 6.0, 7.0, // row 1
         ];
-        let split = split_pooled(&flat, 2, 4, "test").expect("happy path must split ok");
+        let split = split_pooled(&flat, 2, 4, EmbedKind::Query).expect("happy path must split ok");
 
         assert_eq!(split.len(), 2, "[T-012] outer Vec must have `batch` rows");
         assert_eq!(
@@ -887,7 +889,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_shape_mismatch_short_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // len 7
-        match split_pooled(&flat, 2, 4, "test") {
+        match split_pooled(&flat, 2, 4, EmbedKind::Query) {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
                 assert_eq!(expected, 8, "[T-012] expected = batch * hidden = 8");
                 assert_eq!(actual, 7, "[T-012] actual = flat.len() = 7");
@@ -908,7 +910,7 @@ mod tests {
     #[test]
     fn t_012_split_pooled_shape_mismatch_long_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 99.0]; // len 9
-        match split_pooled(&flat, 2, 4, "test") {
+        match split_pooled(&flat, 2, 4, EmbedKind::Query) {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
                 assert_eq!(expected, 8, "[T-012] expected = batch * hidden = 8");
                 assert_eq!(actual, 9, "[T-012] actual = flat.len() = 9");
@@ -930,7 +932,8 @@ mod tests {
     #[test]
     fn t_012_split_pooled_zero_batch_returns_empty_vec() {
         let flat: Vec<f32> = Vec::new();
-        let split = split_pooled(&flat, 0, 768, "test").expect("zero-batch flat must split ok");
+        let split =
+            split_pooled(&flat, 0, 768, EmbedKind::Query).expect("zero-batch flat must split ok");
         assert!(
             split.is_empty(),
             "[T-012] batch=0 must yield an empty outer Vec, got {split:?}"
@@ -946,7 +949,8 @@ mod tests {
     #[test]
     fn t_012_split_pooled_single_batch_for_embed_query_path() {
         let flat: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.5];
-        let split = split_pooled(&flat, 1, 5, "test").expect("single-batch must split ok");
+        let split =
+            split_pooled(&flat, 1, 5, EmbedKind::Query).expect("single-batch must split ok");
 
         assert_eq!(split.len(), 1, "[T-012] batch=1 yields a single inner row");
         assert_eq!(
@@ -987,7 +991,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_nan_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
-        match split_pooled(&flat, 1, 4, "test") {
+        match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -1002,7 +1006,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_positive_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, f32::INFINITY, 2.0, 3.0];
-        match split_pooled(&flat, 1, 4, "test") {
+        match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -1017,7 +1021,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_rejects_negative_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, f32::NEG_INFINITY];
-        match split_pooled(&flat, 1, 4, "test") {
+        match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
             other => panic!("[T-015] expected Err(NonFiniteOutput), got {other:?}"),
         }
@@ -1028,13 +1032,13 @@ mod tests {
     #[test]
     fn t_012_split_pooled_emits_warn_on_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0; 7]; // expected 8
-        let _ = split_pooled(&flat, 2, 4, "test");
+        let _ = split_pooled(&flat, 2, 4, EmbedKind::Query);
         assert!(
             logs_contain("split_pooled: buffer shape mismatch"),
             "warn must be emitted on shape mismatch"
         );
         assert!(
-            logs_contain("call_site=\"test\""),
+            logs_contain("call_site=\"query\""),
             "call_site field must be emitted so query/batch paths are distinguishable",
         );
     }
@@ -1045,7 +1049,7 @@ mod tests {
     #[test]
     fn t_015_split_pooled_emits_warn_on_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
-        let _ = split_pooled(&flat, 1, 4, "test");
+        let _ = split_pooled(&flat, 1, 4, EmbedKind::Query);
         assert!(
             logs_contain("split_pooled: non-finite output"),
             "warn must be emitted on non-finite output"

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -27,9 +27,9 @@ pub(crate) static MLX_CACHE_LOCK: Mutex<()> = Mutex::new(());
 /// 1. `output` is taken by value — no borrows remain after this call.
 /// 2. Model weights must remain live on the caller — only unused cache buffers are freed.
 /// 3. `MLX_CACHE_LOCK` serializes concurrent calls across all modules.
-pub(crate) fn release_inference_output(output: mlx_rs::Array) {
+pub(crate) fn release_inference_output(output: mlx_rs::Array, component: &'static str) {
     drop(output);
-    clear_inference_cache();
+    clear_inference_cache(component);
 }
 
 /// Clear the MLX GPU caches without consuming an Array.
@@ -46,18 +46,18 @@ pub(crate) fn release_inference_output(output: mlx_rs::Array) {
 /// Only call this when there is no live `Array` from the just-failed
 /// forward pass. If an Array exists, prefer [`release_inference_output`]
 /// to preserve the drop-before-clear ordering.
-pub(crate) fn clear_inference_cache() {
+pub(crate) fn clear_inference_cache(component: &'static str) {
     let _guard = MLX_CACHE_LOCK.lock().unwrap_or_else(|e| {
-        tracing::warn!("MLX cache lock was poisoned; recovering");
+        tracing::warn!(component, "MLX cache lock was poisoned; recovering");
         e.into_inner()
     });
     let code = rurico_ffi::mlx_clear_cache();
     if code != 0 {
-        tracing::warn!(code, "mlx_clear_cache failed");
+        tracing::warn!(component, code, "mlx_clear_cache failed");
     }
     let code = rurico_ffi::mlx_compile_clear_cache();
     if code != 0 {
-        tracing::warn!(code, "mlx_detail_compile_clear_cache failed");
+        tracing::warn!(component, code, "mlx_detail_compile_clear_cache failed");
     }
 }
 

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -7,6 +7,22 @@
 
 use std::sync::Mutex;
 
+/// Caller identifier for cache-clear telemetry.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Component {
+    Embed,
+    Reranker,
+}
+
+impl Component {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Embed => "embed",
+            Self::Reranker => "reranker",
+        }
+    }
+}
+
 /// Process-global lock for [`mlx_sys::mlx_clear_cache`] and [`mlx_sys::mlx_detail_compile_clear_cache`] calls.
 ///
 /// Recover from poison: cache-clear is stateless (guards `()`), safe to
@@ -27,7 +43,7 @@ pub(crate) static MLX_CACHE_LOCK: Mutex<()> = Mutex::new(());
 /// 1. `output` is taken by value — no borrows remain after this call.
 /// 2. Model weights must remain live on the caller — only unused cache buffers are freed.
 /// 3. `MLX_CACHE_LOCK` serializes concurrent calls across all modules.
-pub(crate) fn release_inference_output(output: mlx_rs::Array, component: &'static str) {
+pub(crate) fn release_inference_output(output: mlx_rs::Array, component: Component) {
     drop(output);
     clear_inference_cache(component);
 }
@@ -46,7 +62,8 @@ pub(crate) fn release_inference_output(output: mlx_rs::Array, component: &'stati
 /// Only call this when there is no live `Array` from the just-failed
 /// forward pass. If an Array exists, prefer [`release_inference_output`]
 /// to preserve the drop-before-clear ordering.
-pub(crate) fn clear_inference_cache(component: &'static str) {
+pub(crate) fn clear_inference_cache(component: Component) {
+    let component = component.as_str();
     let _guard = MLX_CACHE_LOCK.lock().unwrap_or_else(|e| {
         tracing::warn!(component, "MLX cache lock was poisoned; recovering");
         e.into_inner()

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -202,11 +202,24 @@ pub fn download_artifacts<Id: ModelArtifact>(model: Id) -> Result<ModelPaths, Mo
     });
 
     rx.recv_timeout(DOWNLOAD_TIMEOUT).map_err(|e| match e {
-        mpsc::RecvTimeoutError::Timeout => ModelIoError::Download(format!(
-            "download exceeded {} second timeout (HF Hub may be unreachable or proxy stalled)",
-            DOWNLOAD_TIMEOUT.as_secs()
-        )),
+        mpsc::RecvTimeoutError::Timeout => {
+            tracing::error!(
+                repo_id,
+                revision,
+                timeout_secs = DOWNLOAD_TIMEOUT.as_secs(),
+                "download_artifacts: HF Hub download timed out"
+            );
+            ModelIoError::Download(format!(
+                "download exceeded {} second timeout (HF Hub may be unreachable or proxy stalled)",
+                DOWNLOAD_TIMEOUT.as_secs()
+            ))
+        }
         mpsc::RecvTimeoutError::Disconnected => {
+            tracing::error!(
+                repo_id,
+                revision,
+                "download_artifacts: worker thread disconnected before sending result"
+            );
             ModelIoError::Download("download worker terminated unexpectedly".to_owned())
         }
     })?

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -27,14 +27,32 @@ pub fn download_model<Id: ModelArtifact>(
 ) -> Result<VerifiedArtifacts<Id::Kind>, ArtifactError> {
     let repo_id = model.repo_id();
     let revision = model.revision();
-    tracing::info!(
-        repo_id,
-        revision,
-        "model_lifecycle: downloading artifacts from HF Hub"
-    );
-    let paths = download_artifacts(model)?;
-    let verified = Id::Kind::verify(paths)?;
-    tracing::debug!(repo_id, "model_lifecycle: artifacts verified");
+    tracing::info!(repo_id, revision, "model_lifecycle: download start");
+    let paths = match download_artifacts(model) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(
+                repo_id,
+                revision,
+                error = %e,
+                "model_lifecycle: download failed"
+            );
+            return Err(e.into());
+        }
+    };
+    let verified = match Id::Kind::verify(paths) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!(
+                repo_id,
+                revision,
+                error = %e,
+                "model_lifecycle: verification failed"
+            );
+            return Err(e);
+        }
+    };
+    tracing::info!(repo_id, revision, "model_lifecycle: download complete");
     Ok(verified)
 }
 

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -28,30 +28,12 @@ pub fn download_model<Id: ModelArtifact>(
     let repo_id = model.repo_id();
     let revision = model.revision();
     tracing::info!(repo_id, revision, "model_lifecycle: download start");
-    let paths = match download_artifacts(model) {
-        Ok(p) => p,
-        Err(e) => {
-            tracing::error!(
-                repo_id,
-                revision,
-                error = %e,
-                "model_lifecycle: download failed"
-            );
-            return Err(e.into());
-        }
-    };
-    let verified = match Id::Kind::verify(paths) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!(
-                repo_id,
-                revision,
-                error = %e,
-                "model_lifecycle: verification failed"
-            );
-            return Err(e);
-        }
-    };
+    let paths = download_artifacts(model).inspect_err(|e| {
+        tracing::error!(repo_id, revision, error = %e, "model_lifecycle: download failed");
+    })?;
+    let verified = Id::Kind::verify(paths).inspect_err(|e| {
+        tracing::error!(repo_id, revision, error = %e, "model_lifecycle: verification failed");
+    })?;
     tracing::info!(repo_id, revision, "model_lifecycle: download complete");
     Ok(verified)
 }

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -326,6 +326,7 @@ impl ModernBert {
             tracing::warn!(
                 seq_len,
                 max_seq,
+                batch_size,
                 "model.forward: seq_len exceeds max_seq_len, truncating as defense-in-depth fallback"
             );
             let bs = batch_size as usize;

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -30,7 +30,11 @@ impl RerankerInner {
         let model =
             RerankerModel::load(&artifacts.paths.model, config).map_err(ModelInitError::backend)?;
 
-        tracing::info!(hidden_size = config.hidden_size, "reranker: model loaded");
+        tracing::info!(
+            hidden_size = config.hidden_size,
+            model_path = ?artifacts.paths.model,
+            "reranker: model loaded"
+        );
         Ok(Self { model, tokenizer })
     }
 
@@ -111,6 +115,8 @@ impl RerankerInner {
                 tracing::warn!(
                     expected = batch_size,
                     actual = flat_len,
+                    batch_size,
+                    bucket_len,
                     "score_batch: output shape mismatch"
                 );
                 return Err(RerankerError::inference(format!(
@@ -121,13 +127,14 @@ impl RerankerInner {
             if scores.iter().any(|v| !v.is_finite()) {
                 tracing::warn!(
                     batch_size,
+                    bucket_len,
                     "score_batch: non-finite output detected (NaN or Inf in reranker scores)"
                 );
                 return Err(RerankerError::NonFiniteOutput);
             }
             Ok(scores)
         })();
-        release_inference_output(output);
+        release_inference_output(output, "reranker");
         result
     }
 }

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -1,5 +1,5 @@
 use super::{Artifacts, ModelInitError, RerankerError};
-use crate::mlx_cache::release_inference_output;
+use crate::mlx_cache::{Component, release_inference_output};
 use crate::model_io::{
     BUCKET_BOUNDS, MAX_SEQ_LEN, assign_bucket, compute_sub_batch_size, pad_sequences,
     truncate_with_eos,
@@ -134,7 +134,7 @@ impl RerankerInner {
             }
             Ok(scores)
         })();
-        release_inference_output(output, "reranker");
+        release_inference_output(output, Component::Reranker);
         result
     }
 }


### PR DESCRIPTION
## What & Why

ADR 0007 が定める structured tracing の契約に対し、emit site が format string や stringly-typed field で実装されているため、subscriber 側で grep ベース運用しかできない状態だった。

10 emit site を named field に構造化し、stringly-typed ラベルは enum に置換して type-safe にした。

## Changes

- `PhaseMetrics::log`: format string → 16 named field (`kind`, `tokenize_ms`, ..., `bucket_hist_0..3`)
- `shrink_chunk_to_fit` / `score_batch` / `ModernBert::forward`: byte range, batch_size, bucket_len を補強
- `split_pooled` / `clear_inference_cache`: stringly-typed `call_site` / `component` を `EmbedKind` / `Component` enum に置換 (typo silent failure 防止)
- `mlx_smoke` try_init: 失敗時 stderr 通知 (silent discard 修正)
- `download_artifacts` / lifecycle: start / complete / failed イベント追加, success info にも model_path
- `model_lifecycle`: error logging duplication を `inspect_err` で集約 (24 行 → 4 行)

## Scope

**Not included**: `EmbedInitError` / `RerankerInitError` の初期化失敗時 `tracing::error` は ADR 0007 boundary に従い defer。bin 側 main で error printing 済みなので library 側で発行すると caller 全箇所で重複する。代わりに success info log に `model_path` を追加して context 補強。

## Design Decisions

- 当初 `call_site: &'static str` だったが `"test"` が prod コードに残っても compiler が止めてくれない silent failure を polish レビューで指摘 → `EmbedKind` (Query, Batch) と `Component` (Embed, Reranker) enum に変更
- `download_model` の error logging 重複 (12 行 × 2 ブロックの match) を `inspect_err` で 4 行に集約

## How to Test

1. `cargo test --workspace` → 318 tests pass
2. `cargo clippy --all-targets -- -D warnings` → clean
3. `cargo fmt --check` → clean
4. `RUST_LOG=debug` で mlx_smoke 実行し、`embed phase metrics` イベントが named field で出ることを subscriber log で確認

## Related

- Closes #102
- downstream: yomu の `traced_test` で旧 message text (`embed[{kind}]`) を assertion してる箇所があれば、新 message text (`embed phase metrics` + `kind` field) への追従 issue を merge 後に立てる
