### PR TITLE
fix(model_probe): drain reader thread の reap と stderr flush 契約化 (RC-002)

### DIFF
--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -270,8 +270,7 @@ fn emit_ack_to<W: Write>(stdout: &mut W) -> io::Result<()> {
 /// Symmetric to [`emit_ack_to`] for the failure path. Probe IPC contract:
 /// the child must complete `flush` before [`std::process::exit`] so the
 /// parent's `collect_pipe` observes the full message regardless of stderr's
-/// buffering policy. Production calls this with `&mut io::stderr()`; tests
-/// inject a writer that tracks `flush` calls or fails on `write` / `flush`.
+/// buffering policy.
 fn emit_failure_to<W: Write>(stderr: &mut W, msg: &str) -> io::Result<()> {
     write!(stderr, "{msg}")?;
     stderr.flush()
@@ -436,13 +435,9 @@ where
 
 /// Upper bound on how long `collect_pipe` waits for a reader thread's buffer.
 ///
-/// If a grandchild inherited the probe's pipe FDs, the reader's `read_to_end`
-/// never observes EOF even after the direct child exits. Cap the wait here
-/// and return a best-effort empty buffer. In that path the reader thread is
-/// still blocked on `read_to_end` and **must not be `join`ed** — `join` would
-/// inherit the same indefinite block. Leak is acceptable because grandchild
-/// FD inheritance is itself an exceptional scenario; the happy path reaps
-/// the thread immediately on `recv` success.
+/// Capped because a grandchild that inherited the pipe FDs prevents EOF on
+/// the reader's `read_to_end` even after the direct child exits. See
+/// `probe_via_subprocess_with` for the full IPC contract (parent + child).
 const COLLECT_PIPE_TIMEOUT: Duration = Duration::from_secs(2);
 
 fn collect_pipe(handle: Option<DrainHandle>, label: &str) -> Vec<u8> {

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -245,7 +245,7 @@ pub(crate) fn dispatch_probe<P, E: fmt::Display>(
     };
     let action = compute_probe_exit(outcome);
     if let Some(ref msg) = action.message
-        && write!(io::stderr(), "{msg}").is_err()
+        && emit_failure_to(&mut io::stderr(), msg).is_err()
     {
         process::exit(PROBE_EXIT_STDERR_FAILED);
     }
@@ -263,6 +263,18 @@ fn emit_ack() -> io::Result<()> {
 fn emit_ack_to<W: Write>(stdout: &mut W) -> io::Result<()> {
     writeln!(stdout, "{PROBE_ACK}")?;
     stdout.flush()
+}
+
+/// Write a probe-failure reason to `stderr` and flush, returning any IO error.
+///
+/// Symmetric to [`emit_ack_to`] for the failure path. Probe IPC contract:
+/// the child must complete `flush` before [`std::process::exit`] so the
+/// parent's `collect_pipe` observes the full message regardless of stderr's
+/// buffering policy. Production calls this with `&mut io::stderr()`; tests
+/// inject a writer that tracks `flush` calls or fails on `write` / `flush`.
+fn emit_failure_to<W: Write>(stderr: &mut W, msg: &str) -> io::Result<()> {
+    write!(stderr, "{msg}")?;
+    stderr.flush()
 }
 
 /// Re-exec the current binary as a probe subprocess with the given env vars.
@@ -354,6 +366,27 @@ pub(super) fn child_env_for_spawn(env_pairs: &[(&str, &str)]) -> HashMap<String,
 
 /// Like [`probe_via_subprocess`] but the executable to re-exec is provided
 /// explicitly. Used by tests to avoid depending on `env::current_exe()`.
+///
+/// # IPC Contract
+///
+/// **Child** (`dispatch_probe`): every byte written to stdout (handshake
+/// ACK) or stderr (failure reason) MUST be flushed before [`process::exit`].
+/// `emit_ack_to` and `emit_failure_to` are the only sanctioned write paths
+/// and both call `flush` before returning. A missed flush would not drop
+/// bytes today (`io::stdout()` is line-buffered, `io::stderr()` is
+/// unbuffered), but the contract guards against future buffering policy
+/// changes that could leave bytes stranded in user-space buffers when the
+/// child exits.
+///
+/// **Parent** (`wait_with_timeout` + `collect_pipe`): each piped stream is
+/// drained by a dedicated reader thread held by `DrainHandle`. On `recv`
+/// success the thread is `join`ed immediately so that O(N) probe
+/// invocations do not accumulate OS threads. On `recv_timeout` (a
+/// grandchild inherited the pipe FDs and keeps them open past the direct
+/// child's exit) the reader is left running — the thread is blocked on
+/// `read_to_end` and a `join` would inherit the same indefinite block.
+/// The leak is acceptable because grandchild FD inheritance is an
+/// exceptional scenario; the happy path reaps every reader.
 pub fn probe_via_subprocess_with(
     exe: PathBuf,
     env_pairs: &[(&str, &str)],
@@ -374,20 +407,30 @@ pub fn probe_via_subprocess_with(
     interpret_probe_output(&output)
 }
 
-fn spawn_drain_pipe<R>(pipe: Option<R>, label: &'static str) -> Option<Receiver<Vec<u8>>>
+/// Reader-thread handle paired with the channel that delivers its drained
+/// bytes. Returned from [`spawn_drain_pipe`] so that [`collect_pipe`] can
+/// `join` the reader thread once the channel recv succeeds — preventing
+/// thread accumulation across many probes (parent IPC contract, see
+/// [`probe_via_subprocess_with`]).
+struct DrainHandle {
+    rx: Receiver<Vec<u8>>,
+    join: thread::JoinHandle<()>,
+}
+
+fn spawn_drain_pipe<R>(pipe: Option<R>, label: &'static str) -> Option<DrainHandle>
 where
     R: Read + Send + 'static,
 {
     pipe.map(|mut stream| {
         let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
+        let join = thread::spawn(move || {
             let mut buf = Vec::new();
             if let Err(e) = stream.read_to_end(&mut buf) {
                 tracing::warn!(label, error = %e, "probe: failed to drain child");
             }
             let _ = tx.send(buf);
         });
-        rx
+        DrainHandle { rx, join }
     })
 }
 
@@ -395,16 +438,25 @@ where
 ///
 /// If a grandchild inherited the probe's pipe FDs, the reader's `read_to_end`
 /// never observes EOF even after the direct child exits. Cap the wait here
-/// and return a best-effort empty buffer — the reader thread leaks, which is
-/// acceptable because probes are rare and this scenario is itself exceptional.
+/// and return a best-effort empty buffer. In that path the reader thread is
+/// still blocked on `read_to_end` and **must not be `join`ed** — `join` would
+/// inherit the same indefinite block. Leak is acceptable because grandchild
+/// FD inheritance is itself an exceptional scenario; the happy path reaps
+/// the thread immediately on `recv` success.
 const COLLECT_PIPE_TIMEOUT: Duration = Duration::from_secs(2);
 
-fn collect_pipe(recv: Option<Receiver<Vec<u8>>>, label: &str) -> Vec<u8> {
-    let Some(rx) = recv else {
+fn collect_pipe(handle: Option<DrainHandle>, label: &str) -> Vec<u8> {
+    let Some(DrainHandle { rx, join }) = handle else {
         return Vec::new();
     };
     match rx.recv_timeout(COLLECT_PIPE_TIMEOUT) {
-        Ok(buf) => buf,
+        Ok(buf) => {
+            // recv success means `tx.send(buf)` ran, which only happens after
+            // `read_to_end` returned. The reader thread is finished or about
+            // to finish — `join` returns promptly without blocking.
+            let _ = join.join();
+            buf
+        }
         Err(RecvTimeoutError::Timeout) => {
             tracing::warn!(
                 label,

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -831,3 +831,131 @@ fn t_027_interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
          binary lacks probe handler), got {err}"
     );
 }
+
+// ── Issue #124 (probe IPC contract: drain join + stderr flush) tests ───────
+//
+// `emit_failure_to` is the testable seam for the failure-message stderr write
+// path, symmetric to `emit_ack_to`. The probe IPC contract requires `flush`
+// to complete before `process::exit` so that a future change to stderr
+// buffering policy in the standard library cannot silently drop bytes
+// observed by the parent's `collect_pipe`.
+
+// T-028: emit_failure_to writes msg and calls flush on success
+#[test]
+fn t_028_emit_failure_to_writes_message_and_flushes() {
+    struct FlushTrackingWriter {
+        buf: Vec<u8>,
+        flush_count: usize,
+    }
+    impl io::Write for FlushTrackingWriter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.flush_count += 1;
+            Ok(())
+        }
+    }
+    let mut w = FlushTrackingWriter {
+        buf: Vec::new(),
+        flush_count: 0,
+    };
+    super::emit_failure_to(&mut w, "model load failed: bad weights").unwrap();
+    assert_eq!(w.buf, b"model load failed: bad weights");
+    assert_eq!(
+        w.flush_count, 1,
+        "emit_failure_to must call flush exactly once after the write"
+    );
+}
+
+// T-029: emit_failure_to propagates writer error
+#[test]
+fn t_029_emit_failure_to_propagates_writer_error() {
+    struct FailingWriter;
+    impl io::Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+    }
+    let err = super::emit_failure_to(&mut FailingWriter, "anything")
+        .expect_err("expected emit_failure_to to propagate writer error");
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+}
+
+// T-030: emit_failure_to surfaces flush errors after a successful write
+//
+// Exercises the flush-error-only arm: write succeeds but flush fails. This
+// is the failure mode `emit_failure_to` exists to detect — bytes accepted
+// into a buffer but never delivered to the kernel before `process::exit`.
+#[test]
+fn t_030_emit_failure_to_surfaces_flush_error_after_successful_write() {
+    struct FlushFailingWriter {
+        buf: Vec<u8>,
+    }
+    impl io::Write for FlushFailingWriter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "flush after write failed",
+            ))
+        }
+    }
+    let mut w = FlushFailingWriter { buf: Vec::new() };
+    let err = super::emit_failure_to(&mut w, "msg")
+        .expect_err("expected emit_failure_to to surface flush error");
+    assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    assert_eq!(
+        w.buf, b"msg",
+        "write must succeed before flush is attempted"
+    );
+}
+
+// T-031: spawn_drain_pipe returns a DrainHandle whose thread is reapable
+//        immediately after recv succeeds.
+//
+// Semantic guard for the parent IPC contract: `collect_pipe` joins the reader
+// thread on `recv` success, preventing thread accumulation across O(N) probes.
+// `recv` succeeds only after `tx.send(buf)` runs, which is the last statement
+// in the reader thread body — so `join` must return promptly without blocking.
+//
+// Cursor<Vec<u8>>::read_to_end returns immediately on EOF, simulating the
+// happy path where the child closes its pipe and the reader thread completes.
+#[test]
+fn t_031_spawn_drain_pipe_thread_is_joinable_after_recv() {
+    use std::io::Cursor;
+    let pipe = Cursor::new(b"drained bytes".to_vec());
+    let handle =
+        super::spawn_drain_pipe(Some(pipe), "test").expect("Some(pipe) must yield DrainHandle");
+
+    let buf = handle
+        .rx
+        .recv()
+        .expect("reader thread must send buf after read_to_end completes");
+    assert_eq!(buf, b"drained bytes");
+
+    // join must return without blocking — recv success implies tx.send ran,
+    // which means the reader closure reached its end. A blocking join here
+    // would indicate the reaping invariant is broken.
+    handle
+        .join
+        .join()
+        .expect("reader thread must be joinable after recv");
+}
+
+// T-032: spawn_drain_pipe returns None when no pipe is provided.
+#[test]
+fn t_032_spawn_drain_pipe_returns_none_for_none_input() {
+    let handle = super::spawn_drain_pipe::<io::Empty>(None, "test");
+    assert!(
+        handle.is_none(),
+        "None pipe must produce None handle (no thread spawned)"
+    );
+}

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -11,6 +11,53 @@ use super::*;
 use std::io;
 use std::process::ExitStatus;
 
+mod test_writers {
+    use std::io;
+
+    pub struct FailingWriter;
+    impl io::Write for FailingWriter {
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
+        }
+    }
+
+    #[derive(Default)]
+    pub struct FlushTrackingWriter {
+        pub buf: Vec<u8>,
+        pub flush_count: usize,
+    }
+    impl io::Write for FlushTrackingWriter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.flush_count += 1;
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    pub struct FlushFailingWriter {
+        pub buf: Vec<u8>,
+    }
+    impl io::Write for FlushFailingWriter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "flush after write failed",
+            ))
+        }
+    }
+}
+
 // ── Existing tests preserved verbatim ───────────────────────────────────────
 
 #[test]
@@ -751,16 +798,7 @@ fn t_023_emit_ack_to_writes_ack_token_with_newline() {
 // pipe-broken case typically surfaces at write time on `io::stdout()`.
 #[test]
 fn t_024_emit_ack_to_propagates_writer_error() {
-    struct FailingWriter;
-    impl io::Write for FailingWriter {
-        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
-        }
-    }
-    let err = super::emit_ack_to(&mut FailingWriter)
+    let err = super::emit_ack_to(&mut test_writers::FailingWriter)
         .expect_err("expected emit_ack_to to propagate writer error");
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
 }
@@ -833,34 +871,11 @@ fn t_027_interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
 }
 
 // ── Issue #124 (probe IPC contract: drain join + stderr flush) tests ───────
-//
-// `emit_failure_to` is the testable seam for the failure-message stderr write
-// path, symmetric to `emit_ack_to`. The probe IPC contract requires `flush`
-// to complete before `process::exit` so that a future change to stderr
-// buffering policy in the standard library cannot silently drop bytes
-// observed by the parent's `collect_pipe`.
 
 // T-028: emit_failure_to writes msg and calls flush on success
 #[test]
 fn t_028_emit_failure_to_writes_message_and_flushes() {
-    struct FlushTrackingWriter {
-        buf: Vec<u8>,
-        flush_count: usize,
-    }
-    impl io::Write for FlushTrackingWriter {
-        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-            self.buf.extend_from_slice(data);
-            Ok(data.len())
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            self.flush_count += 1;
-            Ok(())
-        }
-    }
-    let mut w = FlushTrackingWriter {
-        buf: Vec::new(),
-        flush_count: 0,
-    };
+    let mut w = test_writers::FlushTrackingWriter::default();
     super::emit_failure_to(&mut w, "model load failed: bad weights").unwrap();
     assert_eq!(w.buf, b"model load failed: bad weights");
     assert_eq!(
@@ -872,43 +887,17 @@ fn t_028_emit_failure_to_writes_message_and_flushes() {
 // T-029: emit_failure_to propagates writer error
 #[test]
 fn t_029_emit_failure_to_propagates_writer_error() {
-    struct FailingWriter;
-    impl io::Write for FailingWriter {
-        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed"))
-        }
-    }
-    let err = super::emit_failure_to(&mut FailingWriter, "anything")
+    let err = super::emit_failure_to(&mut test_writers::FailingWriter, "anything")
         .expect_err("expected emit_failure_to to propagate writer error");
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
 }
 
-// T-030: emit_failure_to surfaces flush errors after a successful write
-//
-// Exercises the flush-error-only arm: write succeeds but flush fails. This
-// is the failure mode `emit_failure_to` exists to detect — bytes accepted
-// into a buffer but never delivered to the kernel before `process::exit`.
+// T-030: emit_failure_to surfaces flush errors after a successful write — the
+// failure mode `emit_failure_to` exists to detect (bytes accepted into a
+// buffer but never delivered to the kernel before `process::exit`).
 #[test]
 fn t_030_emit_failure_to_surfaces_flush_error_after_successful_write() {
-    struct FlushFailingWriter {
-        buf: Vec<u8>,
-    }
-    impl io::Write for FlushFailingWriter {
-        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-            self.buf.extend_from_slice(data);
-            Ok(data.len())
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "flush after write failed",
-            ))
-        }
-    }
-    let mut w = FlushFailingWriter { buf: Vec::new() };
+    let mut w = test_writers::FlushFailingWriter::default();
     let err = super::emit_failure_to(&mut w, "msg")
         .expect_err("expected emit_failure_to to surface flush error");
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
@@ -918,16 +907,8 @@ fn t_030_emit_failure_to_surfaces_flush_error_after_successful_write() {
     );
 }
 
-// T-031: spawn_drain_pipe returns a DrainHandle whose thread is reapable
-//        immediately after recv succeeds.
-//
-// Semantic guard for the parent IPC contract: `collect_pipe` joins the reader
-// thread on `recv` success, preventing thread accumulation across O(N) probes.
-// `recv` succeeds only after `tx.send(buf)` runs, which is the last statement
-// in the reader thread body — so `join` must return promptly without blocking.
-//
-// Cursor<Vec<u8>>::read_to_end returns immediately on EOF, simulating the
-// happy path where the child closes its pipe and the reader thread completes.
+// T-031: join returns promptly after recv succeeds (reaping invariant on
+// `collect_pipe` happy path).
 #[test]
 fn t_031_spawn_drain_pipe_thread_is_joinable_after_recv() {
     use std::io::Cursor;
@@ -941,9 +922,6 @@ fn t_031_spawn_drain_pipe_thread_is_joinable_after_recv() {
         .expect("reader thread must send buf after read_to_end completes");
     assert_eq!(buf, b"drained bytes");
 
-    // join must return without blocking — recv success implies tx.send ran,
-    // which means the reader closure reached its end. A blocking join here
-    // would indicate the reaping invariant is broken.
     handle
         .join
         .join()


### PR DESCRIPTION
## 概要
- `spawn_drain_pipe` を `DrainHandle { rx, join }` 返却に変更し、`collect_pipe` で `recv` 成功時のみ thread を `join` して reap。O(N) probe 呼び出しでの OS-thread accumulation を防ぐ。
- `dispatch_probe` の stderr 書き込みを `emit_failure_to` seam 経由に変更。`emit_ack_to` と対称的に `flush` 完了を保証する IPC contract を確立。
- `probe_via_subprocess_with` の rustdoc に `# IPC Contract` セクションを canonical home として追加。grandchild-FD-inheritance 時の leak は意図的 (read_to_end ブロック中の thread を join すると永続ブロックするため、現状動作維持)。

## トレードオフ
- Issue 本文の「`process::exit` は `libc::_exit` semantics」は技術的に不正確 (`std::process::exit` は libc::exit 経由で cleanup あり、`io::stderr()` は unbuffered)。今 bytes が落ちているわけではないが、将来 stderr のバッファリング戦略変更に対する契約 guard として価値あり。
- `let _ = join.join()` で reader thread の panic を黙殺。probe IPC layer の信頼性 (parent process が reader thread の異常で panic しない) を優先。

## 範囲
本 PR は `src/model_probe.rs` + `src/model_probe/tests.rs` のみ。downstream (amici / yomu / recall / sae) は API 影響なしのため、rev bump は別 issue で扱う。

## テスト計画
- [x] `cargo test --workspace` (323 pass / 0 fail / 3 ignored)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] 既存 T-153 (verbose drain) / T-188 (grandchild inherits pipes) 無改変で pass 維持
- [x] T-028..T-032 で `emit_failure_to` の write+flush / writer-error / flush-only-error と `DrainHandle` の reapability / None 入力をカバー

Closes #124