### PR TITLE
ModelInitError::Backend に error::Error::source() chain を保存する (#125 Phase 1)

### DIFF
--- a/src/model_init.rs
+++ b/src/model_init.rs
@@ -5,7 +5,7 @@
 //! variant set is identical for both kinds; call sites distinguish kinds via
 //! structured logging fields rather than via the error type.
 
-use std::fmt::Display;
+use std::error::Error;
 
 use crate::model_probe::ProbeError;
 
@@ -17,8 +17,19 @@ use crate::model_probe::ProbeError;
 #[derive(Debug, thiserror::Error)]
 pub enum ModelInitError {
     /// MLX backend initialisation, weight loading, or subprocess probe failure.
-    #[error("model init failed: {0}")]
-    Backend(String),
+    ///
+    /// `source` preserves the originating typed error so callers can walk the
+    /// chain via `std::error::Error::source()`. `None` when the failure path
+    /// carries only a `String` (e.g. `ProbeError::SubprocessFailed`) with no
+    /// upstream typed error to box.
+    #[error("model init failed: {message}")]
+    Backend {
+        /// Display rendering at construction.
+        message: String,
+        /// Source for chain walking.
+        #[source]
+        source: Option<Box<dyn Error + Send + Sync>>,
+    },
     /// Model weights loaded but are corrupt or incompatible with the expected architecture.
     #[error("model load failed: {reason}")]
     ModelCorrupt {
@@ -28,42 +39,47 @@ pub enum ModelInitError {
 }
 
 impl ModelInitError {
-    pub(crate) fn backend(e: impl Display) -> Self {
-        Self::Backend(e.to_string())
+    pub(crate) fn backend(e: impl Error + Send + Sync + 'static) -> Self {
+        Self::Backend {
+            message: e.to_string(),
+            source: Some(Box::new(e)),
+        }
     }
 }
 
 impl From<ProbeError> for ModelInitError {
     fn from(e: ProbeError) -> Self {
         match e {
-            ProbeError::HandlerNotInstalled => ModelInitError::Backend(e.to_string()),
             ProbeError::ModelLoadFailed { reason } => ModelInitError::ModelCorrupt { reason },
-            ProbeError::SetupRejected { .. } => ModelInitError::Backend(e.to_string()),
-            ProbeError::SubprocessFailed(msg) => ModelInitError::Backend(msg),
+            ProbeError::SubprocessFailed(msg) => ModelInitError::Backend {
+                message: msg,
+                source: None,
+            },
+            ProbeError::HandlerNotInstalled => ModelInitError::backend(e),
+            ProbeError::SetupRejected { .. } => ModelInitError::backend(e),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // Tests reference items that do not exist yet; compile failure here is the
-    // Red signal. Green phase (`/code` next pass) implements `ModelInitError`
-    // and the `From<ProbeError>` mapping inside this module's parent scope.
+    use std::error::Error as _;
+
     use crate::model_init::ModelInitError;
     use crate::model_probe::{PROBE_EXIT_PATH_OUTSIDE_CACHE, ProbeError};
 
-    // T-006: From<ProbeError::HandlerNotInstalled> → Backend(s) where s == Display verbatim
+    // T-006: From<ProbeError::HandlerNotInstalled> → Backend { message } where message == Display verbatim
     #[test]
     fn from_probe_error_handler_not_installed_maps_to_backend_with_verbatim_display() {
         let probe_err = ProbeError::HandlerNotInstalled;
         let display = probe_err.to_string();
         let init_err: ModelInitError = probe_err.into();
-        let ModelInitError::Backend(s) = init_err else {
+        let ModelInitError::Backend { message, .. } = &init_err else {
             panic!("expected ModelInitError::Backend, got: {init_err:?}");
         };
         assert_eq!(
-            s, display,
-            "Backend payload must equal ProbeError::HandlerNotInstalled Display output verbatim"
+            message, &display,
+            "Backend.message must equal ProbeError::HandlerNotInstalled Display output verbatim"
         );
     }
 
@@ -81,7 +97,7 @@ mod tests {
         );
     }
 
-    // T-008: From<ProbeError::SetupRejected { .. }> and other backend-failure variants → Backend(_)
+    // T-008: From<ProbeError::SetupRejected { .. }> and other backend-failure variants → Backend { .. }
     #[test]
     fn from_probe_error_setup_rejected_and_subprocess_failed_both_map_to_backend() {
         let setup_err: ModelInitError = ProbeError::SetupRejected {
@@ -89,17 +105,66 @@ mod tests {
         }
         .into();
         assert!(
-            matches!(setup_err, ModelInitError::Backend(_)),
+            matches!(setup_err, ModelInitError::Backend { .. }),
             "ProbeError::SetupRejected must map to ModelInitError::Backend, got: {setup_err:?}"
         );
 
         let subprocess_err: ModelInitError = ProbeError::SubprocessFailed("y".into()).into();
-        let ModelInitError::Backend(s) = subprocess_err else {
+        let ModelInitError::Backend { message, .. } = subprocess_err else {
             panic!("expected ModelInitError::Backend for SubprocessFailed");
         };
         assert_eq!(
-            s, "y",
-            "SubprocessFailed payload must round-trip through Backend"
+            message, "y",
+            "SubprocessFailed payload must round-trip through Backend.message"
+        );
+    }
+
+    // T-125-A: backend(e) preserves the source error so std::error::Error::source()
+    // walks the chain back to the original typed error.
+    #[test]
+    fn backend_helper_preserves_source_chain() {
+        let probe_err = ProbeError::HandlerNotInstalled;
+        let probe_display = probe_err.to_string();
+        let init_err = ModelInitError::backend(probe_err);
+
+        let source = init_err
+            .source()
+            .expect("backend() must populate Backend.source so the chain is walkable");
+        assert_eq!(
+            source.to_string(),
+            probe_display,
+            "Backend.source must Display verbatim as the originating ProbeError"
+        );
+    }
+
+    // T-125-B: From<ProbeError::SetupRejected> routes through backend() and preserves
+    // the source chain. Guards against a regression that special-cases SetupRejected
+    // to construct Backend { source: None } directly and silently drops the typed error.
+    #[test]
+    fn from_probe_error_setup_rejected_preserves_source_chain() {
+        let init_err: ModelInitError = ProbeError::SetupRejected {
+            code: PROBE_EXIT_PATH_OUTSIDE_CACHE,
+        }
+        .into();
+        let source = init_err
+            .source()
+            .expect("SetupRejected must populate Backend.source via backend()");
+        assert!(
+            source.downcast_ref::<ProbeError>().is_some(),
+            "Backend.source must downcast back to ProbeError, got: {source}"
+        );
+    }
+
+    // T-125-C: SubprocessFailed has only a `String` payload (no upstream typed
+    // error to box), so Backend.source is None — documented contract distinct
+    // from HandlerNotInstalled / SetupRejected.
+    #[test]
+    fn from_probe_error_subprocess_failed_has_no_source() {
+        let init_err: ModelInitError = ProbeError::SubprocessFailed("y".into()).into();
+        assert!(
+            init_err.source().is_none(),
+            "SubprocessFailed maps to Backend with source: None — got source: {:?}",
+            init_err.source().map(ToString::to_string)
         );
     }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -200,7 +200,7 @@ pub(crate) fn assert_cache_lookup_returns_none_when_empty<Id: ModelArtifact>(mod
 pub(crate) fn assert_from_probe_error_maps_correctly() {
     let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
     assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m.contains("probe handler not installed")),
+        matches!(err, ModelInitError::Backend { ref message, .. } if message.contains("probe handler not installed")),
         "{err}"
     );
 
@@ -215,7 +215,7 @@ pub(crate) fn assert_from_probe_error_maps_correctly() {
 
     let err: ModelInitError = ProbeError::SubprocessFailed("spawn failed".into()).into();
     assert!(
-        matches!(err, ModelInitError::Backend(ref m) if m == "spawn failed"),
+        matches!(err, ModelInitError::Backend { ref message, .. } if message == "spawn failed"),
         "{err}"
     );
 }


### PR DESCRIPTION
## 概要

`ModelInitError::Backend` で typed error が `to_string()` 経由で永続的に erase されてた問題を修正。`std::error::Error::source()` で chain 辿れるようにし、production の log aggregation で variant pattern match / downcast 経由の structured filtering を可能にする (Issue #125 Phase 1 / RC-005 / OPS-008).

## 変更点

- `src/model_init.rs`: `Backend(String)` → `Backend { message, source: Option<Box<dyn Error + Send + Sync>> }` に struct variant 化。`backend(e)` ヘルパーを `Display` bound から `Error + Send + Sync + 'static` bound に変更し source を box 化して保存
- `src/model_init.rs`: `From<ProbeError>` の typed-error arm (`HandlerNotInstalled` / `SetupRejected`) を `backend()` 経由にして source 保存。`SubprocessFailed` は元々 `String` payload のため `source: None` で contract 維持
- `src/model_init.rs`: 新規 test 3 件追加 (T-125-A: source chain 保存検証、T-125-B: `SetupRejected` から `ProbeError` への downcast 検証、T-125-C: `SubprocessFailed` の `source: None` contract 明示)
- `src/test_support.rs`: pattern match を新 struct variant 形に追従

## スコープ

- **対象外**: Phase 2 (`dispatch_probe` の `E: Display` bound を `Box<dyn Error>` に変更、`ArtifactError::DownloadFailed` の concern split)。本 PR は Issue #125 Phase 1 のみ

## 設計判断

- **Struct variant 化 (Option C)**: trait object 化 (Option A) や sum type 導入 (Option B) は `dispatch.rs` まで伝播する API path の見直しが必要なため Phase 2 へ。Option C は library 内部で chain 復活させつつ既存呼び出し元に変更不要で段階的移行に適する
- **`message` field 並存**: source の `to_string()` を render 時に呼ぶ案もあったが、construction 時に freeze することで `#[error("model init failed: {message}")]` を既存 Display 出力と byte-identical に保てる (`dispatch.rs` の `.to_string()` consumer に non-breaking)
- **`SubprocessFailed → source: None`**: 元 `String` payload で box する typed source が無い。T-125-C で contract として明示し、全 variant が source 持つと誤解する regression を防止

## 動作確認

1. `cargo test --workspace`: 326 passed / 0 failed / 3 ignored
2. `cargo clippy --workspace --all-targets -- -D warnings`: clean
3. `cargo fmt --check`: clean

## 関連

- Closes #125 (Phase 1 のみ。Phase 2 は別 issue で追跡)
- downstream (amici / yomu / recall / sae) の `Backend(s)` pattern match 更新は merge 後に追従 issue を立てる