### PR TITLE
polish(tests): SUT不在の無意味テスト3件を削除

### DIFF
--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -235,16 +235,4 @@ mod tests {
             "expected event message in subscriber output",
         );
     }
-
-    // T-MET-002: bucket_hist sum invariant equals num_chunks so each chunk is
-    // counted in exactly one bucket across query and batch paths.
-    #[test]
-    fn t_met_002_bucket_hist_sum_matches_num_chunks() {
-        let m = PhaseMetrics {
-            num_chunks: 7,
-            bucket_hist: [2, 3, 1, 1],
-            ..Default::default()
-        };
-        assert_eq!(m.bucket_hist.iter().sum::<usize>(), m.num_chunks);
-    }
 }

--- a/src/embed/workloads.rs
+++ b/src/embed/workloads.rs
@@ -88,11 +88,4 @@ mod tests {
             }
         }
     }
-
-    #[test]
-    fn workloads_are_deterministic() {
-        assert_eq!(workload_w1(), workload_w1());
-        assert_eq!(workload_w2(), workload_w2());
-        assert_eq!(workload_w3(), workload_w3());
-    }
 }

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -77,14 +77,3 @@ pub(crate) fn clear_inference_cache(component: Component) {
         tracing::warn!(component, code, "mlx_detail_compile_clear_cache failed");
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mlx_cache_lock_is_acquirable() {
-        let guard = MLX_CACHE_LOCK.lock().unwrap();
-        drop(guard);
-    }
-}


### PR DESCRIPTION
## 概要

- 振る舞い検証ゼロのテスト3件を削除（標準ライブラリの動作確認 / トートロジーのみ）
- ライブラリスイート緑のまま (323 passed, 3 ignored)
- テスト品質調査の P0 削除系として実施

## 削除対象

| File | Test | 理由 |
| --- | --- | --- |
| `src/embed/metrics.rs` | `t_met_002_bucket_hist_sum_matches_num_chunks` | テスト側で設定した `[2,3,1,1].sum() == 7` を確認するだけで SUT 不在 |
| `src/embed/workloads.rs` | `workloads_are_deterministic` | 純粋関数を2回呼んで等価確認 → コンストラクタ的に常に真 |
| `src/mlx_cache.rs` | `mlx_cache_lock_is_acquirable` | 標準ライブラリ `Mutex<()>` の動作確認のみ |

## 動作確認

- [x] `cargo test --lib` (323 passed, 3 ignored, 0 failed)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`