### PR TITLE
polish(tests): probe_env_to_paths の重複テスト 4件を test_support の generic helper に集約

### DIFF
--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -2,13 +2,13 @@ use super::mlx::shrink_chunk_to_fit;
 use super::*;
 use crate::artifacts::EmbedKind;
 use crate::model_io::{EOS_TOKEN_ID, artifacts_from_cache, load_tokenizer};
-use crate::model_lifecycle::probe_env_to_paths;
 #[cfg(unix)]
-use crate::test_support::setup_fake_hf_cache_with_symlinks;
+use crate::test_support::assert_probe_env_to_paths_preserves_snapshot_symlink_filename;
 use crate::test_support::{
     assert_cache_lookup_returns_none_when_empty,
     assert_cache_lookup_returns_some_when_all_files_present,
-    assert_from_probe_error_maps_correctly, setup_fake_hf_cache,
+    assert_from_probe_error_maps_correctly,
+    assert_probe_env_to_paths_returns_paths_when_all_present, setup_fake_hf_cache,
 };
 use std::fs;
 use std::path::Path;
@@ -120,83 +120,12 @@ fn candidate_verify_returns_invalid_config_for_malformed_config() {
 #[cfg(unix)]
 #[test]
 fn t_018_probe_env_to_paths_preserves_snapshot_symlink_filename() {
-    let hf_home = tempfile::tempdir().unwrap();
-    let cache_root = hf_home.path().join("hub");
-    fs::create_dir_all(&cache_root).unwrap();
-    setup_fake_hf_cache_with_symlinks(
-        &cache_root,
-        "org/model",
-        "dev",
-        &[
-            ("model.safetensors", b"weights"),
-            ("config.json", b"{}"),
-            ("tokenizer.json", b"{}"),
-        ],
-    );
-    let snapshot_dir = cache_root.join("models--org--model/snapshots/abc123");
-    let m = snapshot_dir.join("model.safetensors");
-    let c = snapshot_dir.join("config.json");
-    let t = snapshot_dir.join("tokenizer.json");
-
-    let hf_home_path = hf_home.path().to_path_buf();
-    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = probe_env_to_paths::<EmbedKind>(
-            Some(m.to_string_lossy().into_owned()),
-            Some(c.to_string_lossy().into_owned()),
-            Some(t.to_string_lossy().into_owned()),
-        )
-        .unwrap()
-        .unwrap();
-        // Critical regression assertion: load path must be the snapshot
-        // symlink (filename ends in "model.safetensors"), not the
-        // canonicalized blob path (which would be "etag-model.safetensors").
-        assert_eq!(
-            candidate.paths.model.file_name().and_then(|s| s.to_str()),
-            Some("model.safetensors"),
-            "regression: probe_env_to_paths must preserve snapshot symlink filename"
-        );
-        assert_eq!(
-            candidate.paths.config.file_name().and_then(|s| s.to_str()),
-            Some("config.json")
-        );
-        assert_eq!(
-            candidate
-                .paths
-                .tokenizer
-                .file_name()
-                .and_then(|s| s.to_str()),
-            Some("tokenizer.json")
-        );
-    });
+    assert_probe_env_to_paths_preserves_snapshot_symlink_filename::<EmbedKind>();
 }
 
 #[test]
 fn probe_env_to_paths_returns_paths_when_all_present() {
-    let hf_home = tempfile::tempdir().unwrap();
-    let cache_root = hf_home.path().join("hub");
-    fs::create_dir_all(&cache_root).unwrap();
-    let m = cache_root.join("model.safetensors");
-    let c = cache_root.join("config.json");
-    let t = cache_root.join("tokenizer.json");
-    fs::write(&m, b"").unwrap();
-    fs::write(&c, b"{}").unwrap();
-    fs::write(&t, b"{}").unwrap();
-
-    let hf_home_path = hf_home.path().to_path_buf();
-    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = probe_env_to_paths::<EmbedKind>(
-            Some(m.to_string_lossy().into_owned()),
-            Some(c.to_string_lossy().into_owned()),
-            Some(t.to_string_lossy().into_owned()),
-        )
-        .unwrap()
-        .unwrap();
-        // paths field is accessible within the embed module (child module can access parent's private)
-        // load step receives original (non-canonicalized) paths so HF cache symlinks survive
-        assert_eq!(candidate.paths.model, m);
-        assert_eq!(candidate.paths.config, c);
-        assert_eq!(candidate.paths.tokenizer, t);
-    });
+    assert_probe_env_to_paths_returns_paths_when_all_present::<EmbedKind>();
 }
 
 #[test]

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -1,13 +1,13 @@
 use super::mlx::truncate_pair;
 use super::*;
 use crate::artifacts::RerankerKind;
-use crate::model_lifecycle::probe_env_to_paths;
 #[cfg(unix)]
-use crate::test_support::setup_fake_hf_cache_with_symlinks;
+use crate::test_support::assert_probe_env_to_paths_preserves_snapshot_symlink_filename;
 use crate::test_support::{
     VALID_CONFIG_JSON, assert_cache_lookup_returns_none_when_empty,
     assert_cache_lookup_returns_some_when_all_files_present,
     assert_from_probe_error_maps_correctly,
+    assert_probe_env_to_paths_returns_paths_when_all_present,
 };
 use std::fs;
 
@@ -110,78 +110,12 @@ fn t_015_candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
 #[cfg(unix)]
 #[test]
 fn t_019_probe_env_to_paths_preserves_snapshot_symlink_filename() {
-    let hf_home = tempfile::tempdir().unwrap();
-    let cache_root = hf_home.path().join("hub");
-    fs::create_dir_all(&cache_root).unwrap();
-    setup_fake_hf_cache_with_symlinks(
-        &cache_root,
-        "org/reranker",
-        "dev",
-        &[
-            ("model.safetensors", b"weights"),
-            ("config.json", b"{}"),
-            ("tokenizer.json", b"{}"),
-        ],
-    );
-    let snapshot_dir = cache_root.join("models--org--reranker/snapshots/abc123");
-    let m = snapshot_dir.join("model.safetensors");
-    let c = snapshot_dir.join("config.json");
-    let t = snapshot_dir.join("tokenizer.json");
-
-    let hf_home_path = hf_home.path().to_path_buf();
-    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let candidate = probe_env_to_paths::<RerankerKind>(
-            Some(m.to_string_lossy().into_owned()),
-            Some(c.to_string_lossy().into_owned()),
-            Some(t.to_string_lossy().into_owned()),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(
-            candidate.paths.model.file_name().and_then(|s| s.to_str()),
-            Some("model.safetensors"),
-            "regression: probe_env_to_paths must preserve snapshot symlink filename"
-        );
-        assert_eq!(
-            candidate.paths.config.file_name().and_then(|s| s.to_str()),
-            Some("config.json")
-        );
-        assert_eq!(
-            candidate
-                .paths
-                .tokenizer
-                .file_name()
-                .and_then(|s| s.to_str()),
-            Some("tokenizer.json")
-        );
-    });
+    assert_probe_env_to_paths_preserves_snapshot_symlink_filename::<RerankerKind>();
 }
 
 #[test]
-fn probe_env_to_paths_returns_ok_when_all_present() {
-    let hf_home = tempfile::tempdir().unwrap();
-    let cache_root = hf_home.path().join("hub");
-    fs::create_dir_all(&cache_root).unwrap();
-    let m = cache_root.join("model.safetensors");
-    let c = cache_root.join("config.json");
-    let t = cache_root.join("tokenizer.json");
-    fs::write(&m, b"").unwrap();
-    fs::write(&c, b"{}").unwrap();
-    fs::write(&t, b"{}").unwrap();
-
-    let hf_home_path = hf_home.path().to_path_buf();
-    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-        let result = probe_env_to_paths::<RerankerKind>(
-            Some(m.to_string_lossy().into_owned()),
-            Some(c.to_string_lossy().into_owned()),
-            Some(t.to_string_lossy().into_owned()),
-        );
-        // CandidateArtifacts is returned with original (non-canonicalized) paths
-        let candidate = result.unwrap().unwrap();
-        assert_eq!(candidate.paths.model, m);
-        assert_eq!(candidate.paths.config, c);
-        assert_eq!(candidate.paths.tokenizer, t);
-    });
+fn probe_env_to_paths_returns_paths_when_all_present() {
+    assert_probe_env_to_paths_returns_paths_when_all_present::<RerankerKind>();
 }
 
 #[test]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -3,8 +3,10 @@
 use std::fs;
 use std::path::Path;
 
+use crate::artifacts::ModelKind;
 use crate::model_init::ModelInitError;
 use crate::model_io::{ModelArtifact, artifacts_from_cache};
+use crate::model_lifecycle::probe_env_to_paths;
 use crate::model_probe::ProbeError;
 
 /// Valid ModernBERT config JSON with all required fields, for use in tests
@@ -218,6 +220,91 @@ pub(crate) fn assert_from_probe_error_maps_correctly() {
         matches!(err, ModelInitError::Backend { ref message, .. } if message == "spawn failed"),
         "{err}"
     );
+}
+
+/// Generic helper for the Issue #107 regression: `probe_env_to_paths` must
+/// return the snapshot symlink path, not the canonicalized blob path.
+///
+/// MLX `load_safetensors` dispatches on filename extension, so substituting
+/// the blob path (`etag-model.safetensors`) for the snapshot link
+/// (`model.safetensors`) breaks the load step. Verified for both
+/// `EmbedKind` and `RerankerKind` from their respective test files.
+#[cfg(unix)]
+pub(crate) fn assert_probe_env_to_paths_preserves_snapshot_symlink_filename<K: ModelKind>() {
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    setup_fake_hf_cache_with_symlinks(
+        &cache_root,
+        "org/model",
+        "dev",
+        &[
+            ("model.safetensors", b"weights"),
+            ("config.json", b"{}"),
+            ("tokenizer.json", b"{}"),
+        ],
+    );
+    let snapshot_dir = cache_root.join("models--org--model/snapshots/abc123");
+    let m = snapshot_dir.join("model.safetensors");
+    let c = snapshot_dir.join("config.json");
+    let t = snapshot_dir.join("tokenizer.json");
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let candidate = probe_env_to_paths::<K>(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            candidate.paths.model.file_name().and_then(|s| s.to_str()),
+            Some("model.safetensors"),
+            "regression: probe_env_to_paths must preserve snapshot symlink filename"
+        );
+        assert_eq!(
+            candidate.paths.config.file_name().and_then(|s| s.to_str()),
+            Some("config.json")
+        );
+        assert_eq!(
+            candidate
+                .paths
+                .tokenizer
+                .file_name()
+                .and_then(|s| s.to_str()),
+            Some("tokenizer.json")
+        );
+    });
+}
+
+/// Generic helper: `probe_env_to_paths` returns the original
+/// (non-canonicalized) paths in `CandidateArtifacts.paths`. The load step
+/// then receives the snapshot symlink, so HF cache symlinks survive.
+pub(crate) fn assert_probe_env_to_paths_returns_paths_when_all_present<K: ModelKind>() {
+    let hf_home = tempfile::tempdir().unwrap();
+    let cache_root = hf_home.path().join("hub");
+    fs::create_dir_all(&cache_root).unwrap();
+    let m = cache_root.join("model.safetensors");
+    let c = cache_root.join("config.json");
+    let t = cache_root.join("tokenizer.json");
+    fs::write(&m, b"").unwrap();
+    fs::write(&c, b"{}").unwrap();
+    fs::write(&t, b"{}").unwrap();
+
+    let hf_home_path = hf_home.path().to_path_buf();
+    temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
+        let candidate = probe_env_to_paths::<K>(
+            Some(m.to_string_lossy().into_owned()),
+            Some(c.to_string_lossy().into_owned()),
+            Some(t.to_string_lossy().into_owned()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(candidate.paths.model, m);
+        assert_eq!(candidate.paths.config, c);
+        assert_eq!(candidate.paths.tokenizer, t);
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

- `embed/tests.rs` と `reranker/tests.rs` の ~50行コピペテスト 2 ペアを `K: ModelKind` の generic helper 2 件に集約
- 各テスト本体は 1 行の type-argument wrapper になり、不変条件の変更が 1 箇所で完結
- `cargo test --lib` 緑（317 passed / 3 ignored / 0 failed）

## 動機

下記 4 テストはボディがほぼコピペで、`<EmbedKind>` / `<RerankerKind>` の差だけだった：

| File                  | Test                                             | 内容                                  |
| --------------------- | ------------------------------------------------ | ------------------------------------- |
| `embed/tests.rs`      | `t_018_probe_env_to_paths_preserves_snapshot_symlink_filename` (cfg unix) | symlink filename 保持（Issue #107 regression） |
| `reranker/tests.rs`   | `t_019_probe_env_to_paths_preserves_snapshot_symlink_filename` (cfg unix) | 同上                                  |
| `embed/tests.rs`      | `probe_env_to_paths_returns_paths_when_all_present` | paths field round-trips uncanonicalized |
| `reranker/tests.rs`   | `probe_env_to_paths_returns_ok_when_all_present`    | 同上                                  |

不変条件（symlink 保持や paths round-trip）の変更時に4ヶ所更新する必要があり、ドリフトが起きやすかった。

## 変更内容

### `src/test_support.rs` に generic helper 2件を追加

```rust
#[cfg(unix)]
pub(crate) fn assert_probe_env_to_paths_preserves_snapshot_symlink_filename<K: ModelKind>() {
    // setup_fake_hf_cache_with_symlinks → probe_env_to_paths::<K> → assert filename
}

pub(crate) fn assert_probe_env_to_paths_returns_paths_when_all_present<K: ModelKind>() {
    // tempdir → probe_env_to_paths::<K> → assert paths == originals
}
```

### 各テストは 1 行 wrapper に

```rust
#[cfg(unix)]
#[test]
fn t_018_probe_env_to_paths_preserves_snapshot_symlink_filename() {
    assert_probe_env_to_paths_preserves_snapshot_symlink_filename::<EmbedKind>();
}
```

reranker 側は `<RerankerKind>` で同形。

## 動作確認

- [x] `cargo test --lib`（317 passed / 3 ignored）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## 差分

`3 files changed, 97 insertions(+), 147 deletions(-)`（実質 -50行）

| File                  | 増減   |
| --------------------- | ------ |
| `src/test_support.rs` | +87    |
| `src/embed/tests.rs`  | -77    |
| `src/reranker/tests.rs` | -72  |