### PR TITLE
polish(tests): T-NNN プレフィックスを LANG.md 準拠のコメント形式に移行

### DIFF
--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -590,76 +590,89 @@ mod tests {
         Ok(SanitizedFtsQuery(s.to_owned()))
     }
 
+    // T-001: near_removal
     #[test]
-    fn t001_near_removal() {
+    fn near_removal() {
         assert_eq!(sanitize_fts_query("NEAR(a b) hello"), ok("hello"));
     }
 
+    // T-001b: near_with_distance
     #[test]
-    fn t001b_near_with_distance() {
+    fn near_with_distance() {
         assert_eq!(sanitize_fts_query("NEAR/3(a b c) hello"), ok("hello"));
     }
 
+    // T-001c: near_unclosed_paren
     #[test]
-    fn t001c_near_unclosed_paren() {
+    fn near_unclosed_paren() {
         assert_eq!(
             sanitize_fts_query("NEAR(a b hello"),
             Err(SanitizeError::NoSearchableTerms)
         );
     }
 
+    // T-002: auto_quote_hyphen
     #[test]
-    fn t002_auto_quote_hyphen() {
+    fn auto_quote_hyphen() {
         assert_eq!(sanitize_fts_query("rate-limit"), ok("\"rate-limit\""));
     }
 
+    // T-003: auto_quote_colon
     #[test]
-    fn t003_auto_quote_colon() {
+    fn auto_quote_colon() {
         assert_eq!(sanitize_fts_query("std::io"), ok("\"std::io\""));
     }
 
+    // T-004: prefix_strip
     #[test]
-    fn t004_prefix_strip() {
+    fn prefix_strip() {
         assert_eq!(sanitize_fts_query("^+hello"), ok("hello"));
     }
 
+    // T-005b: quote_balancing_exact_output
     #[test]
-    fn t005b_quote_balancing_exact_output() {
+    fn quote_balancing_exact_output() {
         assert_eq!(sanitize_fts_query("unbalanced\""), ok("unbalanced\"\""));
     }
 
+    // T-006: empty_input
     #[test]
-    fn t006_empty_input() {
+    fn empty_input() {
         assert_eq!(sanitize_fts_query(""), Err(SanitizeError::EmptyInput));
     }
 
+    // T-006b: whitespace_only
     #[test]
-    fn t006b_whitespace_only() {
+    fn whitespace_only() {
         assert_eq!(sanitize_fts_query("   "), Err(SanitizeError::EmptyInput));
     }
 
+    // T-011: sandwiched_operator_preserved
     #[test]
-    fn t011_sandwiched_operator_preserved() {
+    fn sandwiched_operator_preserved() {
         assert_eq!(sanitize_fts_query("foo AND bar"), ok("foo AND bar"));
         assert_eq!(sanitize_fts_query("foo OR bar"), ok("foo OR bar"));
     }
 
+    // T-012: dangling_operator_dropped
     #[test]
-    fn t012_dangling_operator_dropped() {
+    fn dangling_operator_dropped() {
         // Leading/trailing operators without both neighbours are dropped.
         assert_eq!(sanitize_fts_query("NOT secret"), ok("secret"));
         assert_eq!(sanitize_fts_query("foo OR"), ok("foo"));
     }
 
+    // T-012b: consecutive_operators_between_terms
     #[test]
-    fn t012b_consecutive_operators_between_terms() {
+    fn consecutive_operators_between_terms() {
         // Neither AND nor OR has a non-operator on both sides → both dropped.
         assert_eq!(sanitize_fts_query("foo AND OR bar"), ok("foo bar"));
         assert_eq!(sanitize_fts_query("NOT foo NOT"), ok("foo"));
     }
 
+    // T-013: operator_only_returns_error
     #[test]
-    fn t013_operator_only_returns_error() {
+    fn operator_only_returns_error() {
         assert_eq!(
             sanitize_fts_query("NOT"),
             Err(SanitizeError::NoSearchableTerms)
@@ -670,58 +683,67 @@ mod tests {
         );
     }
 
+    // T-014: near_then_dangling_operator
     #[test]
-    fn t014_near_then_dangling_operator() {
+    fn near_then_dangling_operator() {
         // "foo OR NEAR(bar baz)" → NEAR stripped → "foo OR" → OR dangling → "foo"
         assert_eq!(sanitize_fts_query("foo OR NEAR(bar baz)"), ok("foo"));
     }
 
+    // T-015: case_insensitive_operators
     #[test]
-    fn t015_case_insensitive_operators() {
+    fn case_insensitive_operators() {
         assert_eq!(sanitize_fts_query("foo or bar"), ok("foo or bar"));
         assert_eq!(sanitize_fts_query("Not secret"), ok("secret"));
     }
 
+    // T-016: prefix_only_returns_error
     #[test]
-    fn t016_prefix_only_returns_error() {
+    fn prefix_only_returns_error() {
         assert_eq!(
             sanitize_fts_query("^"),
             Err(SanitizeError::NoSearchableTerms)
         );
     }
 
+    // T-007: age_zero_returns_one
     #[test]
-    fn t007_age_zero_returns_one() {
+    fn age_zero_returns_one() {
         let result = recency_decay(0.0, 30.0);
         assert!((result - 1.0).abs() < f64::EPSILON);
     }
 
+    // T-008: one_half_life_returns_half
     #[test]
-    fn t008_one_half_life_returns_half() {
+    fn one_half_life_returns_half() {
         let result = recency_decay(30.0, 30.0);
         assert!((result - 0.5).abs() < 0.01);
     }
 
+    // T-009: two_half_lives_returns_quarter
     #[test]
-    fn t009_two_half_lives_returns_quarter() {
+    fn two_half_lives_returns_quarter() {
         let result = recency_decay(60.0, 30.0);
         assert!((result - 0.25).abs() < 0.01);
     }
 
+    // T-010: zero_half_life_returns_zero
     #[test]
-    fn t010_zero_half_life_returns_zero() {
+    fn zero_half_life_returns_zero() {
         let result = recency_decay(0.0, 0.0);
         assert!((result - 0.0).abs() < f64::EPSILON);
     }
 
+    // T-010b: negative_half_life_returns_zero
     #[test]
-    fn t010b_negative_half_life_returns_zero() {
+    fn negative_half_life_returns_zero() {
         let result = recency_decay(5.0, -1.0);
         assert!((result - 0.0).abs() < f64::EPSILON);
     }
 
+    // T-010c: negative_age_clamped_to_one
     #[test]
-    fn t010c_negative_age_clamped_to_one() {
+    fn negative_age_clamped_to_one() {
         let result = recency_decay(-5.0, 30.0);
         assert!((result - 1.0).abs() < f64::EPSILON);
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -31,8 +31,9 @@ pub fn split_text(text: &str, max_bytes: usize) -> Vec<&str> {
 mod tests {
     use crate::text::split_text;
 
+    // T-011: splits_large_text_into_bounded_fragments
     #[test]
-    fn t011_splits_large_text_into_bounded_fragments() {
+    fn splits_large_text_into_bounded_fragments() {
         let text = "a".repeat(20_000);
         let fragments = split_text(&text, 16_000);
         assert_eq!(fragments.len(), 2);
@@ -45,8 +46,9 @@ mod tests {
         }
     }
 
+    // T-012: splits_at_paragraph_boundary
     #[test]
-    fn t012_splits_at_paragraph_boundary() {
+    fn splits_at_paragraph_boundary() {
         let text = "paragraph one\n\nparagraph two\n\nparagraph three";
         let max = "paragraph one\n\nparagraph two".len();
         let fragments = split_text(text, max);
@@ -54,8 +56,9 @@ mod tests {
         assert!(!fragments[0].ends_with("\n\np"));
     }
 
+    // T-013: falls_back_to_line_boundary
     #[test]
-    fn t013_falls_back_to_line_boundary() {
+    fn falls_back_to_line_boundary() {
         let text = "line one\nline two\nline three\nline four";
         let max = "line one\nline two".len();
         let fragments = split_text(text, max);
@@ -63,24 +66,27 @@ mod tests {
         assert!(!fragments[0].contains("line three"));
     }
 
+    // T-015: no_split_when_under_limit
     #[test]
-    fn t015_no_split_when_under_limit() {
+    fn no_split_when_under_limit() {
         let text = "short text";
         let fragments = split_text(text, 1000);
         assert_eq!(fragments.len(), 1);
         assert_eq!(fragments[0], text);
     }
 
+    // T-016: max_bytes_below_4_returns_input_as_is
     #[test]
-    fn t016_max_bytes_below_4_returns_input_as_is() {
+    fn max_bytes_below_4_returns_input_as_is() {
         let text = "hello world";
         let fragments = split_text(text, 3);
         assert_eq!(fragments.len(), 1);
         assert_eq!(fragments[0], text);
     }
 
+    // T-011b: char_boundary_fallback_no_newlines
     #[test]
-    fn t011b_char_boundary_fallback_no_newlines() {
+    fn char_boundary_fallback_no_newlines() {
         let text = "あいうえおか"; // 6 chars, 18 bytes
         let fragments = split_text(text, 10);
         assert!(
@@ -102,8 +108,9 @@ mod tests {
         );
     }
 
+    // T-015b: exact_boundary_no_split
     #[test]
-    fn t015b_exact_boundary_no_split() {
+    fn exact_boundary_no_split() {
         let text = "abcdefghij"; // 10 bytes
         let fragments = split_text(text, 10);
         assert_eq!(fragments.len(), 1);


### PR DESCRIPTION
## 概要

- `text.rs` (7件) と `storage/search.rs` (22件) の `fn tNNN_*` 形式を、LANG.md 準拠の `// T-NNN: function_name` コメント形式へ移行
- 機械的リネームのみ — テスト本体・アサーション・件数は不変
- `cargo test --lib` 緑（317 passed / 3 ignored / 0 failed）

## 動機

LANG.md の Testing 規約は T-NNN 識別子をコメント prefix で書くと指定：

> | T-NNN identifier | Prefix each test with `// T-NNN: function_name` immediately before `#[test]` |

しかし `text.rs` と `storage/search.rs` だけは関数名に直接埋め込む形（`fn t011_splits_*`、`fn t001_near_removal`）になっており、他モジュール（`artifacts.rs` / `model_init.rs` / `model_io.rs` / `model_lifecycle.rs` / `embed/pooling.rs` / `embed/linreg.rs` / `embed/metrics.rs`）の comment-prefix 形式と不揃いだった。

## 変更内容

### 移行前後の対比

```rust
// 移行前
#[test]
fn t001_near_removal() { ... }

// 移行後
// T-001: near_removal
#[test]
fn near_removal() { ... }
```

### 対象 T-NNN

| File                  | T-NNN                                                                                                   | 件数 |
| --------------------- | ------------------------------------------------------------------------------------------------------- | ---- |
| `src/text.rs`         | T-011, T-011b, T-012, T-013, T-015, T-015b, T-016                                                       | 7    |
| `src/storage/search.rs` | T-001/1b/1c, T-002, T-003, T-004, T-005b, T-006/6b, T-007, T-008, T-009, T-010/10b/10c, T-011, T-012/12b, T-013, T-014, T-015, T-016 | 22   |
| 合計                  |                                                                                                         | **29** |

### スコープ外（後続 PR 候補）

- 関数名そのものの descriptiveness 改善（例：`empty_input` → `sanitize_empty_input_returns_error`）はスコープ外。今回は LANG.md 形式コンプライアンスのみ。

## 動作確認

- [x] `cargo test --lib`（317 passed / 3 ignored）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `ugrep -c '^    fn t[0-9]' src/text.rs src/storage/search.rs` で 0 件確認

## 差分

`2 files changed, 58 insertions(+), 29 deletions(-)`（コメント追加分の純増）