### PR TITLE
polish(tests): handle_probe_if_needed_with テストに lookup 呼び出し回数 assert を追加

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -65,27 +65,53 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
     use std::collections::HashMap;
 
-    fn lookup_from(map: &HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
-        let owned: HashMap<String, String> = map
-            .iter()
-            .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-            .collect();
-        move |key: &str| owned.get(key).cloned()
-    }
+    /// Per-kind query count from `handle_probe_if_needed_with`: every kind
+    /// reads `model`, `config`, and `tokenizer` regardless of branch outcome.
+    /// With embed + reranker dispatched in sequence, the lookup is called
+    /// `2 * 3 = 6` times when neither kind triggers a probe.
+    const NO_DISPATCH_LOOKUP_COUNT: usize = 6;
 
     #[test]
     fn handle_probe_if_needed_with_returns_when_no_env_set() {
-        let map: HashMap<&'static str, &'static str> = HashMap::new();
-        handle_probe_if_needed_with(lookup_from(&map));
+        let calls = Cell::new(0_usize);
+        handle_probe_if_needed_with(|_key| {
+            calls.set(calls.get() + 1);
+            None
+        });
+        // The function returned (no `process::exit` from `dispatch_probe`)
+        // and still consulted every PROBE_ENV_* var — the empty env path
+        // short-circuits at `probe_env_to_paths` returning None for both kinds.
+        assert_eq!(
+            calls.get(),
+            NO_DISPATCH_LOOKUP_COUNT,
+            "lookup must be queried for embed + reranker × {{model, config, tokenizer}}"
+        );
     }
 
     #[test]
     fn handle_probe_if_needed_with_skips_paths_without_primary_keys() {
-        let mut map = HashMap::new();
-        map.insert(embed::PROBE_ENV_CONFIG, "/tmp/c");
-        map.insert(reranker::PROBE_ENV_TOKENIZER, "/tmp/t");
-        handle_probe_if_needed_with(lookup_from(&map));
+        let calls = Cell::new(0_usize);
+        let map: HashMap<&'static str, &'static str> = [
+            (embed::PROBE_ENV_CONFIG, "/tmp/c"),
+            (reranker::PROBE_ENV_TOKENIZER, "/tmp/t"),
+        ]
+        .into_iter()
+        .collect();
+        handle_probe_if_needed_with(|key| {
+            calls.set(calls.get() + 1);
+            map.get(key).map(|v| (*v).to_owned())
+        });
+        // PROBE_ENV_MODEL is absent for both kinds, so `resolve_probe_env`
+        // returns None and dispatch is skipped — guards against a regression
+        // where setting only secondary keys tricks the function into spawning
+        // a probe.
+        assert_eq!(
+            calls.get(),
+            NO_DISPATCH_LOOKUP_COUNT,
+            "lookup must be queried for all three vars per kind even when only secondary keys are set"
+        );
     }
 }


### PR DESCRIPTION
## 概要

- `dispatch.rs` の assertion-less な 2 テストに、`Cell<usize>` で lookup 呼び出し回数を計上する明示的 assertion を追加
- 暗黙の「panic しない / `process::exit` しない」契約を、観測可能な数値で固定化
- `cargo test --lib` 緑（317 passed / 3 ignored / 0 failed）

## 動機

`handle_probe_if_needed_with_returns_when_no_env_set` と
`handle_probe_if_needed_with_skips_paths_without_primary_keys` は元々こうやった：

```rust
#[test]
fn handle_probe_if_needed_with_returns_when_no_env_set() {
    let map: HashMap<&'static str, &'static str> = HashMap::new();
    handle_probe_if_needed_with(lookup_from(&map));
}
```

assertion ゼロ — `dispatch_probe` が `process::exit` 呼んだらテストランナーが落ちる、という副作用に依存しただけの暗黙 contract やった。テスト失敗時に何が崩れたかが追えへん。

## 変更内容

### `Cell<usize>` で lookup 呼び出し回数を計測

```rust
const NO_DISPATCH_LOOKUP_COUNT: usize = 6;

#[test]
fn handle_probe_if_needed_with_returns_when_no_env_set() {
    let calls = Cell::new(0_usize);
    handle_probe_if_needed_with(|_key| {
        calls.set(calls.get() + 1);
        None
    });
    assert_eq!(calls.get(), NO_DISPATCH_LOOKUP_COUNT, "...");
}
```

### 検証する2点

1. **両 kind が env-resolution に到達した**: 6 回 = embed + reranker × {model, config, tokenizer}
2. **dispatch されてない**: `dispatch_probe` が呼ばれてたらテストランナーが `process::exit` で死ぬ → assertion 到達したことが no-dispatch の証拠

### `lookup_from` helper は除去

クロージャを inline したため不要に。

## 動作確認

- [x] `cargo test --lib`（317 passed / 3 ignored）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## 差分

`1 file changed, 39 insertions(+), 13 deletions(-)`

## P3 スコープ

調査レポート時点で P3 には2項目あった：

| 項目                                            | 状態 |
| ----------------------------------------------- | ---- |
| `dispatch.rs` の assert 追加                    | ✅ 本PR |
| compile-time test に runtime assert 追加        | ❌ 見送り |

compile-time test 系（`embed/pooling.rs t_004`、`model_lifecycle.rs t_010 / t_011`）への runtime assert 追加は、検証対象に意味のある runtime check が無く `assert!(true)` 的なトートロジー（LANG.md anti-pattern）になるため見送り。