### PR TITLE
polish(tests): hybrid T-NNN プレフィックスを 7 ファイル 64 件に渡って LANG.md コメント形式へ統一

### DIFF
--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -860,7 +860,7 @@ mod tests {
     // and `embed_query_truncated` rely on after the GPU pool reduces
     // readback to `batch * hidden` floats.
     #[test]
-    fn t_012a_split_pooled_happy_path_preserves_row_major_order() {
+    fn split_pooled_happy_path_preserves_row_major_order() {
         let flat: Vec<f32> = vec![
             0.0, 1.0, 2.0, 3.0, // row 0
             4.0, 5.0, 6.0, 7.0, // row 1
@@ -887,7 +887,7 @@ mod tests {
     // whole point of the helper, which is to fail fast rather than silently
     // slice an incomplete final row.
     #[test]
-    fn t_012b_split_pooled_shape_mismatch_short_returns_buffer_shape_mismatch() {
+    fn split_pooled_shape_mismatch_short_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // len 7
         match split_pooled(&flat, 2, 4, EmbedKind::Query) {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
@@ -908,7 +908,7 @@ mod tests {
     // implementer that reads the first `batch * hidden` floats and silently
     // drops the tail — short-direction tests alone would not catch that.
     #[test]
-    fn t_012c_split_pooled_shape_mismatch_long_returns_buffer_shape_mismatch() {
+    fn split_pooled_shape_mismatch_long_returns_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 99.0]; // len 9
         match split_pooled(&flat, 2, 4, EmbedKind::Query) {
             Err(EmbedError::BufferShapeMismatch { expected, actual }) => {
@@ -930,7 +930,7 @@ mod tests {
     // Documents the "empty input is not an error" branch so a future
     // implementer cannot accidentally treat zero as the mismatch case.
     #[test]
-    fn t_012d_split_pooled_zero_batch_returns_empty_vec() {
+    fn split_pooled_zero_batch_returns_empty_vec() {
         let flat: Vec<f32> = Vec::new();
         let split =
             split_pooled(&flat, 0, 768, EmbedKind::Query).expect("zero-batch flat must split ok");
@@ -947,7 +947,7 @@ mod tests {
     // and unwraps the single inner row. Verifies the helper does not require
     // `batch >= 2`.
     #[test]
-    fn t_012e_split_pooled_single_batch_for_embed_query_path() {
+    fn split_pooled_single_batch_for_embed_query_path() {
         let flat: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4, 0.5];
         let split =
             split_pooled(&flat, 1, 5, EmbedKind::Query).expect("single-batch must split ok");
@@ -975,7 +975,7 @@ mod tests {
     // defeat `release_inference_output(pooled)` and is caught by the same
     // line below.
     #[test]
-    fn t_014_pool_output_signature_consumes_output_by_value() {
+    fn pool_output_signature_consumes_output_by_value() {
         let _coerce: fn(Array, &[u32], i32, i32) -> Result<Array, EmbedError> = pool_output;
     }
 
@@ -989,7 +989,7 @@ mod tests {
     // on the already-readback flat buffer so it does not defeat the
     // readback-free hot path (ADR 0002 primary lever).
     #[test]
-    fn t_015a_split_pooled_rejects_nan_with_non_finite_output() {
+    fn split_pooled_rejects_nan_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
         match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
@@ -1004,7 +1004,7 @@ mod tests {
     // failure mode separately so a regression that handles only `NaN` is
     // caught.
     #[test]
-    fn t_015b_split_pooled_rejects_positive_inf_with_non_finite_output() {
+    fn split_pooled_rejects_positive_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, f32::INFINITY, 2.0, 3.0];
         match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
@@ -1019,7 +1019,7 @@ mod tests {
     // assumption explicitly so a future check that uses `> f32::MAX`
     // alone would fail.
     #[test]
-    fn t_015c_split_pooled_rejects_negative_inf_with_non_finite_output() {
+    fn split_pooled_rejects_negative_inf_with_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, 2.0, f32::NEG_INFINITY];
         match split_pooled(&flat, 1, 4, EmbedKind::Query) {
             Err(EmbedError::NonFiniteOutput) => {}
@@ -1030,7 +1030,7 @@ mod tests {
     // T-012f (sub-case of spec T-012): emits warn so operators can diagnose corrupt readback (see ADR 0007).
     #[traced_test]
     #[test]
-    fn t_012f_split_pooled_emits_warn_on_buffer_shape_mismatch() {
+    fn split_pooled_emits_warn_on_buffer_shape_mismatch() {
         let flat: Vec<f32> = vec![0.0; 7]; // expected 8
         let _ = split_pooled(&flat, 2, 4, EmbedKind::Query);
         assert!(
@@ -1047,7 +1047,7 @@ mod tests {
     // weights from upstream input errors (see ADR 0007).
     #[traced_test]
     #[test]
-    fn t_015d_split_pooled_emits_warn_on_non_finite_output() {
+    fn split_pooled_emits_warn_on_non_finite_output() {
         let flat: Vec<f32> = vec![0.0, 1.0, f32::NAN, 3.0];
         let _ = split_pooled(&flat, 1, 4, EmbedKind::Query);
         assert!(

--- a/src/embed/pooling.rs
+++ b/src/embed/pooling.rs
@@ -64,7 +64,7 @@ mod tests {
     // coercion below fails to typecheck and this test refuses to compile —
     // which is the intended regression signal for AC-3.
     #[test]
-    fn t_004_gpu_pool_signature_consumes_hidden_by_value() {
+    fn gpu_pool_signature_consumes_hidden_by_value() {
         let _coerce: fn(Array, &Array) -> Result<Array, Exception> = gpu_pool_and_normalize;
     }
 
@@ -99,7 +99,7 @@ mod tests {
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_001_small_shape_pool_yields_unit_norm_rows() {
+        fn small_shape_pool_yields_unit_norm_rows() {
             require_unsandboxed_mlx_runtime();
             let hidden = make_hidden(2, 4, 3);
             let mask = Array::from_slice(&[1u32, 1, 0, 0, 1, 1, 1, 0], &[2, 4]);
@@ -132,7 +132,7 @@ mod tests {
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_003_large_w1_shape_produces_finite_output() {
+        fn large_w1_shape_produces_finite_output() {
             require_unsandboxed_mlx_runtime();
             let batch = 1i32;
             let seq = 8192i32;
@@ -186,7 +186,7 @@ mod tests {
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_005_u32_mask_cast_to_f32_succeeds() {
+        fn u32_mask_cast_to_f32_succeeds() {
             require_unsandboxed_mlx_runtime();
             let hidden = make_hidden(1, 3, 2);
             let mask = Array::from_slice(&[1u32, 0, 1], &[1, 3]);
@@ -220,7 +220,7 @@ mod tests {
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_011_all_zero_mask_propagates_nan_without_internal_guard() {
+        fn all_zero_mask_propagates_nan_without_internal_guard() {
             require_unsandboxed_mlx_runtime();
             let hidden = make_hidden(2, 3, 4);
             let mask = Array::from_slice(&[1u32, 1, 0, 0, 0, 0], &[2, 3]);

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -119,7 +119,7 @@ fn candidate_verify_returns_invalid_config_for_malformed_config() {
 // extension-based dispatch across all standard HF cache usage.
 #[cfg(unix)]
 #[test]
-fn t_018_probe_env_to_paths_preserves_snapshot_symlink_filename() {
+fn probe_env_to_paths_preserves_snapshot_symlink_filename() {
     assert_probe_env_to_paths_preserves_snapshot_symlink_filename::<EmbedKind>();
 }
 
@@ -182,8 +182,9 @@ fn shrink_chunk_to_fit_short_text_returns_immediately() {
 
 // --- T-001: max_content computation ---
 
+// T-001: max_content_equals_max_seq_len_minus_2_minus_prefix_len
 #[test]
-fn t_001_max_content_equals_max_seq_len_minus_2_minus_prefix_len() {
+fn max_content_equals_max_seq_len_minus_2_minus_prefix_len() {
     // [T-001] FR-001, FR-002: max_content(10) == 8180, 8180 + 10 + 2 == 8192
     assert_eq!(max_content(10), 8180);
     assert_eq!(8180 + 10 + 2, MAX_SEQ_LEN);
@@ -198,8 +199,9 @@ fn g_001_real_tokenizer_extract_prefix_tokens() {
     assert!(!prefix_tokens.is_empty());
 }
 
+// T-008: truncate_for_query_shortens_to_max_len
 #[test]
-fn t_008_truncate_for_query_shortens_to_max_len() {
+fn truncate_for_query_shortens_to_max_len() {
     // [T-008] FR-005: query truncation
     let input_ids: Vec<u32> = (0..100).collect();
     let first_token = input_ids[0];
@@ -216,8 +218,9 @@ fn t_008_truncate_for_query_shortens_to_max_len() {
     assert_eq!(ids[0], first_token);
 }
 
+// T-008b: truncate_for_query_noop_when_short
 #[test]
-fn t_008b_truncate_for_query_noop_when_short() {
+fn truncate_for_query_noop_when_short() {
     let input_ids: Vec<u32> = vec![1, 10, 20, 2]; // BOS, text, text, EOS
     let attention_mask = vec![1u32; 4];
     let expected_ids = input_ids.clone();
@@ -229,8 +232,9 @@ fn t_008b_truncate_for_query_noop_when_short() {
     assert_eq!(mask, expected_mask);
 }
 
+// T-008c: truncate_for_query_noop_at_exact_boundary
 #[test]
-fn t_008c_truncate_for_query_noop_at_exact_boundary() {
+fn truncate_for_query_noop_at_exact_boundary() {
     // [TC-003] Boundary: len == max_len → no truncation
     let max_len = 50;
     #[allow(clippy::cast_possible_truncation)]
@@ -245,8 +249,9 @@ fn t_008c_truncate_for_query_noop_at_exact_boundary() {
     assert_eq!(mask, expected_mask);
 }
 
+// T-008e: truncate_for_query_max_len_1_produces_eos_only
 #[test]
-fn t_008e_truncate_for_query_max_len_1_produces_eos_only() {
+fn truncate_for_query_max_len_1_produces_eos_only() {
     // [TC-003] max_len=1: the only slot is overwritten with EOS → output is [EOS]
     let input_ids: Vec<u32> = vec![1, 100, 200, 2]; // BOS, text, text, EOS
     let attention_mask = vec![1u32; 4];
@@ -257,8 +262,9 @@ fn t_008e_truncate_for_query_max_len_1_produces_eos_only() {
     assert_eq!(mask.len(), 1);
 }
 
+// T-008d: truncate_for_query_zero_max_len_returns_unchanged
 #[test]
-fn t_008d_truncate_for_query_zero_max_len_returns_unchanged() {
+fn truncate_for_query_zero_max_len_returns_unchanged() {
     let input_ids: Vec<u32> = vec![1, 100, 200, 2];
     let attention_mask = vec![1u32; 4];
     let expected_ids = input_ids.clone();
@@ -270,8 +276,9 @@ fn t_008d_truncate_for_query_zero_max_len_returns_unchanged() {
     assert_eq!(mask, expected_mask);
 }
 
+// T-014: mock_chunked_embedder_returns_multi_chunk
 #[test]
-fn t_014_mock_chunked_embedder_returns_multi_chunk() {
+fn mock_chunked_embedder_returns_multi_chunk() {
     let embedder = super::MockChunkedEmbedder::new(3);
     let result = embedder.embed_document("some text").unwrap();
     assert_eq!(result.chunks.len(), 3);

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -320,7 +320,7 @@ fn write_three_artifacts(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
 
 // T-001: validate_probe_paths_with_root happy path -- 3 cached files inside cache root return Ok(())
 #[test]
-fn t_001_validate_probe_paths_with_root_returns_ok_when_all_paths_under_cache_root() {
+fn validate_probe_paths_with_root_returns_ok_when_all_paths_under_cache_root() {
     // Arrange
     let cache_dir = tempfile::tempdir().unwrap();
     let (model, config, tokenizer) = write_three_artifacts(cache_dir.path());
@@ -335,7 +335,7 @@ fn t_001_validate_probe_paths_with_root_returns_ok_when_all_paths_under_cache_ro
 
 // T-002: validate_probe_paths_with_root rejects path outside cache_root with Err(5)
 #[test]
-fn t_002_validate_probe_paths_with_root_rejects_path_outside_cache_root() {
+fn validate_probe_paths_with_root_rejects_path_outside_cache_root() {
     // Arrange
     let cache_dir = tempfile::tempdir().unwrap();
     let outside_dir = tempfile::tempdir().unwrap();
@@ -359,7 +359,7 @@ fn t_002_validate_probe_paths_with_root_rejects_path_outside_cache_root() {
 
 // T-003: validate_probe_paths_with_root reports canonicalize failure with Err(4)
 #[test]
-fn t_003_validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_path() {
+fn validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_path() {
     // Arrange
     let cache_dir = tempfile::tempdir().unwrap();
     let (_, config, tokenizer) = write_three_artifacts(cache_dir.path());
@@ -382,7 +382,7 @@ fn t_003_validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_
 
 // T-004: validate_probe_paths_with_root reports invalid cache root with Err(6)
 #[test]
-fn t_004_validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root() {
+fn validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root() {
     // Arrange
     let cache_dir = tempfile::tempdir().unwrap();
     let (model, config, tokenizer) = write_three_artifacts(cache_dir.path());
@@ -408,7 +408,7 @@ fn t_004_validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root
 // by FR-005's type-level constraint, exercised here through behavior).
 #[cfg(unix)]
 #[test]
-fn t_005_validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
+fn validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
     // Arrange: HF cache layout — blobs/<etag> is the real file, snapshots/<commit>/<name>
     // is a symlink pointing at the blob.
     let cache_dir = tempfile::tempdir().unwrap();
@@ -448,7 +448,7 @@ fn t_005_validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
 // component comparison; the test guards against a regression to byte-prefix
 // comparison.
 #[test]
-fn t_006_validate_probe_paths_with_root_rejects_string_prefix_sibling() {
+fn validate_probe_paths_with_root_rejects_string_prefix_sibling() {
     // Arrange: two sibling tempdirs, "cache_x" and "cache_x_evil".
     let workspace = tempfile::tempdir().unwrap();
     let cache_root = workspace.path().join("cache_x");
@@ -488,7 +488,7 @@ fn t_006_validate_probe_paths_with_root_rejects_string_prefix_sibling() {
 // prefix. After the Green change, this assertion will pass; before the Green
 // change, the assertion fails on the `pub fn` line.
 #[test]
-fn t_016_from_paths_is_declared_pub_crate_in_artifacts_module() {
+fn from_paths_is_declared_pub_crate_in_artifacts_module() {
     // After Phase 1 Unit 1.1, the single `CandidateArtifacts<K>::from_paths`
     // definition lives in `src/artifacts.rs` and is consumed by
     // `model_lifecycle::probe_env_to_paths<K>`. The downstream-visible aliases
@@ -522,7 +522,7 @@ fn t_016_from_paths_is_declared_pub_crate_in_artifacts_module() {
 // poison parallel tests (the first caller fixes the value crate-wide).
 #[cfg(unix)]
 #[test]
-fn t_021_validate_probe_paths_falls_back_to_home_when_hf_home_unset() {
+fn validate_probe_paths_falls_back_to_home_when_hf_home_unset() {
     // Arrange: tempdir + HF cache layout under <tempdir>/.cache/huggingface/hub.
     let home_dir = tempfile::tempdir().unwrap();
     let hub_dir = home_dir.path().join(".cache/huggingface/hub");
@@ -610,7 +610,7 @@ fn setup_rejected_display_includes_code_and_label_per_variant() {
 
 // T-012: FORWARD list contains exactly the 22 expected keys
 #[test]
-fn t_012_forward_list_contains_expected_22_keys() {
+fn forward_list_contains_expected_22_keys() {
     let expected: &[&str] = &[
         "PATH",
         "HOME",
@@ -646,7 +646,7 @@ fn t_012_forward_list_contains_expected_22_keys() {
 
 // T-013: child_env_for_spawn forwards HF_HOME, drops attacker-injected env
 #[test]
-fn t_013_child_env_for_spawn_drops_attacker_env_keeps_forward() {
+fn child_env_for_spawn_drops_attacker_env_keeps_forward() {
     temp_env::with_vars(
         [
             ("HF_HOME", Some("/tmp/test_hf")),
@@ -669,7 +669,7 @@ fn t_013_child_env_for_spawn_drops_attacker_env_keeps_forward() {
 
 // T-022: child_env_for_spawn skips undefined FORWARD keys silently (FR-102)
 #[test]
-fn t_022_child_env_for_spawn_skips_undefined_forward_keys() {
+fn child_env_for_spawn_skips_undefined_forward_keys() {
     temp_env::with_vars([("HF_HOME", None::<&str>)], || {
         let env = super::child_env_for_spawn(&[]);
         assert!(
@@ -685,7 +685,7 @@ fn t_022_child_env_for_spawn_skips_undefined_forward_keys() {
 // keys propagate.
 #[cfg(unix)]
 #[test]
-fn t_013b_probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child() {
+fn probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child() {
     use std::os::unix::fs::PermissionsExt;
     let dir = tempfile::tempdir().unwrap();
     let env_dump = dir.path().join("env_dump.txt");
@@ -735,7 +735,7 @@ fn t_013b_probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child(
 
 // T-023: emit_ack_to writes PROBE_ACK + newline on a valid writer
 #[test]
-fn t_023_emit_ack_to_writes_ack_token_with_newline() {
+fn emit_ack_to_writes_ack_token_with_newline() {
     let mut buf: Vec<u8> = Vec::new();
     let result = super::emit_ack_to(&mut buf);
     assert!(result.is_ok(), "expected Ok, got {result:?}");
@@ -749,7 +749,7 @@ fn t_023_emit_ack_to_writes_ack_token_with_newline() {
 // arm (write success + flush error) is not unit-tested; in production the
 // pipe-broken case typically surfaces at write time on `io::stdout()`.
 #[test]
-fn t_024_emit_ack_to_propagates_writer_error() {
+fn emit_ack_to_propagates_writer_error() {
     let err = super::emit_ack_to(&mut test_writers::FailingWriter)
         .expect_err("expected emit_ack_to to propagate writer error");
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
@@ -761,7 +761,7 @@ fn t_024_emit_ack_to_propagates_writer_error() {
 // before the ACK presence check — otherwise an empty stdout caused by a
 // failed ACK write would be misclassified as `HandlerNotInstalled`.
 #[test]
-fn t_025_interpret_probe_output_maps_exit_7_to_subprocess_failed_even_without_ack() {
+fn interpret_probe_output_maps_exit_7_to_subprocess_failed_even_without_ack() {
     let output = Output {
         status: exit_status(super::PROBE_EXIT_ACK_FAILED),
         stdout: Vec::new(),
@@ -783,7 +783,7 @@ fn t_025_interpret_probe_output_maps_exit_7_to_subprocess_failed_even_without_ac
 // `dispatch_probe` only emits exit 8 after `emit_ack` succeeds, so a real
 // probe failure of this kind always carries the ACK in stdout.
 #[test]
-fn t_026_interpret_probe_output_maps_exit_8_to_subprocess_failed() {
+fn interpret_probe_output_maps_exit_8_to_subprocess_failed() {
     let output = Output {
         status: exit_status(super::PROBE_EXIT_STDERR_FAILED),
         stdout: format!("{PROBE_ACK}\n").into_bytes(),
@@ -808,7 +808,7 @@ fn t_026_interpret_probe_output_maps_exit_8_to_subprocess_failed() {
 // when emitted by `dispatch_probe` after a successful ACK; an exit 8 from
 // any other code path predates the probe contract.
 #[test]
-fn t_027_interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
+fn interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
     let output = Output {
         status: exit_status(super::PROBE_EXIT_STDERR_FAILED),
         stdout: Vec::new(),
@@ -826,7 +826,7 @@ fn t_027_interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
 
 // T-028: emit_failure_to writes msg and calls flush on success
 #[test]
-fn t_028_emit_failure_to_writes_message_and_flushes() {
+fn emit_failure_to_writes_message_and_flushes() {
     let mut w = test_writers::FlushTrackingWriter::default();
     super::emit_failure_to(&mut w, "model load failed: bad weights").unwrap();
     assert_eq!(w.buf, b"model load failed: bad weights");
@@ -838,7 +838,7 @@ fn t_028_emit_failure_to_writes_message_and_flushes() {
 
 // T-029: emit_failure_to propagates writer error
 #[test]
-fn t_029_emit_failure_to_propagates_writer_error() {
+fn emit_failure_to_propagates_writer_error() {
     let err = super::emit_failure_to(&mut test_writers::FailingWriter, "anything")
         .expect_err("expected emit_failure_to to propagate writer error");
     assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
@@ -848,7 +848,7 @@ fn t_029_emit_failure_to_propagates_writer_error() {
 // failure mode `emit_failure_to` exists to detect (bytes accepted into a
 // buffer but never delivered to the kernel before `process::exit`).
 #[test]
-fn t_030_emit_failure_to_surfaces_flush_error_after_successful_write() {
+fn emit_failure_to_surfaces_flush_error_after_successful_write() {
     let mut w = test_writers::FlushFailingWriter::default();
     let err = super::emit_failure_to(&mut w, "msg")
         .expect_err("expected emit_failure_to to surface flush error");
@@ -862,7 +862,7 @@ fn t_030_emit_failure_to_surfaces_flush_error_after_successful_write() {
 // T-031: join returns promptly after recv succeeds (reaping invariant on
 // `collect_pipe` happy path).
 #[test]
-fn t_031_spawn_drain_pipe_thread_is_joinable_after_recv() {
+fn spawn_drain_pipe_thread_is_joinable_after_recv() {
     use std::io::Cursor;
     let pipe = Cursor::new(b"drained bytes".to_vec());
     let handle =
@@ -882,7 +882,7 @@ fn t_031_spawn_drain_pipe_thread_is_joinable_after_recv() {
 
 // T-032: spawn_drain_pipe returns None when no pipe is provided.
 #[test]
-fn t_032_spawn_drain_pipe_returns_none_for_none_input() {
+fn spawn_drain_pipe_returns_none_for_none_input() {
     let handle = super::spawn_drain_pipe::<io::Empty>(None, "test");
     assert!(
         handle.is_none(),

--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -745,10 +745,11 @@ mod tests {
             }
         }
 
+        // T-010: forward_truncates_oversize_input
         #[test]
         #[ignore = "requires unsandboxed MLX runtime"]
         #[serial]
-        fn t_010_forward_truncates_oversize_input() {
+        fn forward_truncates_oversize_input() {
             require_unsandboxed_mlx_runtime();
             // [T-010] seq_len > max_seq_len → truncate + warn, not error
             let config = test_config(); // max_position_embeddings = 512

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -11,8 +11,9 @@ use crate::test_support::{
 };
 use std::fs;
 
+// T-003: candidate_verify_returns_missing_file_for_nonexistent_paths
 #[test]
-fn t_003_candidate_verify_returns_missing_file_for_nonexistent_paths() {
+fn candidate_verify_returns_missing_file_for_nonexistent_paths() {
     let candidate = CandidateArtifacts::from_paths(
         "/nonexistent/model.safetensors".into(),
         "/nonexistent/config.json".into(),
@@ -25,8 +26,9 @@ fn t_003_candidate_verify_returns_missing_file_for_nonexistent_paths() {
     );
 }
 
+// T-004: truncate_pair_short_input_unchanged
 #[test]
-fn t_004_truncate_pair_short_input_unchanged() {
+fn truncate_pair_short_input_unchanged() {
     let mut ids: Vec<u32> = (0..100).collect();
     let mut mask: Vec<u32> = vec![1; 100];
     let original_ids = ids.clone();
@@ -36,8 +38,9 @@ fn t_004_truncate_pair_short_input_unchanged() {
     assert_eq!(mask, original_mask);
 }
 
+// T-005: truncate_pair_long_input_truncated_with_eos
 #[test]
-fn t_005_truncate_pair_long_input_truncated_with_eos() {
+fn truncate_pair_long_input_truncated_with_eos() {
     let mut ids: Vec<u32> = (0..8193).map(|i| i as u32).collect();
     let mut mask: Vec<u32> = vec![1; 8193];
     truncate_pair(&mut ids, &mut mask, 8192, 0);
@@ -46,8 +49,9 @@ fn t_005_truncate_pair_long_input_truncated_with_eos() {
     assert_eq!(ids[8191], 2, "last token should be EOS(2)");
 }
 
+// T-007: sort_results_descending_by_score
 #[test]
-fn t_007_sort_results_descending_by_score() {
+fn sort_results_descending_by_score() {
     let scores = vec![0.3, 0.9, 0.1];
     let results = sort_results(&scores);
     assert_eq!(results.len(), 3);
@@ -59,8 +63,9 @@ fn t_007_sort_results_descending_by_score() {
     assert!((results[2].score - 0.1).abs() < 1e-6);
 }
 
+// T-007b: sort_results_ties_break_by_original_index
 #[test]
-fn t_007b_sort_results_ties_break_by_original_index() {
+fn sort_results_ties_break_by_original_index() {
     // scores: [0.5, 0.7, 0.7, 0.5] — desc by score, asc by index on ties.
     let scores = vec![0.5, 0.7, 0.7, 0.5];
     let results = sort_results(&scores);
@@ -68,18 +73,21 @@ fn t_007b_sort_results_ties_break_by_original_index() {
     assert_eq!(indices, vec![1, 2, 0, 3]);
 }
 
+// T-013: cache_lookup_returns_some_when_all_files_present
 #[test]
-fn t_013_cache_lookup_returns_some_when_all_files_present() {
+fn cache_lookup_returns_some_when_all_files_present() {
     assert_cache_lookup_returns_some_when_all_files_present(RerankerModelId::RuriV3Reranker310m);
 }
 
+// T-021: cache_lookup_returns_none_when_cache_empty
 #[test]
-fn t_021_cache_lookup_returns_none_when_cache_empty() {
+fn cache_lookup_returns_none_when_cache_empty() {
     assert_cache_lookup_returns_none_when_empty(RerankerModelId::default());
 }
 
+// T-014: candidate_verify_returns_invalid_config_for_empty_config
 #[test]
-fn t_014_candidate_verify_returns_invalid_config_for_empty_config() {
+fn candidate_verify_returns_invalid_config_for_empty_config() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
     fs::write(dir.path().join("config.json"), b"{}").unwrap();
@@ -92,8 +100,9 @@ fn t_014_candidate_verify_returns_invalid_config_for_empty_config() {
     );
 }
 
+// T-015: candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer
 #[test]
-fn t_015_candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
+fn candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("model.safetensors"), b"fake").unwrap();
     fs::write(dir.path().join("config.json"), VALID_CONFIG_JSON.as_bytes()).unwrap();
@@ -109,7 +118,7 @@ fn t_015_candidate_verify_returns_invalid_tokenizer_for_bad_tokenizer() {
 // T-019: regression — same invariant as T-018 for the reranker module.
 #[cfg(unix)]
 #[test]
-fn t_019_probe_env_to_paths_preserves_snapshot_symlink_filename() {
+fn probe_env_to_paths_preserves_snapshot_symlink_filename() {
     assert_probe_env_to_paths_preserves_snapshot_symlink_filename::<RerankerKind>();
 }
 
@@ -218,30 +227,33 @@ mod mlx_runtime_tests {
             .expect("model should be cached for test-mlx tests")
     }
 
+    // T-006: score_batch_empty_returns_ok_empty
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_006_score_batch_empty_returns_ok_empty() {
+    fn score_batch_empty_returns_ok_empty() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let scores = reranker.score_batch(&[]).unwrap();
         assert!(scores.is_empty());
     }
 
+    // T-008: rerank_empty_returns_ok_empty
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_008_rerank_empty_returns_ok_empty() {
+    fn rerank_empty_returns_ok_empty() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let results = reranker.rerank("query", &[]).unwrap();
         assert!(results.is_empty());
     }
 
+    // T-011: score_returns_value_in_unit_interval
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_011_score_returns_value_in_unit_interval() {
+    fn score_returns_value_in_unit_interval() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let score = reranker.score("test", "テスト文").unwrap();
@@ -251,10 +263,11 @@ mod mlx_runtime_tests {
         );
     }
 
+    // T-012: rerank_returns_descending_scores_with_valid_indices
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_012_rerank_returns_descending_scores_with_valid_indices() {
+    fn rerank_returns_descending_scores_with_valid_indices() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let docs = ["related document", "unrelated text", "somewhat relevant"];
@@ -268,10 +281,11 @@ mod mlx_runtime_tests {
         assert_eq!(indices, vec![0, 1, 2]);
     }
 
+    // T-016: score_batch_preserves_input_order_and_ranking
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_016_score_batch_preserves_input_order_and_ranking() {
+    fn score_batch_preserves_input_order_and_ranking() {
         require_unsandboxed_mlx_runtime();
         let reranker = Reranker::new(&load_cached_artifacts()).unwrap();
         let pair_a = ("東京の人口", "東京は日本最大の都市");
@@ -292,10 +306,11 @@ mod mlx_runtime_tests {
         }
     }
 
+    // T-018: new_succeeds_with_cached_model
     #[test]
     #[ignore = "requires unsandboxed MLX runtime"]
     #[serial]
-    fn t_018_new_succeeds_with_cached_model() {
+    fn new_succeeds_with_cached_model() {
         require_unsandboxed_mlx_runtime();
         let result = Reranker::new(&load_cached_artifacts());
         assert!(

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -343,7 +343,7 @@ mod tests {
     // T-017: setup_fake_hf_cache_with_symlinks builds the production HF cache layout
     #[cfg(unix)]
     #[test]
-    fn t_017_setup_fake_hf_cache_with_symlinks_creates_symlink_structure() {
+    fn setup_fake_hf_cache_with_symlinks_creates_symlink_structure() {
         let dir = tempfile::tempdir().unwrap();
         setup_fake_hf_cache_with_symlinks(
             dir.path(),


### PR DESCRIPTION
## 概要

- 残ってた `fn t_NNN_xxx` + `// T-NNN:` 二重コーディング 64 件を 7 ファイル一括移行
- `cargo test --lib` 緑（317 passed / 3 ignored / 0 failed）— mechanical rename のみ、振る舞い変化なし
- これでコードベース全体が LANG.md `// T-NNN: function_name` 規約 100% 準拠

## 動機

#136 では `fn tNNN_*`（アンダースコア無し）の `text.rs` / `storage/search.rs` だけ移行したが、`fn t_NNN_*`（アンダースコア有り）の hybrid form（コメント + 関数名 双方に T-NNN 埋め込み）は 7 ファイル 64 件残ってた。スコープが揃ってないと「どっちが正しいの？」が曖昧になるので一気に揃える。

## 変更内容

| File                       | 件数 | アプローチ                           |
| -------------------------- | ---- | ------------------------------------ |
| `src/model_probe/tests.rs` | 22   | sed で prefix drop（コメント既存）   |
| `src/embed/mlx.rs`         | 11   | sed で prefix drop（コメント既存）   |
| `src/embed/pooling.rs`     | 5    | sed で prefix drop（コメント既存）   |
| `src/test_support.rs`      | 1    | sed で prefix drop（コメント既存）   |
| `src/reranker/tests.rs`    | 16   | コメント追加 + prefix drop（per-test edit） |
| `src/embed/tests.rs`       | 8    | コメント追加 + prefix drop（per-test edit） |
| `src/modernbert/model.rs`  | 1    | コメント追加 + prefix drop（per-test edit） |
| **合計**                   | **64** |                                    |

### 移行前後の対比

```rust
// 移行前
#[test]
fn t_003_candidate_verify_returns_missing_file_for_nonexistent_paths() { ... }

// 移行後
// T-003: candidate_verify_returns_missing_file_for_nonexistent_paths
#[test]
fn candidate_verify_returns_missing_file_for_nonexistent_paths() { ... }
```

Multi-attr test の場合は最上位にコメントを置く：

```rust
// T-006: score_batch_empty_returns_ok_empty
#[test]
#[ignore = "requires unsandboxed MLX runtime"]
#[serial]
fn score_batch_empty_returns_ok_empty() { ... }
```

## 動作確認

- [x] `cargo test --lib`（317 passed / 3 ignored）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `ugrep -rcP '^\s*fn t_[0-9]' src/` で 0 件確認

## 差分

`7 files changed, 87 insertions(+), 64 deletions(-)`（コメント追加分の純増 +23）

## 完了状態

これで LANG.md 規約 `// T-NNN: function_name` プレフィックス形式が**コードベース全体で 100% 準拠**になる。テスト関数名は self-documenting snake_case のみ、T-NNN 識別子はコメントのみで管理。