### PR TITLE
polish(test_support): HF blob fixture を拡張子なしに揃える

### DIFF
--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -107,6 +107,11 @@ pub(crate) fn setup_fake_hf_cache(
 /// files, mirroring the production HF Hub cache layout
 /// (`snapshots/<commit>/<file>` -> `../../blobs/<etag>`).
 ///
+/// Blob filenames are extension-less (e.g. `etag-model`, not
+/// `etag-model.safetensors`) to mirror real HF Hub blobs (`blobs/<sha256>`).
+/// Preserving the snapshot-side extension is the load-time invariant under
+/// test, so the blob side must NOT carry one.
+///
 /// Used by Issue #107 regression tests to exercise the symlink-preserving
 /// invariant: `validate_probe_paths` and `probe_env_to_paths` must NOT
 /// substitute the canonicalized blob path for the snapshot path, because
@@ -131,12 +136,14 @@ pub(crate) fn setup_fake_hf_cache_with_symlinks(
     let snapshot_dir = repo_dir.join("snapshots").join(commit_hash);
     fs::create_dir_all(&snapshot_dir).unwrap();
     for &(name, content) in files {
-        // Stable etag derived from filename so the blob name is deterministic.
-        let etag = format!("etag-{name}");
+        let stem = Path::new(name)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(name);
+        let etag = format!("etag-{stem}");
         let blob = blobs_dir.join(&etag);
         fs::write(&blob, content).unwrap();
         let snapshot_link = snapshot_dir.join(name);
-        // Relative symlink target: snapshots/<commit>/X -> ../../blobs/<etag>
         symlink(format!("../../blobs/{etag}"), &snapshot_link).unwrap();
     }
 }
@@ -226,7 +233,7 @@ pub(crate) fn assert_from_probe_error_maps_correctly() {
 /// return the snapshot symlink path, not the canonicalized blob path.
 ///
 /// MLX `load_safetensors` dispatches on filename extension, so substituting
-/// the blob path (`etag-model.safetensors`) for the snapshot link
+/// the blob path (`etag-model`, extension-less) for the snapshot link
 /// (`model.safetensors`) breaks the load step. Verified for both
 /// `EmbedKind` and `RerankerKind` from their respective test files.
 #[cfg(unix)]


### PR DESCRIPTION
## 概要

- `setup_fake_hf_cache_with_symlinks` が生成する blob filename を `etag-{name}` (例: `etag-model.safetensors`) から `etag-{stem}` (例: `etag-model`) に変更
- 実 HF Hub cache では blob は `blobs/<sha256>` で extension を持たないため、fixture 側もそれに揃えて test fidelity を上げる
- これで `model_probe/tests.rs:420-422` の手書き layout (`etag-model` 等) と整合
- 結果として symlink-extension regression (33c91c1 production breakage) の検知精度が上がる

## テスト計画

- [x] `cargo test --workspace --lib` (317 passed, 0 failed)
- [x] symlink 関連 4 test 個別確認
  - `test_support::tests::setup_fake_hf_cache_with_symlinks_creates_symlink_structure`
  - `model_probe::tests::validate_probe_paths_with_root_accepts_symlink_under_cache_root`
  - `embed::tests::probe_env_to_paths_preserves_snapshot_symlink_filename`
  - `reranker::tests::probe_env_to_paths_preserves_snapshot_symlink_filename`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Closes #119