### PR TITLE
docs(adr): ADR 0001/0002 を Accepted に同期 + 実装現状を反映

### DIFF
--- a/docs/decisions/0001-typed-fts-query-contract.md
+++ b/docs/decisions/0001-typed-fts-query-contract.md
@@ -1,6 +1,6 @@
 # ADR 0001: Adopt a Typed FTS Query Contract in `rurico`
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-03-28
 - Confidence: high - The current API contract is ambiguous, and the migration path across downstream crates is clear.
 
@@ -31,9 +31,16 @@ The storage API will move toward these types:
 The first step is:
 
 1. Change `sanitize_fts_query` from `String` to `Result<SanitizedFtsQuery, SanitizeError>`.
-2. Define `SanitizeError` with two variants:
+2. Define `SanitizeError`. Initially scoped to two variants:
    `EmptyInput`
    `NoSearchableTerms`
+   Later expanded to four variants when `prepare_match_query` was parameterized
+   over `vocab_table` (PR #38) and the failure modes for invalid identifiers
+   and SQLite lookup errors needed to be distinguished:
+   `EmptyInput`
+   `NoSearchableTerms`
+   `InvalidVocabTable(String)`
+   `VocabLookupFailed(String)`
 3. Preserve operator-like keywords (`AND`, `OR`, `NOT`) as literal terms during sanitization.
 4. Change `fts_expand_short_terms` to accept `&SanitizedFtsQuery` instead of raw `&str`.
 5. Return a typed value for final `MATCH` usage, either via `MatchFtsQuery` or a helper such as `build_match_fts_query`.
@@ -100,14 +107,21 @@ Negative:
 
 ## Migration Plan
 
-1. Update `rurico` storage API and tests.
-2. Migrate `recall` from local sanitization to `rurico`.
-3. Migrate `sae` from local sanitization to `rurico`.
-4. Add sanitization to `yomu` before short-term expansion.
-5. Run `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` in all affected crates.
+1. Update `rurico` storage API and tests. **Done 2026-03-28 (PR #9 typed result, PR #13 public API consolidation; later refined by PR #38 with `vocab_table` parameterization on 2026-04-21).**
+2. Migrate `recall` from local sanitization to `rurico`. **Done in downstream `recall` repo follow-up.**
+3. Migrate `sae` from local sanitization to `rurico`. **Done in downstream `sae` repo follow-up.**
+4. Add sanitization to `yomu` before short-term expansion. **Done in downstream `yomu` repo follow-up.**
+5. Run `cargo test` and `cargo clippy --all-targets --all-features -- -D warnings` in all affected crates. **Done as part of each step's PR gate.**
 
 ## Reassessment Triggers
 
-- A downstream crate needs more detailed failure causes than `EmptyInput` and `NoSearchableTerms`
+- A downstream crate needs more detailed failure causes than the four current variants
 - FTS query construction grows beyond sanitize plus expansion into a true parser/validator
 - another storage backend with different query semantics is added
+
+## Notes
+
+The original migration tracking note lived at
+`docs/issues/typed-fts-query-contract-migration.md`. That path is
+`.gitignore`d (the entire `docs/issues/` tree is excluded), so this ADR's
+Migration Plan above is the canonical, in-repo record of step status.

--- a/docs/decisions/0002-gpu-side-pooling-embed.md
+++ b/docs/decisions/0002-gpu-side-pooling-embed.md
@@ -1,6 +1,6 @@
 # ADR 0002: GPU-side Pooling for the embed Pipeline
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-04-24
 - Confidence: medium. The mlx-rs 0.25.3 Array API surface for reduction + broadcasting divide is unconfirmed, and the empirical precision margin over NFR-001 is unmeasured pre-prototype.
 
@@ -116,16 +116,16 @@ Positive:
 
 Negative:
 
-- `src/embed/pooling.rs` grows from 85 lines to roughly 165 lines while both variants coexist. Phase 3c cleanup removes the CPU variant after rewiring stabilises, but Phase 3b to 3c leaves a dead-code window.
+- `src/embed/pooling.rs` grows from 85 lines to roughly 165 lines while both variants coexist. Phase 3c cleanup removes the CPU variant after rewiring stabilises, but Phase 3b to 3c leaves a dead-code window. **Resolved 2026-04-25 (PR #64): CPU `mean_pooling` / `l2_normalize` / `postprocess_embedding` removed after Phase 3b stabilised; the dead-code window closed inside the same review burst.**
 - Approach is conditional on mlx-rs 0.25.3 exposing reduction + broadcasting ops. If not, Phase 3 is deferred until a bindings update or an alternative (f64 intermediate, CPU-hybrid) is chosen.
 - Probe bin is additional binary target surface that must be kept green until Phase 3c deletes it.
 - FR-001a invariant is now distributed across `validate_attention_mask` (upstream rejection) and the probe bin (`is_finite` defensive guard). A regression that removes either location would leave a NaN-pathway silently open. Mitigation: T-011 is re-typed as an integration scenario on the probe bin; any replacement wiring must add an equivalent guard at the new direct-caller site.
 
 ## Migration Plan
 
-1. Phase 3a. Add `src/bin/gpu_pool_probe.rs` and `gpu_pool_and_normalize` in `src/embed/pooling.rs`. Probe bin measures `max_abs_diff` and `cosine_sim` on W1 single chunk. Production paths unchanged.
-2. Phase 3b. If probe passes the 10x margin, rewire `forward_sub_batch` and `embed_query_truncated`. Delete `unpack_batch_output`. CPU variants in `pooling.rs` become dead code but are not yet removed.
-3. Phase 3c. Remove the CPU variants (`mean_pooling`, `l2_normalize`, `postprocess_embedding`), remove the probe bin, write `docs/benchmarks/phase3_result.md` with measured readback reduction and Phase 2 aspirational recovery status.
+1. Phase 3a. Add `src/bin/gpu_pool_probe.rs` and `gpu_pool_and_normalize` in `src/embed/pooling.rs`. Probe bin measures `max_abs_diff` and `cosine_sim` on W1 single chunk. Production paths unchanged. **Done 2026-04-25 (PR #62).**
+2. Phase 3b. If probe passes the 10x margin, rewire `forward_sub_batch` and `embed_query_truncated`. Delete `unpack_batch_output`. CPU variants in `pooling.rs` become dead code but are not yet removed. **Done 2026-04-25 (PR #63).**
+3. Phase 3c. Remove the CPU variants (`mean_pooling`, `l2_normalize`, `postprocess_embedding`), remove the probe bin, write `docs/benchmarks/phase3_result.md` with measured readback reduction and Phase 2 aspirational recovery status. **Done 2026-04-25 (PR #64); `docs/benchmarks/phase3_result.md` shipped in the same PR.**
 
 ## Reassessment Triggers
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -2,8 +2,8 @@
 
 | ID | Title | Status | Date |
 | --- | --- | --- | --- |
-| [0001](./0001-typed-fts-query-contract.md) | Adopt a Typed FTS Query Contract in `rurico` | Proposed | 2026-03-28 |
-| [0002](./0002-gpu-side-pooling-embed.md) | GPU-side Pooling for the embed Pipeline | Proposed | 2026-04-24 |
+| [0001](./0001-typed-fts-query-contract.md) | Adopt a Typed FTS Query Contract in `rurico` | Accepted | 2026-03-28 |
+| [0002](./0002-gpu-side-pooling-embed.md) | GPU-side Pooling for the embed Pipeline | Accepted | 2026-04-24 |
 | [0003](./0003-evaluation-methodology.md) | Search Quality Evaluation Methodology for `rurico` | Superseded by ADR 0006 | 2026-04-25 |
 | [0004](./0004-retrieval-and-rerank-pipeline-contract-for-rurico.md) | Retrieval and Rerank Pipeline Contract for `rurico` | Accepted | 2026-04-26 |
 | [0005](./0005-prefix-ensemble-experiment-not-adopted.md) | Phase 6 Prefix-Ensemble Experiment — Not Adopted | Accepted | 2026-04-27 |


### PR DESCRIPTION
## 概要

Issue #97 (DOC-002〜010) の対応。実装完了済の ADR 0001/0002 が `Proposed` のまま放置されていた状態を解消し、Migration Plan に実完了の date / PR 参照を annotate する。

## 変更内容

| ファイル                                          | 変更                                                                                                                                      |
| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
| `docs/decisions/README.md`                        | ADR 0001/0002 status `Proposed` → `Accepted`                                                                                              |
| `docs/decisions/0001-typed-fts-query-contract.md` | Status `Accepted`、SanitizeError variants 2→4 追記 (PR #38 で `InvalidVocabTable` / `VocabLookupFailed` 追加)、Migration Plan 各 step 完了 annotation、Notes 追加 |
| `docs/decisions/0002-gpu-side-pooling-embed.md`   | Status `Accepted`、dead-code window 解消 annotation (PR #64)、Phase 3a/3b/3c Migration Plan annotation (PR #62/#63/#64)                         |

## migration issue doc の扱い

Issue #97 では `docs/issues/typed-fts-query-contract-migration.md` への Closed marker または ADR 統合が要件だったが、`docs/issues/` ツリーは `.gitignore` 対象であり repo に push できない。代替として ADR 0001 末尾に `Notes` を追加し、当該 ADR が canonical record だと宣言する形で解決。

## 受け入れ条件マッピング

- [x] ADR 0001/0002 Status を Accepted に更新
- [x] `docs/decisions/README.md` table を同期
- [x] ADR 0001 の SanitizeError 記述を shipped (4 variants) と一致
- [x] ADR 0002 の outdated consequence/migration plan を現状反映
- [x] migration issue doc に Closed marker または ADR 統合 (ADR 0001 Notes として統合)
- [ ] PR template に lifecycle checklist 追加 — Issue 上で「任意」とされていたため scope 外

## テスト計画

- [x] `cargo build --workspace` (副作用なきこと確認、Cargo.lock 副次変更は revert 済)
- [x] markdown 体裁目視
- [x] commit hash と PR 番号 (PR #9 / #13 / #38 / #62 / #63 / #64) を `git log` から照合済

Closes #97