### PR TITLE
fix(rurico-ffi): sqlite_vec_register の transmute を typed extern "C" 宣言に置換

### DIFF
--- a/crates/rurico-ffi/src/storage.rs
+++ b/crates/rurico-ffi/src/storage.rs
@@ -4,24 +4,19 @@ use std::os::raw::{c_char, c_int};
 
 use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
 
-// Pull in the upstream `sqlite-vec` crate solely so its `build.rs` produces
-// `libsqlite_vec0.a` and that static library reaches the link step. We do
-// not import its `sqlite3_vec_init` symbol because the upstream binding is
-// declared as zero-arg (`extern "C" { fn sqlite3_vec_init(); }`), which
-// hides the real C ABI and would force a `transmute` at the
-// `sqlite3_auto_extension` call site.
+// Link `libsqlite_vec0.a` produced by the upstream `sqlite-vec` build script;
+// the symbol itself is re-declared below with the real C signature.
 use sqlite_vec as _;
 
-// Re-declare `sqlite3_vec_init` with the real signature from `sqlite-vec.h`,
-// matching `int sqlite3_vec_init(sqlite3*, char**, const sqlite3_api_routines*)`.
-// Declaring it here lets the compiler verify ABI compatibility at the
-// `Some(sqlite3_vec_init)` coercion site instead of relying on a `transmute`.
+// `sqlite3_vec_init` from `sqlite-vec.h`:
+//   int sqlite3_vec_init(sqlite3 *db, char **pzErrMsg,
+//                        const sqlite3_api_routines *pApi);
 #[allow(unsafe_code)]
 unsafe extern "C" {
     fn sqlite3_vec_init(
         db: *mut sqlite3,
-        pz_err_msg: *mut *mut c_char,
-        p_api: *const sqlite3_api_routines,
+        err_msg: *mut *mut c_char,
+        api: *const sqlite3_api_routines,
     ) -> c_int;
 }
 
@@ -33,11 +28,10 @@ unsafe extern "C" {
 /// function pointer, so repeated calls are safe.
 #[allow(unsafe_code)]
 pub fn sqlite_vec_register() -> i32 {
-    // SAFETY: the locally re-declared `sqlite3_vec_init` matches the C
-    // signature in `sqlite-vec.h`, so the function-pointer coercion into
-    // `sqlite3_auto_extension`'s expected type is ABI-correct without a
-    // `transmute`. SQLite invokes the function with the declared argument
-    // types at connection-open time.
+    // SAFETY: the local re-declaration of `sqlite3_vec_init` matches the
+    // exact symbol signature exported by `libsqlite_vec0.a`. `extern "C" fn`
+    // items have `'static` lifetime, which is what `sqlite3_auto_extension`
+    // requires for an auto-extension entry.
     unsafe { sqlite3_auto_extension(Some(sqlite3_vec_init)) }
 }
 

--- a/crates/rurico-ffi/src/storage.rs
+++ b/crates/rurico-ffi/src/storage.rs
@@ -1,10 +1,29 @@
 //! Safe wrapper for sqlite-vec FFI registration.
 
-use std::mem::transmute;
 use std::os::raw::{c_char, c_int};
 
 use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
-use sqlite_vec::sqlite3_vec_init;
+
+// Pull in the upstream `sqlite-vec` crate solely so its `build.rs` produces
+// `libsqlite_vec0.a` and that static library reaches the link step. We do
+// not import its `sqlite3_vec_init` symbol because the upstream binding is
+// declared as zero-arg (`extern "C" { fn sqlite3_vec_init(); }`), which
+// hides the real C ABI and would force a `transmute` at the
+// `sqlite3_auto_extension` call site.
+use sqlite_vec as _;
+
+// Re-declare `sqlite3_vec_init` with the real signature from `sqlite-vec.h`,
+// matching `int sqlite3_vec_init(sqlite3*, char**, const sqlite3_api_routines*)`.
+// Declaring it here lets the compiler verify ABI compatibility at the
+// `Some(sqlite3_vec_init)` coercion site instead of relying on a `transmute`.
+#[allow(unsafe_code)]
+unsafe extern "C" {
+    fn sqlite3_vec_init(
+        db: *mut sqlite3,
+        pz_err_msg: *mut *mut c_char,
+        p_api: *const sqlite3_api_routines,
+    ) -> c_int;
+}
 
 /// Register sqlite-vec as a process-global SQLite auto-extension.
 ///
@@ -14,19 +33,31 @@ use sqlite_vec::sqlite3_vec_init;
 /// function pointer, so repeated calls are safe.
 #[allow(unsafe_code)]
 pub fn sqlite_vec_register() -> i32 {
-    // SAFETY: sqlite3_vec_init is the auto-extension entry point exported by
-    // sqlite-vec. sqlite-vec exports it as `unsafe extern "C" fn()`, while
-    // rusqlite's sqlite3_auto_extension expects the full init signature. Both
-    // are C fn pointers with compatible calling conventions; SQLite calls the
-    // function with the correct arguments at connection open time.
-    unsafe {
-        sqlite3_auto_extension(Some(transmute::<
-            unsafe extern "C" fn(),
-            unsafe extern "C" fn(
-                *mut sqlite3,
-                *mut *mut c_char,
-                *const sqlite3_api_routines,
-            ) -> c_int,
-        >(sqlite3_vec_init)))
+    // SAFETY: the locally re-declared `sqlite3_vec_init` matches the C
+    // signature in `sqlite-vec.h`, so the function-pointer coercion into
+    // `sqlite3_auto_extension`'s expected type is ABI-correct without a
+    // `transmute`. SQLite invokes the function with the declared argument
+    // types at connection-open time.
+    unsafe { sqlite3_auto_extension(Some(sqlite3_vec_init)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sqlite_vec_register;
+    use rusqlite::Connection;
+
+    #[test]
+    fn sqlite_vec_register_enables_vec_version_function() {
+        let rc = sqlite_vec_register();
+        assert_eq!(rc, 0, "sqlite3_auto_extension returned non-zero rc {rc}");
+
+        let conn = Connection::open_in_memory().unwrap();
+        let version: String = conn
+            .query_row("select vec_version()", [], |row| row.get(0))
+            .unwrap();
+        assert!(
+            version.starts_with('v'),
+            "expected sqlite-vec version to start with 'v', got {version:?}"
+        );
     }
 }


### PR DESCRIPTION
## 概要

- `crates/rurico-ffi/src/storage.rs` の `std::mem::transmute` を排除
- 自前 `unsafe extern "C" fn sqlite3_vec_init(sqlite3*, char**, const sqlite3_api_routines*) -> c_int` を再宣言
- `Some(sqlite3_vec_init)` の coercion site で compile-time に ABI 検証
- smoke test (in-memory SQLite + `select vec_version()`) を新規追加

## 背景

`sqlite-vec` crate の Rust binding は `extern "C" { pub fn sqlite3_vec_init(); }` という zero-arg 形式で、 C 側の真の signature ((`sqlite-vec.h:34`) `int sqlite3_vec_init(sqlite3*, char**, const sqlite3_api_routines*)`) を隠す。これに `sqlite3_auto_extension` の 3-arg signature を満たすため `std::mem::transmute` を使っていた。

## 採用アプローチ（issue 案 A）

`sqlite-vec` crate は `[dependencies]` に残して `build.rs` 経由で `libsqlite_vec0.a` を生成・link 。シンボル参照は rurico-ffi 側で `unsafe extern "C"` ブロックを書いて行う。

```rust
unsafe extern "C" {
    fn sqlite3_vec_init(
        db: *mut sqlite3,
        err_msg: *mut *mut c_char,
        api: *const sqlite3_api_routines,
    ) -> c_int;
}

pub fn sqlite_vec_register() -> i32 {
    unsafe { sqlite3_auto_extension(Some(sqlite3_vec_init)) }
}
```

## なぜ案 A

| 項目                | transmute (旧)              | 自前宣言 (新)                                       |
| ------------------- | --------------------------- | --------------------------------------------------- |
| ABI 検証            | 実行時のみ (silent UB risk) | compile-time (`Some(...)` coercion で型一致を要求) |
| sqlite-vec bump 時 | 気付けない                   | C signature 変わると compile error                  |
| SAFETY 根拠         | "calling conv 互換"の主張   | 「symbol 自体の signature と一致」と記述可能        |

## テスト計画

- [x] `cargo test -p rurico-ffi --lib` (1 passed: smoke test)
- [x] `cargo test --workspace` regression なし
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `/polish` workflow (simplify / codex / coderabbit) で finding 全消化、enhancer-code が "nothing to clean"

## 受け入れ条件

- [x] `crates/rurico-ffi/src/storage.rs:20-27` の `std::mem::transmute` 削除
- [x] `cargo test --workspace` pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] スモークテスト pass (`vec_version()` が "v" prefix 文字列を返す)

Closes #98