### PR TITLE
refactor(api): 可視性を厳格化、sandbox を公開API に昇格

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,13 +282,12 @@ let aggregated = aggregator.aggregate(&merged);
 
 ### ベクトルのバイト変換
 
-`sqlite-vec` にベクトルをバインドする際に使う。
+`sqlite-vec` にベクトルをバインドする際は `bytemuck::cast_slice` で zero-copy に `&[f32] → &[u8]` を行う。rurico は little-endian ターゲットでのみビルドされるため、変換結果は sqlite-vec が期待する byte layout と一致する。
 
 ```rust
-use rurico::storage::f32_as_bytes;
-
 let vector: Vec<f32> = embedder.embed_query("検索")?;
-stmt.execute(rusqlite::params![f32_as_bytes(&vector)])?;
+let bytes: &[u8] = bytemuck::cast_slice(&vector);
+stmt.execute(rusqlite::params![bytes])?;
 ```
 
 ### エラー型

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -1,8 +1,9 @@
 mod embedder;
 /// Ordinary least squares linear regression. Internal support for the Phase 2
-/// smoke harness (`mlx_smoke measure-baseline`'s R² assertion). Exposed `pub`
-/// for cross-target reuse within this crate only — not part of the public
-/// semantic-search surface.
+/// smoke harness (`mlx_smoke measure-baseline`'s R² assertion). Compiled only
+/// when its sole caller (`mlx_smoke`, gated on the `smoke` feature) or the
+/// crate's own test target is built.
+#[cfg(any(test, feature = "smoke"))]
 #[doc(hidden)]
 pub mod linreg;
 mod metrics;
@@ -30,7 +31,7 @@ pub use crate::model_init::ModelInitError;
 pub use crate::model_lifecycle::{cached_artifacts, download_model};
 pub use embedder::Embedder;
 pub use metrics::BatchMetrics;
-pub use pooling::gpu_pool_and_normalize;
+pub(crate) use pooling::gpu_pool_and_normalize;
 
 use crate::artifacts;
 use crate::model_io::{ModelArtifact, truncate_with_eos};
@@ -84,7 +85,7 @@ pub const DOCUMENT_PREFIX: &str = "検索文書: ";
 
 pub use crate::model_io::MAX_SEQ_LEN;
 /// Number of overlapping tokens between adjacent chunks.
-pub const CHUNK_OVERLAP_TOKENS: usize = 2048;
+pub(crate) const CHUNK_OVERLAP_TOKENS: usize = 2048;
 
 /// Maximum text content tokens for a given prefix length.
 /// Computed as `MAX_SEQ_LEN - 2 (BOS + EOS) - prefix_len`.

--- a/src/embed/fixtures.rs
+++ b/src/embed/fixtures.rs
@@ -31,7 +31,6 @@ use std::io;
 use std::io::{Read, Write};
 
 use super::ChunkedEmbedding;
-use crate::storage::f32_as_bytes;
 
 /// Minimum cosine similarity for two fixtures to count as numerically
 /// equivalent (Spec NFR-001).
@@ -89,8 +88,8 @@ pub enum ShapeMismatch {
 ///
 /// Each chunk triggers two writes: a 4-byte `hidden_dim` header and the
 /// f32 payload as a single contiguous little-endian byte slice (via
-/// [`f32_as_bytes`]). Callers writing to a [`std::fs::File`] must wrap it
-/// in a [`std::io::BufWriter`] to avoid one syscall per chunk boundary.
+/// `bytemuck::cast_slice`). Callers writing to a [`std::fs::File`] must wrap
+/// it in a [`std::io::BufWriter`] to avoid one syscall per chunk boundary.
 pub fn save<W: Write>(w: &mut W, docs: &[ChunkedEmbedding]) -> io::Result<()> {
     let num_docs = u32::try_from(docs.len()).expect("num_docs fits in u32");
     w.write_all(&num_docs.to_le_bytes())?;
@@ -100,7 +99,7 @@ pub fn save<W: Write>(w: &mut W, docs: &[ChunkedEmbedding]) -> io::Result<()> {
         for chunk in &doc.chunks {
             let dim = u32::try_from(chunk.len()).expect("hidden_dim fits in u32");
             w.write_all(&dim.to_le_bytes())?;
-            w.write_all(f32_as_bytes(chunk))?;
+            w.write_all(bytemuck::cast_slice::<f32, u8>(chunk))?;
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,9 @@ pub mod reranker;
 pub mod retrieval;
 /// Codex seatbelt sandbox detection for MLX runtime gating.
 ///
-/// Internal support API used by smoke binaries and integration tests. Exposed
-/// as `pub` for cross-target reuse within this crate — not part of the public
-/// semantic-search surface for downstream consumers.
-#[doc(hidden)]
+/// Public API for downstream consumers that drive MLX through rurico and need
+/// to skip MLX-touching paths inside Codex Desktop's seatbelt sandbox. See
+/// the [module-level docs](sandbox) for the operational contract.
 pub mod sandbox;
 /// SQLite-backed vector + FTS5 hybrid storage.
 pub mod storage;

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -128,7 +128,7 @@ impl ModelPaths {
 /// # Errors
 ///
 /// Returns [`ModelIoError::Config`] on IO failure or JSON parse error.
-pub fn read_config<T: DeserializeOwned>(path: &Path) -> Result<T, ModelIoError> {
+pub(crate) fn read_config<T: DeserializeOwned>(path: &Path) -> Result<T, ModelIoError> {
     let text = fs::read_to_string(path).map_err(|e| ModelIoError::Config {
         path: path.to_path_buf(),
         reason: e.to_string(),

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -9,10 +9,20 @@
 //! also supply their own `impl Aggregator` for domain-specific dedupers.
 
 use std::collections::HashMap;
+use std::f64::consts::LN_2;
 
 use serde::{Deserialize, Serialize};
 
-use crate::storage::recency_decay;
+/// Exponential recency decay: 1.0 at age=0, 0.5 at one half-life, approaching 0.0.
+///
+/// Negative `age_days` is clamped to 0 (returns 1.0).
+/// Returns 0.0 when `half_life_days <= 0.0` (avoids division by zero).
+pub(crate) fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
+    if half_life_days <= 0.0 {
+        return 0.0;
+    }
+    (-LN_2 * age_days.max(0.0) / half_life_days).exp()
+}
 
 /// Source of a Stage 1 candidate hit (ADR 0004 Stage 1 output).
 ///
@@ -476,6 +486,48 @@ impl Aggregator for TopKAverageAggregator {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // T-007: age_zero_returns_one
+    #[test]
+    fn age_zero_returns_one() {
+        let result = recency_decay(0.0, 30.0);
+        assert!((result - 1.0).abs() < f64::EPSILON);
+    }
+
+    // T-008: one_half_life_returns_half
+    #[test]
+    fn one_half_life_returns_half() {
+        let result = recency_decay(30.0, 30.0);
+        assert!((result - 0.5).abs() < 0.01);
+    }
+
+    // T-009: two_half_lives_returns_quarter
+    #[test]
+    fn two_half_lives_returns_quarter() {
+        let result = recency_decay(60.0, 30.0);
+        assert!((result - 0.25).abs() < 0.01);
+    }
+
+    // T-010: zero_half_life_returns_zero
+    #[test]
+    fn zero_half_life_returns_zero() {
+        let result = recency_decay(0.0, 0.0);
+        assert!((result - 0.0).abs() < f64::EPSILON);
+    }
+
+    // T-010b: negative_half_life_returns_zero
+    #[test]
+    fn negative_half_life_returns_zero() {
+        let result = recency_decay(5.0, -1.0);
+        assert!((result - 0.0).abs() < f64::EPSILON);
+    }
+
+    // T-010c: negative_age_clamped_to_one
+    #[test]
+    fn negative_age_clamped_to_one() {
+        let result = recency_decay(-5.0, 30.0);
+        assert!((result - 1.0).abs() < f64::EPSILON);
+    }
 
     fn hit(id: &str, score: f64) -> MergedHit {
         MergedHit {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,8 +1,17 @@
 //! Codex seatbelt sandbox detection for MLX runtime gating.
 //!
-//! MLX / Metal initialization aborts in Codex Desktop's seatbelt sandbox.
-//! Smoke binaries self-skip with [`SEATBELT_SKIP_EXIT`] via [`exit_if_seatbelt`],
-//! and `test-mlx` runtime tests bail via [`require_unsandboxed_mlx_runtime`].
+//! MLX / Metal initialization aborts under Codex Desktop's seatbelt sandbox,
+//! so any consumer driving MLX through rurico must opt out of MLX-touching
+//! code paths when that environment is detected.
+//!
+//! # Operational contract
+//!
+//! - Smoke / verification binaries call `exit_if_seatbelt` near `main` and
+//!   exit cleanly with `SEATBELT_SKIP_EXIT` (BSD `EX_CONFIG`) so test
+//!   harnesses can distinguish "skipped under sandbox" from a real failure.
+//! - Runtime tests that require live MLX (e.g. behind a `test-mlx` feature)
+//!   call `require_unsandboxed_mlx_runtime` to bail loudly rather than crash
+//!   inside Metal.
 
 use std::env;
 use std::process;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,17 +4,10 @@ mod search;
 use std::sync::OnceLock;
 
 pub use query_normalize::{QueryNormalizationConfig, normalize_for_fts, pre_phase_5_disabled};
-pub use search::{
-    MatchFtsQuery, SanitizeError, fts_quote, prepare_match_query, recency_decay, rrf_merge,
-};
+pub use search::{MatchFtsQuery, SanitizeError, fts_quote, prepare_match_query, rrf_merge};
 
 #[cfg(not(target_endian = "little"))]
 compile_error!("rurico requires a little-endian target for f32↔u8 embedding storage");
-
-/// Reinterpret `&[f32]` as `&[u8]` (zero-copy, little-endian).
-pub fn f32_as_bytes(slice: &[f32]) -> &[u8] {
-    bytemuck::cast_slice(slice)
-}
 
 /// Register sqlite-vec as a process-global auto-extension.
 ///

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,21 +1,9 @@
 use std::collections::HashMap;
-use std::f64::consts::LN_2;
 use std::hash::Hash;
 
 use rusqlite::Connection;
 
 use super::query_normalize::{QueryNormalizationConfig, normalize_for_fts};
-
-/// Exponential recency decay: 1.0 at age=0, 0.5 at one half-life, approaching 0.0.
-///
-/// Negative `age_days` is clamped to 0 (returns 1.0).
-/// Returns 0.0 when `half_life_days <= 0.0` (avoids division by zero).
-pub fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
-    if half_life_days <= 0.0 {
-        return 0.0;
-    }
-    (-LN_2 * age_days.max(0.0) / half_life_days).exp()
-}
 
 /// Filter out `NEAR(...)` and `NEAR/N(...)` groups from whitespace-split tokens.
 fn strip_near_groups(query: &str) -> Vec<&str> {
@@ -704,47 +692,5 @@ mod tests {
             sanitize_fts_query("^"),
             Err(SanitizeError::NoSearchableTerms)
         );
-    }
-
-    // T-007: age_zero_returns_one
-    #[test]
-    fn age_zero_returns_one() {
-        let result = recency_decay(0.0, 30.0);
-        assert!((result - 1.0).abs() < f64::EPSILON);
-    }
-
-    // T-008: one_half_life_returns_half
-    #[test]
-    fn one_half_life_returns_half() {
-        let result = recency_decay(30.0, 30.0);
-        assert!((result - 0.5).abs() < 0.01);
-    }
-
-    // T-009: two_half_lives_returns_quarter
-    #[test]
-    fn two_half_lives_returns_quarter() {
-        let result = recency_decay(60.0, 30.0);
-        assert!((result - 0.25).abs() < 0.01);
-    }
-
-    // T-010: zero_half_life_returns_zero
-    #[test]
-    fn zero_half_life_returns_zero() {
-        let result = recency_decay(0.0, 0.0);
-        assert!((result - 0.0).abs() < f64::EPSILON);
-    }
-
-    // T-010b: negative_half_life_returns_zero
-    #[test]
-    fn negative_half_life_returns_zero() {
-        let result = recency_decay(5.0, -1.0);
-        assert!((result - 0.0).abs() < f64::EPSILON);
-    }
-
-    // T-010c: negative_age_clamped_to_one
-    #[test]
-    fn negative_age_clamped_to_one() {
-        let result = recency_decay(-5.0, 30.0);
-        assert!((result - 1.0).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## 概要

Issue #103 で指定されたリファクタリングを実装。内部可視性を厳格化し、公開API サーフェスを整理しました。

## 変更内容

- **可視性の厳格化**: `CHUNK_OVERLAP_TOKENS`, `gpu_pool_and_normalize`, `read_config` を `pub` から `pub(crate)` に変更
- **非推奨ヘルパーの削除**: `pub fn f32_as_bytes()` を削除。ダウンストリーム利用者は `bytemuck::cast_slice::<f32, u8>()` を直接使用する必要があります
- **sandbox モジュールの昇格**: `#[doc(hidden)]` を削除、運用契約ドキュメントを拡充。MLX 駆動利用者向けの公式公開API に
- **recency_decay の再配置**: storage モジュールから retrieval モジュールへ関数とテストを移動
- **README.md の更新**: API 変更をドキュメント例に反映

## 破壊的変更

- `f32_as_bytes` が公開API から削除
- `storage::recency_decay` → `retrieval::recency_decay` に移動
- `embed::CHUNK_OVERLAP_TOKENS`, `embed::gpu_pool_and_normalize` が `pub(crate)` に
- `model_io::read_config` が `pub(crate)` に

## テストカバレッジ

全 317 テスト合格。recency_decay テスト (T-007 ～ T-010c) は再配置され、同一のロジックで保持されました。

## ダウンストリーム移行

影響を受けるダウンストリーム crate (yomu, sae, recall, amici) は以下の対応が必要です:
1. `f32_as_bytes(slice)` を `bytemuck::cast_slice::<f32, u8>(slice)` に更新
2. `storage::recency_decay` インポートを `retrieval::recency_decay` に更新

各リポジトリの Issue として個別の移行追跡用を作成予定です。

Closes #103