### PR TITLE
ci: テスト feature flag を clippy と整合させ ignored テストを文書化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo check --workspace
 
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --features test-support,test-mlx
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check
-        run: cargo check --workspace
+        run: cargo check --workspace --features test-support,test-mlx
 
       - name: Test
         run: cargo test --workspace --features test-support,test-mlx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to rurico
+
+## テスト
+
+CI で実行されるテスト一式は以下で再現できる。
+
+```sh
+cargo test --workspace --features test-support,test-mlx
+```
+
+`test-support` / `test-mlx` feature を有効にすることで、CI の clippy step (`cargo clippy --workspace --all-targets --all-features -- -D warnings`) が見ているコードを test 側でも exercise する。CI の test step もこの組み合わせで実行される。
+
+### `#[ignore]` テストの実行
+
+ネットワークアクセスや実モデルを要するテストは `#[ignore]` で gate されており、デフォルトでは実行されない。再有効化方法は各テストの doc comment に記載してある。例:
+
+```sh
+# 実モデルを HF Hub からダウンロードして tokenizer 動作を検証
+cargo test -- --ignored g_001_real_tokenizer_extract_prefix_tokens
+```
+
+`src/embed/tests.rs` の 3 件と、`src/reranker/tests.rs` 内 `mlx_runtime_tests` モジュールの test がこのカテゴリに該当する。
+
+### `mlx_smoke` smoke テスト
+
+`mlx_smoke` 統合テスト (`tests/mlx_smoke.rs`) と同名 binary (`src/bin/mlx_smoke.rs`) は `smoke` feature の背後にあり、実 ruri-v3 モデル + Apple Silicon の MLX runtime を要する。CI では走らせない（モデルダウンロードと推論で macos-latest runner の 15 分 timeout を圧迫するため）。ローカルで実行する場合は事前に対象モデルをキャッシュしてから:
+
+```sh
+# ruri-v3 系モデルがローカル HF cache にあることを前提に走らせる
+cargo test --workspace --features smoke --test mlx_smoke -- --ignored
+```
+
+binary 版を直接呼ぶ場合:
+
+```sh
+cargo run --features smoke --bin mlx_smoke
+```
+
+## ブランチと commit
+
+- ブランチ名は `<type>/<short-topic>` 形式（例: `fix/foo-bar`, `ci/baz-qux`）。
+- commit message は Conventional Commits（`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `polish:`, `ci:` 等）。
+
+## Lint と format
+
+PR 提出前に以下が通ることを確認する。
+
+```sh
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo fmt -- --check
+```

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -191,7 +191,6 @@ fn max_content_equals_max_seq_len_minus_2_minus_prefix_len() {
 }
 
 /// Requires HF Hub model download (network access).
-/// Run with: `cargo test -- --ignored g_001_real_tokenizer_extract_prefix_tokens`
 #[test]
 #[ignore]
 fn g_001_real_tokenizer_extract_prefix_tokens() {
@@ -298,7 +297,6 @@ fn mock_chunked_embedder_returns_multi_chunk() {
 // are covered by `tests/mlx_smoke.rs` via subprocess isolation.
 
 /// Requires HF Hub model download (network access).
-/// Run with: `cargo test -- --ignored regression_prefix_merge_standalone_vs_full_tokenization_diverges`
 #[test]
 #[ignore]
 fn regression_prefix_merge_standalone_vs_full_tokenization_diverges() {
@@ -326,7 +324,6 @@ fn regression_prefix_merge_standalone_vs_full_tokenization_diverges() {
 }
 
 /// Requires HF Hub model download (network access).
-/// Run with: `cargo test -- --ignored regression_long_document_sequential_planner_overlap_and_coverage`
 #[test]
 #[ignore]
 fn regression_long_document_sequential_planner_overlap_and_coverage() {

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -190,8 +190,10 @@ fn max_content_equals_max_seq_len_minus_2_minus_prefix_len() {
     assert_eq!(8180 + 10 + 2, MAX_SEQ_LEN);
 }
 
+/// Requires HF Hub model download (network access).
+/// Run with: `cargo test -- --ignored g_001_real_tokenizer_extract_prefix_tokens`
 #[test]
-#[ignore] // requires model download
+#[ignore]
 fn g_001_real_tokenizer_extract_prefix_tokens() {
     let artifacts = download_model(ModelId::default()).expect("download model");
     let tokenizer = load_tokenizer(&artifacts.paths.tokenizer).unwrap();
@@ -295,8 +297,10 @@ fn mock_chunked_embedder_returns_multi_chunk() {
 // MLX-dependent embedding tests (short text, long text, batch, prefix-merge)
 // are covered by `tests/mlx_smoke.rs` via subprocess isolation.
 
+/// Requires HF Hub model download (network access).
+/// Run with: `cargo test -- --ignored regression_prefix_merge_standalone_vs_full_tokenization_diverges`
 #[test]
-#[ignore] // requires model download
+#[ignore]
 fn regression_prefix_merge_standalone_vs_full_tokenization_diverges() {
     // Verify that the prefix boundary actually diverges for these texts,
     // confirming the need for Approach A.
@@ -321,8 +325,10 @@ fn regression_prefix_merge_standalone_vs_full_tokenization_diverges() {
     }
 }
 
+/// Requires HF Hub model download (network access).
+/// Run with: `cargo test -- --ignored regression_long_document_sequential_planner_overlap_and_coverage`
 #[test]
-#[ignore] // requires model download
+#[ignore]
 fn regression_long_document_sequential_planner_overlap_and_coverage() {
     // Mirrors the production sequential chunk planner. Verifies:
     // 1. Every chunk fits MAX_SEQ_LEN (adaptive shrink)


### PR DESCRIPTION
## 概要

- CI test step に `--features test-support,test-mlx` 追加。clippy の `--all-features` surface と揃え、`test-mlx` / `test-support` gated コードを test 側でも exercise する
- Check step も同じ feature set に揃え、cargo の incremental cache を Test と共有させる
- `src/embed/tests.rs` の 3 件 `#[ignore]` test に再有効化方法を rustdoc 化（`/// Requires HF Hub model download (network access).`）
- `CONTRIBUTING.md` 新規作成。CI 再現コマンド、`#[ignore]` テスト実行方法、`mlx_smoke` 手動実行手順、ブランチ・commit・lint 規約を集約

Closes #108

## テスト計画

- [x] `cargo test --workspace --features test-support,test-mlx` → 317 passed / 27 ignored / 0 failed (4.22s, local)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] CI macos-latest が 15min budget 内で完了することを確認

## 解決対象

- ENC-014 (test 側で smoke 不在) — Option β を採用、smoke は local 専用 + CONTRIBUTING に手順
- ENC-015 (clippy/test feature 不一致) — Test/Check 両方に `test-support,test-mlx` 追加で解消
- COV-001 (ignored test の再有効化 path 未文書化) — 各 test に rustdoc 追加 + CONTRIBUTING.md に集約

## ダウンストリーム

API 影響なし（CI / docs / 内部 test のみ）。memory 方針 (`feedback_defer_bump_for_no_op_merge`) に従い、本 merge では amici / yomu / recall / sae の rev bump issue は切らず、次の機能変更マージで合流させる。