### PR TITLE
feat(model_probe): setup フェーズ拒否を typed SetupReason enum で表現

### DIFF
--- a/src/model_init.rs
+++ b/src/model_init.rs
@@ -66,7 +66,7 @@ mod tests {
     use std::error::Error as _;
 
     use crate::model_init::ModelInitError;
-    use crate::model_probe::{PROBE_EXIT_PATH_OUTSIDE_CACHE, ProbeError};
+    use crate::model_probe::{ProbeError, SetupReason};
 
     // T-006: From<ProbeError::HandlerNotInstalled> → Backend { message } where message == Display verbatim
     #[test]
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn from_probe_error_setup_rejected_and_subprocess_failed_both_map_to_backend() {
         let setup_err: ModelInitError = ProbeError::SetupRejected {
-            code: PROBE_EXIT_PATH_OUTSIDE_CACHE,
+            reason: SetupReason::PathOutsideCache,
         }
         .into();
         assert!(
@@ -143,7 +143,7 @@ mod tests {
     #[test]
     fn from_probe_error_setup_rejected_preserves_source_chain() {
         let init_err: ModelInitError = ProbeError::SetupRejected {
-            code: PROBE_EXIT_PATH_OUTSIDE_CACHE,
+            reason: SetupReason::PathOutsideCache,
         }
         .into();
         let source = init_err

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -13,7 +13,7 @@
 
 use crate::artifacts::{ArtifactError, CandidateArtifacts, ModelKind, VerifiedArtifacts};
 use crate::model_io::{ModelArtifact, artifacts_if_cached, download_artifacts};
-use crate::model_probe::{resolve_probe_env, validate_probe_paths};
+use crate::model_probe::{SetupReason, resolve_probe_env, validate_probe_paths};
 
 /// Download model files from Hugging Face Hub and verify them as `Id::Kind` artifacts.
 ///
@@ -65,13 +65,13 @@ pub fn cached_artifacts<Id: ModelArtifact>(
 /// Returns `None` if this is not a probe invocation (primary model env var absent).
 /// Returns `Some(Ok(_))` if all three vars are set and pass path validation.
 /// Returns `Some(Err(_))` if the model var is set but config or tokenizer is
-/// missing or the paths fail validation (exit code from
+/// missing or the paths fail validation ([`SetupReason`] from
 /// [`validate_probe_paths`]).
 pub(crate) fn probe_env_to_paths<K: ModelKind>(
     model: Option<String>,
     config: Option<String>,
     tokenizer: Option<String>,
-) -> Option<Result<CandidateArtifacts<K>, i32>> {
+) -> Option<Result<CandidateArtifacts<K>, SetupReason>> {
     resolve_probe_env(model, config, tokenizer).map(|r| {
         r.and_then(|(m, c, t)| {
             validate_probe_paths(&m, &c, &t)?;
@@ -92,6 +92,7 @@ mod tests {
     use crate::embed::ModelId;
     use crate::model_io::ModelArtifact;
     use crate::model_lifecycle::{cached_artifacts, download_model, probe_env_to_paths};
+    use crate::model_probe::SetupReason;
     use crate::reranker::RerankerModelId;
     use crate::test_support::{
         FAKE_BACKBONE_KEY, MINIMAL_TOKENIZER_JSON, VALID_CONFIG_JSON, setup_fake_hf_cache,
@@ -213,7 +214,7 @@ mod tests {
 
         let hf_home_path = hf_home.path().to_path_buf();
         temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-            let result: Option<Result<CandidateArtifacts<EmbedKind>, i32>> =
+            let result: Option<Result<CandidateArtifacts<EmbedKind>, SetupReason>> =
                 probe_env_to_paths::<EmbedKind>(
                     Some(m.to_string_lossy().into_owned()),
                     Some(c.to_string_lossy().into_owned()),
@@ -243,7 +244,7 @@ mod tests {
 
         let hf_home_path = hf_home.path().to_path_buf();
         temp_env::with_vars([("HF_HOME", Some(hf_home_path.to_str().unwrap()))], || {
-            let result: Option<Result<CandidateArtifacts<RerankerKind>, i32>> =
+            let result: Option<Result<CandidateArtifacts<RerankerKind>, SetupReason>> =
                 probe_env_to_paths::<RerankerKind>(
                     Some(m.to_string_lossy().into_owned()),
                     Some(c.to_string_lossy().into_owned()),

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -72,6 +72,61 @@ pub(crate) const PROBE_EXIT_ACK_FAILED: i32 = 7;
 /// "model load failed with empty reason".
 pub(crate) const PROBE_EXIT_STDERR_FAILED: i32 = 8;
 
+/// Reason a probe subprocess was rejected during the setup phase. Each
+/// variant maps 1:1 to a `PROBE_EXIT_*` constant via the `#[repr(i32)]`
+/// discriminant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+#[non_exhaustive]
+pub enum SetupReason {
+    /// Primary model env var set, but config or tokenizer is missing.
+    EnvIncomplete = PROBE_EXIT_ENV_INCOMPLETE,
+    /// `std::fs::canonicalize` failed on a candidate path.
+    CanonicalizeFailed = PROBE_EXIT_CANONICALIZE_FAILED,
+    /// Candidate path canonicalized outside the HF cache root.
+    PathOutsideCache = PROBE_EXIT_PATH_OUTSIDE_CACHE,
+    /// `std::fs::canonicalize` failed on the cache root itself.
+    CacheRootInvalid = PROBE_EXIT_CACHE_ROOT_INVALID,
+}
+
+impl SetupReason {
+    /// Exit code for this reason.
+    pub fn code(self) -> i32 {
+        self as i32
+    }
+
+    /// Human-readable label. Surfaced in the child stderr message
+    /// `"probe setup rejected: <label>"` (forensic log anchor; SEC-002).
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::EnvIncomplete => "env incomplete",
+            Self::CanonicalizeFailed => "path canonicalize failed",
+            Self::PathOutsideCache => "path outside cache",
+            Self::CacheRootInvalid => "cache root invalid",
+        }
+    }
+}
+
+impl TryFrom<i32> for SetupReason {
+    type Error = ();
+
+    fn try_from(code: i32) -> Result<Self, Self::Error> {
+        match code {
+            PROBE_EXIT_ENV_INCOMPLETE => Ok(Self::EnvIncomplete),
+            PROBE_EXIT_CANONICALIZE_FAILED => Ok(Self::CanonicalizeFailed),
+            PROBE_EXIT_PATH_OUTSIDE_CACHE => Ok(Self::PathOutsideCache),
+            PROBE_EXIT_CACHE_ROOT_INVALID => Ok(Self::CacheRootInvalid),
+            _ => Err(()),
+        }
+    }
+}
+
+impl fmt::Display for SetupReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "code {}: {}", self.code(), self.label())
+    }
+}
+
 /// Verify that `model`, `config`, and `tokenizer` paths all canonicalize to
 /// component-wise descendants of `cache_root`. The candidate paths are
 /// not modified — the load step receives the original symlink path so HF
@@ -80,21 +135,21 @@ pub(crate) const PROBE_EXIT_STDERR_FAILED: i32 = 8;
 ///
 /// # Errors
 ///
-/// - [`PROBE_EXIT_CACHE_ROOT_INVALID`] if `cache_root` cannot be canonicalized
-/// - [`PROBE_EXIT_CANONICALIZE_FAILED`] if any candidate path cannot be canonicalized
-/// - [`PROBE_EXIT_PATH_OUTSIDE_CACHE`] if any candidate path's canonical form
+/// - [`SetupReason::CacheRootInvalid`] if `cache_root` cannot be canonicalized
+/// - [`SetupReason::CanonicalizeFailed`] if any candidate path cannot be canonicalized
+/// - [`SetupReason::PathOutsideCache`] if any candidate path's canonical form
 ///   is not a component-wise descendant of `cache_root`'s canonical form
 pub(crate) fn validate_probe_paths_with_cache(
     cache: &hf_hub::Cache,
     model: &Path,
     config: &Path,
     tokenizer: &Path,
-) -> Result<(), i32> {
-    let canon_root = fs::canonicalize(cache.path()).map_err(|_| PROBE_EXIT_CACHE_ROOT_INVALID)?;
+) -> Result<(), SetupReason> {
+    let canon_root = fs::canonicalize(cache.path()).map_err(|_| SetupReason::CacheRootInvalid)?;
     for p in [model, config, tokenizer] {
-        let canon = fs::canonicalize(p).map_err(|_| PROBE_EXIT_CANONICALIZE_FAILED)?;
+        let canon = fs::canonicalize(p).map_err(|_| SetupReason::CanonicalizeFailed)?;
         if !canon.starts_with(&canon_root) {
-            return Err(PROBE_EXIT_PATH_OUTSIDE_CACHE);
+            return Err(SetupReason::PathOutsideCache);
         }
     }
     Ok(())
@@ -115,7 +170,7 @@ pub(crate) fn validate_probe_paths(
     model: &Path,
     config: &Path,
     tokenizer: &Path,
-) -> Result<(), i32> {
+) -> Result<(), SetupReason> {
     validate_probe_paths_with_cache(&hf_hub::Cache::from_env(), model, config, tokenizer)
 }
 
@@ -143,48 +198,33 @@ pub enum ProbeError {
         /// Failure detail from stderr.
         reason: String,
     },
-    /// Setup-phase rejection (path validation or env hardening) in the probe child.
-    ///
-    /// `code` is one of [`PROBE_EXIT_CANONICALIZE_FAILED`] (4),
-    /// [`PROBE_EXIT_PATH_OUTSIDE_CACHE`] (5), or
-    /// [`PROBE_EXIT_CACHE_ROOT_INVALID`] (6).
-    #[error("probe setup rejected (code {code}: {})", setup_label(*code))]
+    /// Setup-phase rejection (path validation or env hardening) in the probe
+    /// child. Display surfaces as `"probe setup rejected (code N: label)"`
+    /// — the wire format forensic logs grep on.
+    #[error("probe setup rejected ({reason})")]
     SetupRejected {
-        /// Setup-phase exit code.
-        code: i32,
+        /// Setup-phase rejection reason.
+        reason: SetupReason,
     },
     /// Subprocess spawn or wait failure.
     #[error("probe error: {0}")]
     SubprocessFailed(String),
 }
 
-/// Human-readable label for a setup-phase exit code, used in
-/// [`ProbeError::SetupRejected`] Display and in [`setup_failure_message`]
-/// (child stderr message).
-fn setup_label(code: i32) -> &'static str {
-    match code {
-        PROBE_EXIT_ENV_INCOMPLETE => "env incomplete",
-        PROBE_EXIT_CANONICALIZE_FAILED => "path canonicalize failed",
-        PROBE_EXIT_PATH_OUTSIDE_CACHE => "path outside cache",
-        PROBE_EXIT_CACHE_ROOT_INVALID => "cache root invalid",
-        _ => "unknown setup failure",
-    }
-}
-
 /// Resolve probe env vars into a `(model, config, tokenizer)` path triple.
 ///
 /// Returns `None` if the primary model env var is absent (not a probe invocation).
-/// Returns `Some(Err(PROBE_EXIT_ENV_INCOMPLETE))` if model is set but config or
+/// Returns `Some(Err(SetupReason::EnvIncomplete))` if model is set but config or
 /// tokenizer is missing.
 pub(crate) fn resolve_probe_env(
     model: Option<String>,
     config: Option<String>,
     tokenizer: Option<String>,
-) -> Option<Result<(PathBuf, PathBuf, PathBuf), i32>> {
+) -> Option<Result<(PathBuf, PathBuf, PathBuf), SetupReason>> {
     let model = model?;
     Some(match (config, tokenizer) {
         (Some(config), Some(tokenizer)) => Ok((model.into(), config.into(), tokenizer.into())),
-        _ => Err(PROBE_EXIT_ENV_INCOMPLETE),
+        _ => Err(SetupReason::EnvIncomplete),
     })
 }
 
@@ -205,22 +245,26 @@ pub(crate) struct ProbeExitAction {
 
 /// Determine the exit code and stderr message for a probe dispatch.
 ///
-/// - `Err(code)`: env vars incomplete → exit with that code
+/// - `Err(reason)`: setup rejected → exit with `reason.code()`
 /// - `Ok(Ok(()))`: model loaded successfully → exit 0
-/// - `Ok(Err(reason))`: model load failed → exit 1 with reason
-pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> ProbeExitAction {
+/// - `Ok(Err(load_err))`: model load failed → exit 1 with the load error message
+pub(crate) fn compute_probe_exit(
+    result: Result<Result<(), String>, SetupReason>,
+) -> ProbeExitAction {
     match result {
-        Err(code) => ProbeExitAction {
-            code,
-            message: Some(format!("probe setup rejected: {}", setup_label(code))),
+        Err(reason) => ProbeExitAction {
+            code: reason.code(),
+            // label() only — not full Display — so the stderr wire format
+            // stays `"probe setup rejected: <label>"` (SEC-002 forensic log).
+            message: Some(format!("probe setup rejected: {}", reason.label())),
         },
         Ok(Ok(())) => ProbeExitAction {
             code: 0,
             message: None,
         },
-        Ok(Err(reason)) => ProbeExitAction {
+        Ok(Err(load_err)) => ProbeExitAction {
             code: 1,
-            message: Some(reason),
+            message: Some(load_err),
         },
     }
 }
@@ -233,14 +277,14 @@ pub(crate) fn compute_probe_exit(result: Result<Result<(), String>, i32>) -> Pro
 /// can distinguish them from `HandlerNotInstalled` (caller forgot the probe
 /// handler) or `ModelLoadFailed` (load itself failed with a reason).
 pub(crate) fn dispatch_probe<P, E: fmt::Display>(
-    result: Result<P, i32>,
+    result: Result<P, SetupReason>,
     load: impl FnOnce(P) -> Result<(), E>,
 ) -> ! {
     if emit_ack().is_err() {
         process::exit(PROBE_EXIT_ACK_FAILED);
     }
     let outcome = match result {
-        Err(code) => Err(code),
+        Err(reason) => Err(reason),
         Ok(candidate) => Ok(load(candidate).map_err(|e| e.to_string())),
     };
     let action = compute_probe_exit(outcome);
@@ -590,22 +634,19 @@ pub(crate) fn interpret_probe_output(output: &Output) -> Result<ProbeStatus, Pro
         Some(PROBE_EXIT_STDERR_FAILED) => Err(ProbeError::SubprocessFailed(
             "probe child failed to write failure reason to stderr".into(),
         )),
-        Some(
-            code @ (PROBE_EXIT_ENV_INCOMPLETE
-            | PROBE_EXIT_CANONICALIZE_FAILED
-            | PROBE_EXIT_PATH_OUTSIDE_CACHE
-            | PROBE_EXIT_CACHE_ROOT_INVALID),
-        ) => Err(ProbeError::SetupRejected { code }),
-        Some(_) => {
-            let reason = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-            Err(ProbeError::ModelLoadFailed {
-                reason: if reason.is_empty() {
-                    "model load failed".into()
-                } else {
-                    reason
-                },
-            })
-        }
+        Some(code) => match SetupReason::try_from(code) {
+            Ok(reason) => Err(ProbeError::SetupRejected { reason }),
+            Err(()) => {
+                let stderr_text = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+                Err(ProbeError::ModelLoadFailed {
+                    reason: if stderr_text.is_empty() {
+                        "model load failed".into()
+                    } else {
+                        stderr_text
+                    },
+                })
+            }
+        },
         None => Ok(ProbeStatus::BackendUnavailable),
     }
 }

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -1,13 +1,7 @@
 //! Tests for `crate::model_probe`.
-//!
-//! Existing tests cover `resolve_probe_env`, `interpret_probe_output`,
-//! `compute_probe_exit`, and the wait/spawn machinery. New tests added for
-//! Issue #107 Phase 1 (AC-1, AC-4) cover `validate_probe_paths_with_root`
-//! and the production wrapper `validate_probe_paths`. The visibility
-//! downgrade of `from_paths` is verified by `tests/ui/from_paths_pub_crate.rs`
-//! (trybuild compile-fail; Issue #118).
 
 use super::*;
+use std::fs;
 use std::io;
 use std::process::ExitStatus;
 
@@ -58,8 +52,6 @@ mod test_writers {
     }
 }
 
-// ── Existing tests preserved verbatim ───────────────────────────────────────
-
 #[test]
 fn resolve_probe_env_returns_none_when_model_absent() {
     assert!(resolve_probe_env(None, None, None).is_none());
@@ -70,11 +62,11 @@ fn resolve_probe_env_returns_none_when_model_absent() {
 fn resolve_probe_env_returns_err_when_incomplete() {
     assert_eq!(
         resolve_probe_env(Some("m".into()), None, Some("t".into())),
-        Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
+        Some(Err(SetupReason::EnvIncomplete))
     );
     assert_eq!(
         resolve_probe_env(Some("m".into()), Some("c".into()), None),
-        Some(Err(PROBE_EXIT_ENV_INCOMPLETE))
+        Some(Err(SetupReason::EnvIncomplete))
     );
 }
 
@@ -160,7 +152,7 @@ fn interpret_timeout_output_returns_backend_unavailable() {
 
 #[test]
 fn probe_exit_env_incomplete() {
-    let action = compute_probe_exit(Err(PROBE_EXIT_ENV_INCOMPLETE));
+    let action = compute_probe_exit(Err(SetupReason::EnvIncomplete));
     assert_eq!(action.code, PROBE_EXIT_ENV_INCOMPLETE);
     assert!(action.message.is_some());
 }
@@ -294,20 +286,7 @@ fn wait_with_timeout_with_kills_long_running_child_on_short_timeout() {
     );
 }
 
-// ── Issue #107 Phase 1 tests (AC-1, AC-4) ────────────────────────────────────
-//
-// Red-phase tests against `validate_probe_paths_with_root`,
-// `validate_probe_paths`, and the constants `PROBE_EXIT_CANONICALIZE_FAILED`
-// (4) / `PROBE_EXIT_PATH_OUTSIDE_CACHE` (5) / `PROBE_EXIT_CACHE_ROOT_INVALID`
-// (6). None of these symbols exist yet, so the Red signal is a compile error.
-// The Green implementation must declare them with `pub(crate)` visibility.
-
-use std::fs;
-
-/// Helper: write the three artifact files into `dir` and return their paths.
-///
-/// Used by T-001/T-002/T-003/T-006 (and the symlink variants in T-005/T-021)
-/// to keep arrangement uniform.
+/// Write the three artifact files into `dir` and return their paths.
 fn write_three_artifacts(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let model = dir.join("model.safetensors");
     let config = dir.join("config.json");
@@ -351,10 +330,9 @@ fn validate_probe_paths_with_root_rejects_path_outside_cache_root() {
     // Assert
     assert_eq!(
         result,
-        Err(super::PROBE_EXIT_PATH_OUTSIDE_CACHE),
-        "expected Err(5) for path outside cache root"
+        Err(SetupReason::PathOutsideCache),
+        "expected Err(SetupReason::PathOutsideCache) for path outside cache root"
     );
-    assert_eq!(super::PROBE_EXIT_PATH_OUTSIDE_CACHE, 5);
 }
 
 // T-003: validate_probe_paths_with_root reports canonicalize failure with Err(4)
@@ -374,10 +352,9 @@ fn validate_probe_paths_with_root_returns_err_4_for_nonexistent_candidate_path()
     // Assert
     assert_eq!(
         result,
-        Err(super::PROBE_EXIT_CANONICALIZE_FAILED),
-        "expected Err(4) for nonexistent candidate path"
+        Err(SetupReason::CanonicalizeFailed),
+        "expected Err(SetupReason::CanonicalizeFailed) for nonexistent candidate path"
     );
-    assert_eq!(super::PROBE_EXIT_CANONICALIZE_FAILED, 4);
 }
 
 // T-004: validate_probe_paths_with_root reports invalid cache root with Err(6)
@@ -395,17 +372,16 @@ fn validate_probe_paths_with_root_returns_err_6_for_nonexistent_cache_root() {
     // Assert
     assert_eq!(
         result,
-        Err(super::PROBE_EXIT_CACHE_ROOT_INVALID),
-        "expected Err(6) when cache_root cannot be canonicalized"
+        Err(SetupReason::CacheRootInvalid),
+        "expected Err(SetupReason::CacheRootInvalid) when cache_root cannot be canonicalized"
     );
-    assert_eq!(super::PROBE_EXIT_CACHE_ROOT_INVALID, 6);
 }
 
 // T-005: validate_probe_paths_with_root accepts symlink path inside cache_root
 //
 // The function MUST return Ok(()) and MUST NOT modify the caller's PathBuf
-// (signature is `&Path` in, `Result<(), i32>` out — symlink invariant guarded
-// by FR-005's type-level constraint, exercised here through behavior).
+// (signature is `&Path` in, `Result<(), SetupReason>` out — symlink invariant
+// guarded by FR-005's type-level constraint, exercised here through behavior).
 #[cfg(unix)]
 #[test]
 fn validate_probe_paths_with_root_accepts_symlink_under_cache_root() {
@@ -468,15 +444,10 @@ fn validate_probe_paths_with_root_rejects_string_prefix_sibling() {
     // component-wise starts_with rejects it.
     assert_eq!(
         result,
-        Err(super::PROBE_EXIT_PATH_OUTSIDE_CACHE),
+        Err(SetupReason::PathOutsideCache),
         "component-wise prefix check must reject `cache_x_evil` against `cache_x`"
     );
 }
-
-// T-016: replaced by `tests/ui/from_paths_pub_crate.rs` (trybuild compile-fail).
-// Visibility verification now lives in the integration-test surface so the
-// compiler — not a source-string match — enforces the `pub(crate)` boundary.
-// See Issue #118.
 
 // T-021: validate_probe_paths (production wrapper) HF_HOME unset fallback (FR-101 + FR-006)
 //
@@ -518,15 +489,8 @@ fn validate_probe_paths_falls_back_to_home_when_hf_home_unset() {
     );
 }
 
-// ── Issue #107 Phase 2 tests (AC-2) ──────────────────────────────────────────
-//
-// Tests for typed setup-failure error variant `ProbeError::SetupRejected { code }`
-// and the `interpret_probe_output` dispatch from setup-phase exit codes 4 / 5 / 6.
-
 // T-007 / T-007a / T-008 / T-009: setup-phase exit codes 3..=6 each map to
-// ProbeError::SetupRejected with the exit code preserved. Stderr is decorative
-// for SetupRejected (Display reads from `code`, not stderr), so all four cases
-// share an empty stderr.
+// ProbeError::SetupRejected with the typed reason preserved.
 #[test]
 fn interpret_probe_output_maps_setup_exit_codes_to_setup_rejected() {
     for code in [
@@ -542,40 +506,115 @@ fn interpret_probe_output_maps_setup_exit_codes_to_setup_rejected() {
         };
         let err = interpret_probe_output(&output).unwrap_err();
         assert!(
-            matches!(err, ProbeError::SetupRejected { code: c } if c == code),
-            "exit {code}: expected SetupRejected {{ code: {code} }}, got {err}"
+            matches!(err, ProbeError::SetupRejected { reason } if reason.code() == code),
+            "exit {code}: expected SetupRejected with reason.code() == {code}, got {err}"
         );
     }
 }
 
 // T-011a / T-011b / T-011c / T-011d: SetupRejected Display surfaces both the
-// exit code and a human-readable label per variant.
+// exit code and a human-readable label per variant. The wire format
+// "probe setup rejected (code N: label)" is contractual — forensic logs
+// rely on the numeric code being present.
 #[test]
 fn setup_rejected_display_includes_code_and_label_per_variant() {
-    let cases: &[(i32, &str)] = &[
-        (PROBE_EXIT_ENV_INCOMPLETE, "env incomplete"),
-        (PROBE_EXIT_CANONICALIZE_FAILED, "path canonicalize failed"),
-        (PROBE_EXIT_PATH_OUTSIDE_CACHE, "path outside cache"),
-        (PROBE_EXIT_CACHE_ROOT_INVALID, "cache root invalid"),
+    let cases: &[(SetupReason, &str)] = &[
+        (SetupReason::EnvIncomplete, "env incomplete"),
+        (SetupReason::CanonicalizeFailed, "path canonicalize failed"),
+        (SetupReason::PathOutsideCache, "path outside cache"),
+        (SetupReason::CacheRootInvalid, "cache root invalid"),
     ];
-    for &(code, label) in cases {
-        let s = format!("{}", ProbeError::SetupRejected { code });
+    for &(reason, label) in cases {
+        let s = format!("{}", ProbeError::SetupRejected { reason });
         assert!(
-            s.contains(&code.to_string()),
-            "code {code}: Display must contain the exit code, got: {s}"
+            s.contains(&reason.code().to_string()),
+            "{reason:?}: Display must contain the exit code, got: {s}"
         );
         assert!(
             s.contains(label),
-            "code {code}: Display must contain label {label:?}, got: {s}"
+            "{reason:?}: Display must contain label {label:?}, got: {s}"
         );
     }
 }
 
-// ── Issue #107 Phase 3 tests (AC-3) ──────────────────────────────────────────
-//
-// Tests for the FORWARD env allowlist constant, the `child_env_for_spawn` test
-// seam (FR-016 — pure function returning the spawn env map), and the silent
-// skip behavior for undefined FORWARD keys (FR-102).
+// T-115-A
+#[test]
+fn setup_reason_code_matches_probe_exit_constant_per_variant() {
+    assert_eq!(SetupReason::EnvIncomplete.code(), PROBE_EXIT_ENV_INCOMPLETE);
+    assert_eq!(
+        SetupReason::CanonicalizeFailed.code(),
+        PROBE_EXIT_CANONICALIZE_FAILED
+    );
+    assert_eq!(
+        SetupReason::PathOutsideCache.code(),
+        PROBE_EXIT_PATH_OUTSIDE_CACHE
+    );
+    assert_eq!(
+        SetupReason::CacheRootInvalid.code(),
+        PROBE_EXIT_CACHE_ROOT_INVALID
+    );
+}
+
+// T-115-B
+#[test]
+fn setup_reason_try_from_round_trips_for_every_variant() {
+    for reason in [
+        SetupReason::EnvIncomplete,
+        SetupReason::CanonicalizeFailed,
+        SetupReason::PathOutsideCache,
+        SetupReason::CacheRootInvalid,
+    ] {
+        assert_eq!(
+            SetupReason::try_from(reason.code()),
+            Ok(reason),
+            "round-trip must yield Ok({reason:?})"
+        );
+    }
+}
+
+// T-115-C
+#[test]
+fn setup_reason_try_from_returns_err_for_non_setup_exit_codes() {
+    for code in [
+        0,
+        1,
+        2,
+        PROBE_EXIT_ACK_FAILED,
+        PROBE_EXIT_STDERR_FAILED,
+        9,
+        999,
+        -1,
+    ] {
+        assert!(
+            SetupReason::try_from(code).is_err(),
+            "code {code} must NOT map to any SetupReason variant"
+        );
+    }
+}
+
+// T-115-D: child stderr forensic log (SEC-002 dynamic message) reads from
+// label() — guard against an accidental rename that would silently shift it.
+#[test]
+fn setup_reason_label_is_stable_per_variant() {
+    let cases: &[(SetupReason, &str)] = &[
+        (SetupReason::EnvIncomplete, "env incomplete"),
+        (SetupReason::CanonicalizeFailed, "path canonicalize failed"),
+        (SetupReason::PathOutsideCache, "path outside cache"),
+        (SetupReason::CacheRootInvalid, "cache root invalid"),
+    ];
+    for &(reason, expected) in cases {
+        assert_eq!(reason.label(), expected, "{reason:?} label drift");
+    }
+}
+
+// T-115-E
+#[test]
+fn setup_reason_display_combines_code_and_label() {
+    assert_eq!(
+        format!("{}", SetupReason::PathOutsideCache),
+        format!("code {PROBE_EXIT_PATH_OUTSIDE_CACHE}: path outside cache"),
+    );
+}
 
 // T-012: FORWARD list contains exactly the 22 expected keys
 #[test]
@@ -692,16 +731,6 @@ fn probe_via_subprocess_with_env_clear_blocks_attacker_env_in_real_child() {
     );
 }
 
-// ── Issue #94 (probe IO error propagation) tests ────────────────────────────
-//
-// `emit_ack_to` is a testable seam exposed for these tests; production calls
-// `emit_ack` which delegates to `emit_ack_to(&mut io::stdout())`. The new
-// IO-infrastructure exit codes `PROBE_EXIT_ACK_FAILED` (7) and
-// `PROBE_EXIT_STDERR_FAILED` (8) signal that the probe child could not
-// emit its handshake (stdout) or its failure reason (stderr) — distinct
-// from `HandlerNotInstalled` (caller forgot the probe handler) and
-// `ModelLoadFailed` (load itself failed).
-
 // T-023: emit_ack_to writes PROBE_ACK + newline on a valid writer
 #[test]
 fn emit_ack_to_writes_ack_token_with_newline() {
@@ -744,7 +773,6 @@ fn interpret_probe_output_maps_exit_7_to_subprocess_failed_even_without_ack() {
         msg.contains("ACK") || msg.contains("handshake"),
         "expected ACK/handshake mention, got: {msg}"
     );
-    assert_eq!(super::PROBE_EXIT_ACK_FAILED, 7);
 }
 
 // T-026: interpret_probe_output maps exit 8 to SubprocessFailed when ACK is present
@@ -766,7 +794,6 @@ fn interpret_probe_output_maps_exit_8_to_subprocess_failed() {
         msg.contains("stderr") || msg.contains("reason"),
         "expected stderr/reason mention, got: {msg}"
     );
-    assert_eq!(super::PROBE_EXIT_STDERR_FAILED, 8);
 }
 
 // T-027: exit 8 without ACK preserves HandlerNotInstalled diagnostic
@@ -790,8 +817,6 @@ fn interpret_probe_output_exit_8_without_ack_is_handler_not_installed() {
          binary lacks probe handler), got {err}"
     );
 }
-
-// ── Issue #124 (probe IPC contract: drain join + stderr flush) tests ───────
 
 // T-028: emit_failure_to writes msg and calls flush on success
 #[test]


### PR DESCRIPTION
## 概要

- `ProbeError::SetupRejected` の raw `i32` exit code を typed `SetupReason` enum に置き換え。コンパイル時ディスパッチ保証を獲得
- `SetupReason` の各 variant は `#[repr(i32)]` で `PROBE_EXIT_*` 定数と 1:1 対応。`TryFrom<i32>` 実装で OS 境界での変換にも対応
- Wire-format 保持：フォレンジックログは `label()` のみ参照（full Display ではない）。SEC-002 の監査可能性を維持

## 破壊的変更

フィールド名が `code: i32` から `reason: SetupReason` へ変更。`SetupRejected { code }` でパターンマッチしてた downstream 呼び出し元は `SetupRejected { reason }` に更新が必要。downstream リポへの追従は cross-repo policy に従い個別 Issue で対応。

## テスト計画

- [x] 既存 321 個の unit テストすべて pass
- [x] SetupReason 用の新規テスト 5 個追加（T-115-A 〜 T-115-E）
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [ ] downstream リポへの追従 Issue 起票

Closes #115