### PR TITLE
dispatch テストの lookup 呼び出し回数 assertion を削除

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -65,53 +65,28 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
     use std::collections::HashMap;
 
-    /// Per-kind query count from `handle_probe_if_needed_with`: every kind
-    /// reads `model`, `config`, and `tokenizer` regardless of branch outcome.
-    /// With embed + reranker dispatched in sequence, the lookup is called
-    /// `2 * 3 = 6` times when neither kind triggers a probe.
-    const NO_DISPATCH_LOOKUP_COUNT: usize = 6;
+    // Both tests rely on a side-effect oracle: `dispatch_probe` would call
+    // `process::exit` and kill the test runner, so reaching the end of the
+    // test proves the no-dispatch path was taken for both kinds.
 
     #[test]
     fn handle_probe_if_needed_with_returns_when_no_env_set() {
-        let calls = Cell::new(0_usize);
-        handle_probe_if_needed_with(|_key| {
-            calls.set(calls.get() + 1);
-            None
-        });
-        // The function returned (no `process::exit` from `dispatch_probe`)
-        // and still consulted every PROBE_ENV_* var — the empty env path
-        // short-circuits at `probe_env_to_paths` returning None for both kinds.
-        assert_eq!(
-            calls.get(),
-            NO_DISPATCH_LOOKUP_COUNT,
-            "lookup must be queried for embed + reranker × {{model, config, tokenizer}}"
-        );
+        handle_probe_if_needed_with(|_key| None);
     }
 
     #[test]
     fn handle_probe_if_needed_with_skips_paths_without_primary_keys() {
-        let calls = Cell::new(0_usize);
         let map: HashMap<&'static str, &'static str> = [
             (embed::PROBE_ENV_CONFIG, "/tmp/c"),
             (reranker::PROBE_ENV_TOKENIZER, "/tmp/t"),
         ]
         .into_iter()
         .collect();
-        handle_probe_if_needed_with(|key| {
-            calls.set(calls.get() + 1);
-            map.get(key).map(|v| (*v).to_owned())
-        });
-        // PROBE_ENV_MODEL is absent for both kinds, so `resolve_probe_env`
-        // returns None and dispatch is skipped — guards against a regression
-        // where setting only secondary keys tricks the function into spawning
-        // a probe.
-        assert_eq!(
-            calls.get(),
-            NO_DISPATCH_LOOKUP_COUNT,
-            "lookup must be queried for all three vars per kind even when only secondary keys are set"
-        );
+        // PROBE_ENV_MODEL is absent for both kinds, so dispatch is skipped:
+        // setting only secondary keys must NOT trick the function into
+        // spawning a probe.
+        handle_probe_if_needed_with(|key| map.get(key).map(|v| (*v).to_owned()));
     }
 }


### PR DESCRIPTION
## 何 & なぜ

752c685 で追加された `NO_DISPATCH_LOOKUP_COUNT = 6` assertion を `handle_probe_if_needed_with` テストから削除する。追加された呼び出し回数のカウントは実装詳細 (kind ごとに 3 変数 lookup × 2 kinds) をテスト契約に格上げしてしまい、outcome を維持する short-circuit リファクタでテストが壊れる fragility を生んでいた。

## 変更点

- `src/dispatch.rs::tests` から `Cell<usize>` カウントと `NO_DISPATCH_LOOKUP_COUNT` 定数を削除。
- 2 つの `assert_eq!(calls.get(), NO_DISPATCH_LOOKUP_COUNT, ...)` assertion を削除。side-effect oracle (テスト完走 ⇒ `dispatch_probe` が `process::exit` を呼ばなかった) で no-dispatch path はすでに検証されている。
- 削除した per-test の説明文の代わりに、side-effect oracle を明示する mod レベルのコメントを追加。

## スコープ

- **含まれないもの**: inline closure パターンは維持 (元の `lookup_from` ヘルパーより簡潔で、上記 fragility の影響を受けない)。

## 設計判断

- 全 revert ではなく部分 revert を選択: inline closure 形式 (`|_key| None`, `map.get(key).map(|v| (*v).to_owned())`) は元の `lookup_from` ヘルパーより短く、fragility の発生源は magic-number assertion だけだった。

## テスト手順

1. `cargo test --lib dispatch` → 2 passed.
2. `cargo test --lib` → 321 passed, 3 ignored.

## 関連

- 752c685 (`polish(tests): assert lookup-call count in handle_probe_if_needed_with tests`) の部分 revert
