### PR TITLE
refactor(rrf): rrf_merge を retrieval::WeightedRrf に統合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Breaking Changes
 
+- **`storage::rrf_merge` and `RRF_K` constant removed.** The free function and
+  its hardcoded `RRF_K = 60.0` are deleted; `retrieval::WeightedRrf` is now
+  the canonical RRF primitive (configurable `rrf_k` via `HybridSearchConfig`,
+  multi-source weights, recency support). For drop-in replacement of the
+  legacy behavior, use `WeightedRrf::default().merge(&candidates)` — bit-equal
+  to the removed `rrf_merge` (default `rrf_k = 60.0`, weight = 1.0, including
+  the `doc_id` ascending tie-break). Callers that fed `(K, f64)` tuples must
+  convert to `Vec<Candidate>` (see `rurico::retrieval::Candidate`).
 - **`EmbedInitError` and `RerankerInitError` removed; replaced by single
   `ModelInitError` (`rurico::model_init::ModelInitError`).** Variant set
   (`Backend(String)` and `ModelCorrupt { reason: String }`) is unchanged;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Apple Silicon (MLX) 上で日本語テキストのembedding・reranking・類似
 | `embed`       | embedding 生成（MLX 推論、tokenization、pooling、probe）                                                                              |
 | `reranker`    | 検索結果の reranking（cross-encoder スコアリング、probe）                                                                             |
 | `modernbert`  | ModernBERT モデル定義と config                                                                                                        |
-| `storage`     | SQLite + sqlite-vec のベクトル検索プリミティブ（FTS sanitize / `MatchFtsQuery`、`rrf_merge`、`recency_decay`、`QueryNormalizationConfig`） |
+| `storage`     | SQLite + sqlite-vec のベクトル検索プリミティブ（FTS sanitize / `MatchFtsQuery`、`recency_decay`、`QueryNormalizationConfig`） |
 | `retrieval`   | 5-stage retrieval pipeline contract（ADR 0004）— `Candidate` / `MergedHit` / `MergeStrategy` / `Aggregator` / `HybridSearchConfig` / `RecencyConfig` |
 | `text`        | テキスト分割（段落 > 行 > 文字境界で UTF-8 安全に分割）                                                                               |
 | `artifacts`   | モデルファイルの型付き検証パイプライン（`CandidateArtifacts` → `VerifiedArtifacts`）                                                  |
@@ -197,16 +197,20 @@ let nfkc_only = QueryNormalizationConfig {
 let off = pre_phase_5_disabled();
 ```
 
-### ハイブリッド検索プリミティブ — `rrf_merge`
+### ハイブリッド検索 RRF — `WeightedRrf`
 
-FTS5 とベクトル検索の結果を Reciprocal Rank Fusion で統合する低レベル関数。スコア値を無視してランク位置のみで折りたたむ。weight 調整・recency 加味・複数 source 対応を扱いたい場合は [Retrieval Pipeline](#retrieval-pipeline5-stage-contract) の `WeightedRrf` / `merge_with_recency` を使う。
+FTS5 とベクトル検索の結果を Reciprocal Rank Fusion で統合する canonical fusion strategy。weight 調整・recency 加味・複数 source 対応に加え、default config (`rrf_k=60.0`, weight=1.0) でランク位置のみによる折りたたみも担う。詳細な 5-stage pipeline contract は [Retrieval Pipeline](#retrieval-pipeline5-stage-contract) を参照。
 
 ```rust
-use rurico::storage::rrf_merge;
+use rurico::retrieval::{Candidate, CandidateSource, MergeStrategy, WeightedRrf};
 
-let fts_hits = vec![(1, 0.9), (2, 0.7), (3, 0.5)];
-let vec_hits = vec![(2, 0.95), (4, 0.8), (1, 0.6)];
-let merged = rrf_merge(&fts_hits, &vec_hits);
+let candidates = vec![
+    Candidate { source: CandidateSource::Fts, doc_id: "1".into(), chunk_id: None, score: 0.9, rank: 0 },
+    Candidate { source: CandidateSource::Fts, doc_id: "2".into(), chunk_id: None, score: 0.7, rank: 1 },
+    Candidate { source: CandidateSource::Vector, doc_id: "2".into(), chunk_id: None, score: 0.95, rank: 0 },
+    Candidate { source: CandidateSource::Vector, doc_id: "4".into(), chunk_id: None, score: 0.8, rank: 1 },
+];
+let merged = WeightedRrf::default().merge(&candidates);
 ```
 
 ### recency decay プリミティブ
@@ -221,7 +225,7 @@ let score = recency_decay(7.0, 30.0); // 7日経過、半減期30日
 
 ### Retrieval Pipeline（5-stage contract）
 
-`retrieval` モジュールは ADR 0004 が固定する 5 ステージ pipeline contract を提供する。`storage` のプリミティブ（`prepare_match_query` / `rrf_merge` / `recency_decay`）を組み合わせる際の標準配線で、Phase 3 (#67) で aggregation hook、Phase 4 (#68) で hybrid weight/recency、#76 で chunk-level retrieval が揃った。
+`retrieval` モジュールは ADR 0004 が固定する 5 ステージ pipeline contract を提供する。`storage` のプリミティブ（`prepare_match_query` / `recency_decay`）と組み合わせる際の標準配線で、Phase 3 (#67) で aggregation hook、Phase 4 (#68) で hybrid weight/recency、#76 で chunk-level retrieval が揃った。
 
 | Stage | 入力 → 出力                              | 提供型・関数                                                                                                                                                |
 | ----- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/decisions/0003-evaluation-methodology.md
+++ b/docs/decisions/0003-evaluation-methodology.md
@@ -10,7 +10,7 @@ Issue #53 splits search-quality improvement into Phase 1〜6, where Phase 1 buil
 
 Three contract gaps must be resolved before implementation:
 
-1. **`rurico` does not ship a hybrid search**. `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query` as **primitives only**. The actual hybrid pipeline (schema, vec0 SQL, FTS↔vec join, rerank wiring) lives in downstream crates: `recall/src/search.rs`, `recall/src/hybrid.rs`, `sae`, `yomu`. A baseline taken on a harness-internal pipeline is not a baseline of `rurico` itself unless the relationship between the two is named explicitly.
+1. **`rurico` does not ship a hybrid search**. `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query` as **primitives only**. The actual hybrid pipeline (schema, vec0 SQL, FTS↔vec join, rerank wiring) lives in downstream crates: `recall/src/search.rs`, `recall/src/hybrid.rs`, `sae`, `yomu`. A baseline taken on a harness-internal pipeline is not a baseline of `rurico` itself unless the relationship between the two is named explicitly. <!-- 2026-05-08: rrf_merge references in this ADR are superseded by issue #104; primitive is now `retrieval::WeightedRrf`. -->
 
 2. **Per-category breakdown on small per-category sample sizes is not informative**. Bootstrap CI on graded relevance `nDCG@10` with 5 queries per category sits around `±0.25〜0.30`, wider than realistic per-Phase improvements. A breakdown table that always overlaps the gate threshold cannot drive decisions.
 

--- a/docs/decisions/0003-evaluation-methodology.md
+++ b/docs/decisions/0003-evaluation-methodology.md
@@ -4,13 +4,15 @@
 - Date: 2026-04-25
 - Confidence: medium-high. Reference composition pattern is empirically established in `recall/src/hybrid.rs`; statistical significance via bootstrap CI on 140+ query fixtures is a well-known IR convention; the unknown is whether mlx inference f32 drift across machines / mlx-rs versions stays inside the regeneration tolerance already adopted by ADR 0002.
 
+> **Note (2026-05-08)**: `rrf_merge` references in this ADR are superseded by issue #104. The canonical RRF primitive is now `retrieval::WeightedRrf` (configurable via `HybridSearchConfig`, `WeightedRrf::default()` is bit-equal to the removed legacy fn).
+
 ## Context
 
 Issue #53 splits search-quality improvement into Phase 1〜6, where Phase 1 builds the evaluation harness used by all later phases to detect regressions and validate improvements. Issue #65 is the Phase 1 implementation issue.
 
 Three contract gaps must be resolved before implementation:
 
-1. **`rurico` does not ship a hybrid search**. `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query` as **primitives only**. The actual hybrid pipeline (schema, vec0 SQL, FTS↔vec join, rerank wiring) lives in downstream crates: `recall/src/search.rs`, `recall/src/hybrid.rs`, `sae`, `yomu`. A baseline taken on a harness-internal pipeline is not a baseline of `rurico` itself unless the relationship between the two is named explicitly. <!-- 2026-05-08: rrf_merge references in this ADR are superseded by issue #104; primitive is now `retrieval::WeightedRrf`. -->
+1. **`rurico` does not ship a hybrid search**. `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query` as **primitives only**. The actual hybrid pipeline (schema, vec0 SQL, FTS↔vec join, rerank wiring) lives in downstream crates: `recall/src/search.rs`, `recall/src/hybrid.rs`, `sae`, `yomu`. A baseline taken on a harness-internal pipeline is not a baseline of `rurico` itself unless the relationship between the two is named explicitly.
 
 2. **Per-category breakdown on small per-category sample sizes is not informative**. Bootstrap CI on graded relevance `nDCG@10` with 5 queries per category sits around `±0.25〜0.30`, wider than realistic per-Phase improvements. A breakdown table that always overlaps the gate threshold cannot drive decisions.
 

--- a/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -10,7 +10,7 @@ Issue #53 plans a six-phase retrieval-quality programme. Phase 1 (#65, ADR 0003)
 
 Three contract gaps must be resolved before Phase 3 can start:
 
-1. **`rurico` ships primitives, not a pipeline.** `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query`; `src/embed/embedder.rs` exposes the `Embed` trait; `src/reranker.rs` exposes the `Rerank` trait. Each downstream (`recall`, `sae`, `yomu`) re-composes them by hand, so a high-recall/rerank-aware "standard pipeline" cannot be reused. Issue #53 Idea 6 names this explicitly: *reranker should be a first-class pipeline*.
+1. **`rurico` ships primitives, not a pipeline.** `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query`; `src/embed/embedder.rs` exposes the `Embed` trait; `src/reranker.rs` exposes the `Rerank` trait. Each downstream (`recall`, `sae`, `yomu`) re-composes them by hand, so a high-recall/rerank-aware "standard pipeline" cannot be reused. Issue #53 Idea 6 names this explicitly: *reranker should be a first-class pipeline*. <!-- 2026-05-08: rrf_merge references in this ADR are superseded by issue #104; primitive is now `retrieval::WeightedRrf` (this ADR's canonical Stage-2 strategy). -->
 
 2. **Two parallel implementations of the same shape already exist.** Phase 1c committed `src/eval/pipeline.rs` (ADR 0003 Option C: a recall-shaped reference composition gated behind `eval-harness`). Phase 1's commitments were scoped to evaluation, but the file implements precisely the FTS+vec+RRF+rerank shape Phase 2 needs to standardise. Without a stated relationship between this file and the production module, Phase 3 will either duplicate or diverge.
 

--- a/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -4,13 +4,15 @@
 - Date: 2026-04-26 (proposed) · 2026-04-27 (accepted)
 - Confidence: medium at proposal. The 5-stage shape was empirically validated by `src/eval/pipeline.rs` (Phase 1c) and mirrored the production pipeline in `recall/src/search.rs`. The unknown was whether the Phase 3 aggregation step fit cleanly between merge and rerank for downstream crates whose hybrid wiring evolved independently (`sae`, `yomu`); resolved by Phase 3 (#67) + the chunk-level retrieval follow-up (#76), which landed the `Aggregator` trait at the contracted position with no shape change.
 
+> **Note (2026-05-08)**: `rrf_merge` references in this ADR are superseded by issue #104. The canonical RRF primitive is now `retrieval::WeightedRrf` — this ADR's own Stage-2 `MergeStrategy::WeightedRrf` (configurable via `HybridSearchConfig`, `WeightedRrf::default()` is bit-equal to the removed legacy fn).
+
 ## Context
 
 Issue #53 plans a six-phase retrieval-quality programme. Phase 1 (#65, ADR 0003) delivered the evaluation harness; Phases 3–6 will implement aggregation (#67), hybrid weights (#68), query normalization (#69), and prefix ensemble (#70). Issue #66 (this ADR) freezes the **interfaces** Phases 3–6 will plug into.
 
 Three contract gaps must be resolved before Phase 3 can start:
 
-1. **`rurico` ships primitives, not a pipeline.** `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query`; `src/embed/embedder.rs` exposes the `Embed` trait; `src/reranker.rs` exposes the `Rerank` trait. Each downstream (`recall`, `sae`, `yomu`) re-composes them by hand, so a high-recall/rerank-aware "standard pipeline" cannot be reused. Issue #53 Idea 6 names this explicitly: *reranker should be a first-class pipeline*. <!-- 2026-05-08: rrf_merge references in this ADR are superseded by issue #104; primitive is now `retrieval::WeightedRrf` (this ADR's canonical Stage-2 strategy). -->
+1. **`rurico` ships primitives, not a pipeline.** `src/storage/search.rs:150,191` exposes `rrf_merge` and `prepare_match_query`; `src/embed/embedder.rs` exposes the `Embed` trait; `src/reranker.rs` exposes the `Rerank` trait. Each downstream (`recall`, `sae`, `yomu`) re-composes them by hand, so a high-recall/rerank-aware "standard pipeline" cannot be reused. Issue #53 Idea 6 names this explicitly: *reranker should be a first-class pipeline*.
 
 2. **Two parallel implementations of the same shape already exist.** Phase 1c committed `src/eval/pipeline.rs` (ADR 0003 Option C: a recall-shaped reference composition gated behind `eval-harness`). Phase 1's commitments were scoped to evaluation, but the file implements precisely the FTS+vec+RRF+rerank shape Phase 2 needs to standardise. Without a stated relationship between this file and the production module, Phase 3 will either duplicate or diverge.
 

--- a/docs/decisions/0006-eval-harness-migration-to-amici.md
+++ b/docs/decisions/0006-eval-harness-migration-to-amici.md
@@ -4,6 +4,8 @@
 - Date: 2026-04-27
 - Confidence: high. The cyclic-dependency constraint that justified inlining the reference composition in ADR 0003 does not apply to `amici` (`amici/Cargo.toml:14` already pins `rurico`); the production wiring that the harness mirrors lives in `amici` today; embedder and reranker primitives remain in `rurico` and are called by `amici` unchanged, so the regenerated baseline is expected to match the existing `rurico/tests/fixtures/eval/baseline.json` bit-identically modulo the per-metric tolerance envelope already established in ADR 0003.
 
+> **Note (2026-05-08)**: `rrf_merge` listed in §3 ("Stay in `rurico`") is superseded by issue #104 — the primitive was deleted in favor of `retrieval::WeightedRrf` (the canonical Stage-2 strategy from ADR 0004).
+
 ## Context
 
 ADR 0003 placed an inline reference composition inside `rurico/src/eval/pipeline.rs` to evaluate `rurico` primitives in a `recall`-shape hybrid pipeline without forming a `rurico → recall` cyclic dependency. Since ADR 0003 was accepted, three signals shifted the calculus:
@@ -31,7 +33,7 @@ Migrate the search-quality evaluation harness from `rurico` to `amici`. Concrete
 2. **Drop the mirror**: the harness in `amici` calls `crate::storage::fts::clean_for_trigram` directly (after `amici#24` ships the `MAX_COMBOS` guard). The mirrored copy in `rurico/src/eval/pipeline.rs:383-415` is deleted along with the rest of `src/eval/`.
 
 3. **Stay in `rurico`**:
-   - `src/storage/` primitives (`MatchFtsQuery`, `prepare_match_query`, `normalize_for_fts`, `rrf_merge`) <!-- 2026-05-08: rrf_merge superseded by issue #104; primitive is now `retrieval::WeightedRrf`. -->
+   - `src/storage/` primitives (`MatchFtsQuery`, `prepare_match_query`, `normalize_for_fts`, `rrf_merge`)
    - `src/bin/mlx_smoke.rs` and `tests/mlx_smoke.rs` — primitive-level speed and numerical-equivalence harness (ADR 0002), not retrieval quality.
 
 4. **ADR continuity**:

--- a/docs/decisions/0006-eval-harness-migration-to-amici.md
+++ b/docs/decisions/0006-eval-harness-migration-to-amici.md
@@ -31,7 +31,7 @@ Migrate the search-quality evaluation harness from `rurico` to `amici`. Concrete
 2. **Drop the mirror**: the harness in `amici` calls `crate::storage::fts::clean_for_trigram` directly (after `amici#24` ships the `MAX_COMBOS` guard). The mirrored copy in `rurico/src/eval/pipeline.rs:383-415` is deleted along with the rest of `src/eval/`.
 
 3. **Stay in `rurico`**:
-   - `src/storage/` primitives (`MatchFtsQuery`, `prepare_match_query`, `normalize_for_fts`, `rrf_merge`)
+   - `src/storage/` primitives (`MatchFtsQuery`, `prepare_match_query`, `normalize_for_fts`, `rrf_merge`) <!-- 2026-05-08: rrf_merge superseded by issue #104; primitive is now `retrieval::WeightedRrf`. -->
    - `src/bin/mlx_smoke.rs` and `tests/mlx_smoke.rs` — primitive-level speed and numerical-equivalence harness (ADR 0002), not retrieval quality.
 
 4. **ADR continuity**:

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -208,8 +208,7 @@ pub struct RecencyConfig {
 /// Each candidate contributes `weight / (rrf_k + rank)` to its `doc_id`'s
 /// fused score, where `weight` comes from
 /// [`HybridSearchConfig::source_weights`]. With default config the formula
-/// reduces to `1 / (60 + rank)` — bit-equal to the pre-Phase-4 `rrf_merge`
-/// primitive.
+/// reduces to `1 / (60 + rank)`.
 #[derive(Debug, Default, Clone)]
 pub struct WeightedRrf {
     /// Active hybrid scoring configuration.
@@ -762,6 +761,31 @@ mod tests {
         assert!((output[0].score - d1_score).abs() < f64::EPSILON);
         assert_eq!(output[1].doc_id, "d2");
         assert!((output[1].score - d2_score).abs() < f64::EPSILON);
+    }
+
+    // T-104-001: weighted_rrf_default_breaks_ties_by_doc_id
+    //
+    // When two docs receive identical RRF scores under default config, merge
+    // must order them by doc_id ascending — same tie-break as the legacy
+    // rrf_merge primitive (sort ... then_with(|a, b| a.0.cmp(&b.0))).
+    #[test]
+    fn weighted_rrf_default_breaks_ties_by_doc_id() {
+        let strategy = WeightedRrf::default();
+        let candidates = vec![
+            candidate(CandidateSource::Fts, "d3", 0),
+            candidate(CandidateSource::Vector, "d1", 0),
+        ];
+        let output = strategy.merge(&candidates);
+        assert_eq!(output.len(), 2);
+        assert!(
+            (output[0].score - output[1].score).abs() < f64::EPSILON,
+            "scores must be tied"
+        );
+        assert_eq!(
+            output[0].doc_id, "d1",
+            "lower doc_id must come first on tie"
+        );
+        assert_eq!(output[1].doc_id, "d3");
     }
 
     // T-068-006: weighted_rrf_zero_weight_drops_source

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -765,9 +765,9 @@ mod tests {
 
     // T-104-001: weighted_rrf_default_breaks_ties_by_doc_id
     //
-    // When two docs receive identical RRF scores under default config, merge
-    // must order them by doc_id ascending — same tie-break as the legacy
-    // rrf_merge primitive (sort ... then_with(|a, b| a.0.cmp(&b.0))).
+    // When two docs receive identical RRF scores, merge must order them by
+    // doc_id ascending (lexicographic). Tie-break contract preserved on the
+    // canonical WeightedRrf path.
     #[test]
     fn weighted_rrf_default_breaks_ties_by_doc_id() {
         let strategy = WeightedRrf::default();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,7 @@ mod search;
 use std::sync::OnceLock;
 
 pub use query_normalize::{QueryNormalizationConfig, normalize_for_fts, pre_phase_5_disabled};
-pub use search::{MatchFtsQuery, SanitizeError, fts_quote, prepare_match_query, rrf_merge};
+pub use search::{MatchFtsQuery, SanitizeError, fts_quote, prepare_match_query};
 
 #[cfg(not(target_endian = "little"))]
 compile_error!("rurico requires a little-endian target for f32↔u8 embedding storage");

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -1,6 +1,3 @@
-use std::collections::HashMap;
-use std::hash::Hash;
-
 use rusqlite::Connection;
 
 use super::query_normalize::{QueryNormalizationConfig, normalize_for_fts};
@@ -131,28 +128,6 @@ pub(crate) fn sanitize_fts_query(query: &str) -> Result<SanitizedFtsQuery, Sanit
     } else {
         Ok(SanitizedFtsQuery(result))
     }
-}
-
-const RRF_K: f64 = 60.0;
-
-/// Reciprocal Rank Fusion merge — only rank position matters, score values are ignored.
-/// Returns merged results sorted by RRF score descending, ties broken by key ascending.
-pub fn rrf_merge<K: Clone + Eq + Hash + Ord>(
-    fts_hits: &[(K, f64)],
-    vec_hits: &[(K, f64)],
-) -> Vec<(K, f64)> {
-    let mut scores: HashMap<K, f64> = HashMap::new();
-
-    for (rank, (key, _)) in fts_hits.iter().enumerate() {
-        *scores.entry(key.clone()).or_default() += 1.0 / (RRF_K + rank as f64);
-    }
-    for (rank, (key, _)) in vec_hits.iter().enumerate() {
-        *scores.entry(key.clone()).or_default() += 1.0 / (RRF_K + rank as f64);
-    }
-
-    let mut results: Vec<(K, f64)> = scores.into_iter().collect();
-    results.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-    results
 }
 
 /// Wrap `s` in double quotes for FTS5 MATCH syntax, escaping internal `"` as `""`.
@@ -296,36 +271,6 @@ pub(crate) fn fts_expand_short_terms(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn rrf_merge_both_lists() {
-        let fts: Vec<(u32, f64)> = vec![(1, 1.0), (2, 0.5)];
-        let vec: Vec<(u32, f64)> = vec![(2, 1.0), (3, 0.5)];
-        let result = rrf_merge(&fts, &vec);
-        assert_eq!(result[0].0, 2);
-        assert!(result[0].1 > result[1].1);
-        assert!(result[1].1 >= result[2].1);
-    }
-
-    #[test]
-    fn rrf_merge_tied_scores_ordered_by_key() {
-        let fts: Vec<(u32, f64)> = vec![(3, 1.0)];
-        let vec: Vec<(u32, f64)> = vec![(1, 1.0)];
-        let result = rrf_merge(&fts, &vec);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].0, 1, "lower key should come first on tie");
-        assert_eq!(result[1].0, 3);
-        assert_eq!(result[0].1, result[1].1, "scores must be equal");
-    }
-
-    #[test]
-    fn rrf_merge_empty_fts() {
-        let fts: Vec<(String, f64)> = vec![];
-        let vec: Vec<(String, f64)> = vec![("a".into(), 1.0), ("b".into(), 0.5)];
-        let result = rrf_merge(&fts, &vec);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].0, "a");
-    }
 
     #[test]
     fn fts_quote_simple() {


### PR DESCRIPTION
## 概要

- `storage::rrf_merge` を完全削除、`retrieval::WeightedRrf` に集約 (DES-016 解決)
- `WeightedRrf::default()` は旧 `rrf_merge` と bit-equal: 新規 test `weighted_rrf_default_breaks_ties_by_doc_id` で score-tied 入力への doc_id 昇順 tie-break 保証も検証
- README / ADR 0003 / 0004 / 0006 の dangling reference 解消、CHANGELOG Breaking 追記

## テスト計画

- [x] `cargo test --workspace` 全 pass (319 lib + integration)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 新規 test `weighted_rrf_default_breaks_ties_by_doc_id` 単独 pass

## クロスリポ追従

- recall thkt/recall#79 / sae thkt/sae#106: 次回 rev bump 時に追従 (defer、rev pin で先行ビルド維持)
- amici: 次回 rev bump 時に同期で comment 修正 (defer、機能変更ゼロのため独立 issue 不要、`eval/pipeline.rs:557` の test 説明 comment 1 行のみ)

Closes #104.
