### PR TITLE
test(coverage): 空入力 / 境界条件の体系的なテスト追加

### DIFF
--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -768,6 +768,40 @@ mod tests {
         assert!(artifacts.delete_files().is_err());
     }
 
+    // T-105-011: delete_files_continues_after_first_failure
+    //
+    // The continues-on-error contract documented on `delete_files`: when the
+    // first file is already absent, the remaining files MUST still be
+    // attempted (and removed) so a re-download from a fresh cache cannot be
+    // blocked by a half-cleaned directory.
+    #[test]
+    fn delete_files_continues_after_first_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        write_fake_safetensors(&dir.path().join("model.safetensors"), &[FAKE_BACKBONE_KEY]);
+        write_valid_config(dir.path());
+        write_valid_tokenizer(dir.path());
+        let paths = ModelPaths::from_dir(dir.path());
+        let artifacts = verify_as_embed(paths).unwrap();
+
+        // Pre-remove model so delete_files hits an error on the first file
+        // and must continue with the remaining two.
+        fs::remove_file(dir.path().join("model.safetensors")).unwrap();
+
+        let err = artifacts
+            .delete_files()
+            .expect_err("first removal must error");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+
+        assert!(
+            !dir.path().join("config.json").exists(),
+            "config.json must be removed despite earlier failure"
+        );
+        assert!(
+            !dir.path().join("tokenizer.json").exists(),
+            "tokenizer.json must be removed despite earlier failure"
+        );
+    }
+
     // ── CandidateArtifacts<K> verify dispatch ───────────────────────────────
 
     use crate::artifacts::CandidateArtifacts;

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -106,9 +106,18 @@ pub(crate) const fn max_content(prefix_len: usize) -> usize {
 /// chunks distinguishable through Stage 1 candidates and Stage 2 fusion. The
 /// vector length is always equal to `chunks.len()`; constructors enforce this
 /// invariant.
+///
+/// `ChunkedEmbedding::new` is non-fallible: producers (`Embed::embed_document`
+/// and friends) are expected to deliver at least one chunk, but the
+/// constructor does not enforce non-emptiness. Callers are responsible for
+/// avoiding `new(vec![])` — the resulting value is structurally valid (with
+/// `chunks` and `chunk_ids` both empty) and will not panic, but downstream
+/// code that assumes "always non-empty" must justify that assumption itself.
 #[derive(Debug, Clone)]
 pub struct ChunkedEmbedding {
-    /// One embedding vector per chunk. Always non-empty.
+    /// One embedding vector per chunk. Producers always return at least one
+    /// chunk; [`ChunkedEmbedding::new`] does not enforce this — see the type
+    /// doc for caller responsibility.
     pub chunks: Vec<Vec<f32>>,
     /// Stable identifier per chunk. Same length as `chunks`. Auto-generated
     /// as `"c0"`, `"c1"`, … by [`ChunkedEmbedding::new`]; persistence formats
@@ -122,6 +131,11 @@ impl ChunkedEmbedding {
     /// `"c1"`, …). The default label scheme keeps producers (the MLX
     /// embedder, mocks, persistence loaders) consistent without forcing each
     /// caller to mint its own scheme.
+    ///
+    /// Non-fallible by design: passing an empty `chunks` vector returns a
+    /// value with both `chunks` and `chunk_ids` empty rather than panicking
+    /// or returning a `Result`. See the type-level doc for the
+    /// caller-responsibility contract.
     pub fn new(chunks: Vec<Vec<f32>>) -> Self {
         let chunk_ids = (0..chunks.len()).map(|i| format!("c{i}")).collect();
         Self { chunks, chunk_ids }

--- a/src/embed/fixtures.rs
+++ b/src/embed/fixtures.rs
@@ -392,4 +392,28 @@ mod tests {
         let err = load(&mut Cursor::new(&bytes)).expect_err("dim * 4 overflow must error");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
+
+    // T-105-004: save_load_round_trip_with_zero_docs_yields_empty_vec
+    #[test]
+    fn save_load_round_trip_with_zero_docs_yields_empty_vec() {
+        let docs: Vec<ChunkedEmbedding> = Vec::new();
+        let mut buf = Vec::new();
+        save(&mut buf, &docs).unwrap();
+        let loaded = load(&mut Cursor::new(&buf)).unwrap();
+        assert!(
+            loaded.is_empty(),
+            "0-doc fixture must round-trip back to an empty Vec"
+        );
+    }
+
+    // T-105-005: compare_returns_zero_diff_when_both_sides_empty
+    #[test]
+    fn compare_returns_zero_diff_when_both_sides_empty() {
+        let diff = compare(&[], &[]).unwrap();
+        assert_eq!(diff.max_abs_diff, 0.0);
+        assert_eq!(
+            diff.cosine_min, 1.0,
+            "empty fixtures must report cosine=1.0 (vacuous match), not 0.0"
+        );
+    }
 }

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -443,3 +443,22 @@ fn embed_text_propagates_error() {
 fn from_probe_error_maps_correctly() {
     assert_from_probe_error_maps_correctly();
 }
+
+// T-105-010: chunked_embedding_new_with_empty_input_yields_empty_fields
+//
+// Pin the Option β invariant from issue #105: `new(vec![])` is non-fallible
+// and returns a structurally valid value with both `chunks` and `chunk_ids`
+// empty. Producers that require non-emptiness must enforce that themselves —
+// the constructor is intentionally a thin builder, not a guard.
+#[test]
+fn chunked_embedding_new_with_empty_input_yields_empty_fields() {
+    let ce = ChunkedEmbedding::new(Vec::new());
+    assert!(
+        ce.chunks.is_empty(),
+        "new(vec![]) must keep chunks empty without panicking"
+    );
+    assert!(
+        ce.chunk_ids.is_empty(),
+        "chunk_ids length must mirror chunks (zero on empty input)"
+    );
+}

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -258,4 +258,50 @@ mod tests {
             );
         });
     }
+
+    // T-105-002a: probe_env_to_paths_returns_none_when_embed_model_var_absent
+    #[test]
+    fn probe_env_to_paths_returns_none_when_embed_model_var_absent() {
+        let result: Option<Result<CandidateArtifacts<EmbedKind>, SetupReason>> =
+            probe_env_to_paths::<EmbedKind>(None, Some("c".into()), Some("t".into()));
+        assert!(
+            result.is_none(),
+            "model var absent must short-circuit to None for embed kind"
+        );
+    }
+
+    // T-105-002b: probe_env_to_paths_returns_none_when_reranker_model_var_absent
+    #[test]
+    fn probe_env_to_paths_returns_none_when_reranker_model_var_absent() {
+        let result: Option<Result<CandidateArtifacts<RerankerKind>, SetupReason>> =
+            probe_env_to_paths::<RerankerKind>(None, Some("c".into()), Some("t".into()));
+        assert!(
+            result.is_none(),
+            "model var absent must short-circuit to None for reranker kind"
+        );
+    }
+
+    // T-105-002c: probe_env_to_paths_returns_err_when_embed_config_missing
+    #[test]
+    fn probe_env_to_paths_returns_err_when_embed_config_missing() {
+        let result: Option<Result<CandidateArtifacts<EmbedKind>, SetupReason>> =
+            probe_env_to_paths::<EmbedKind>(Some("m".into()), None, Some("t".into()));
+        let inner = result.expect("model var present must produce Some, not None");
+        assert!(
+            matches!(inner, Err(SetupReason::EnvIncomplete)),
+            "missing config var must surface as EnvIncomplete"
+        );
+    }
+
+    // T-105-002d: probe_env_to_paths_returns_err_when_reranker_tokenizer_missing
+    #[test]
+    fn probe_env_to_paths_returns_err_when_reranker_tokenizer_missing() {
+        let result: Option<Result<CandidateArtifacts<RerankerKind>, SetupReason>> =
+            probe_env_to_paths::<RerankerKind>(Some("m".into()), Some("c".into()), None);
+        let inner = result.expect("model var present must produce Some, not None");
+        assert!(
+            matches!(inner, Err(SetupReason::EnvIncomplete)),
+            "missing tokenizer var must surface as EnvIncomplete"
+        );
+    }
 }

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -73,6 +73,16 @@ fn sort_results_ties_break_by_original_index() {
     assert_eq!(indices, vec![1, 2, 0, 3]);
 }
 
+// T-105-012: sort_results_with_empty_scores_returns_empty_vec
+#[test]
+fn sort_results_with_empty_scores_returns_empty_vec() {
+    let results = sort_results(&[]);
+    assert!(
+        results.is_empty(),
+        "empty scores slice must yield zero RankedResult entries"
+    );
+}
+
 // T-013: cache_lookup_returns_some_when_all_files_present
 #[test]
 fn cache_lookup_returns_some_when_all_files_present() {

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1048,6 +1048,79 @@ mod tests {
         assert_eq!(d2_bucket.len(), 1);
     }
 
+    // T-105-008a: weighted_rrf_merge_returns_empty_for_empty_candidates
+    #[test]
+    fn weighted_rrf_merge_returns_empty_for_empty_candidates() {
+        let strategy = WeightedRrf::default();
+        let output = strategy.merge(&[]);
+        assert!(
+            output.is_empty(),
+            "empty candidate slice must yield empty merged hits"
+        );
+    }
+
+    // T-105-008b: weighted_rrf_merge_with_recency_returns_empty_for_empty_candidates
+    #[test]
+    fn weighted_rrf_merge_with_recency_returns_empty_for_empty_candidates() {
+        let strategy = WeightedRrf::default();
+        let recency = RecencyConfig {
+            weight: 1.0,
+            half_life_days: 30.0,
+        };
+        let output = strategy.merge_with_recency(&[], &recency, |_| Some(0.0));
+        assert!(
+            output.is_empty(),
+            "empty candidates must short-circuit even with non-zero recency weight"
+        );
+    }
+
+    // T-105-009: group_by_parent_returns_empty_map_for_empty_hits
+    #[test]
+    fn group_by_parent_returns_empty_map_for_empty_hits() {
+        let buckets = group_by_parent(&[]);
+        assert!(
+            buckets.is_empty(),
+            "empty hits slice must yield zero parent buckets"
+        );
+    }
+
+    // T-105-017a: merged_hit_deserializes_when_chunk_id_field_omitted
+    //
+    // Backward-compat with pre-Issue #76 baseline.json files that omit the
+    // chunk_id field. `serde(default)` keeps Option<String> defaulting to None
+    // — pin the behaviour so a future serde attribute change does not silently
+    // break legacy fixture round-trips.
+    #[test]
+    fn merged_hit_deserializes_when_chunk_id_field_omitted() {
+        let json = r#"{"doc_id":"d1","score":0.5,"source_scores":{"fts":0.5}}"#;
+        let hit: MergedHit = serde_json::from_str(json).expect("legacy JSON must parse");
+        assert_eq!(hit.doc_id, "d1");
+        assert!((hit.score - 0.5).abs() < f64::EPSILON);
+        assert_eq!(
+            hit.chunk_id, None,
+            "omitted chunk_id must default to None, not error"
+        );
+        assert_eq!(
+            hit.source_scores.get(&CandidateSource::Fts),
+            Some(&0.5),
+            "source_scores must round-trip the populated entry"
+        );
+    }
+
+    // T-105-017b: hybrid_search_config_serde_round_trips_default
+    //
+    // Default config must serialize then deserialize to a value equal to the
+    // starting Default — guards against an accidental serde attribute change
+    // that would shift downstream JSON shape.
+    #[test]
+    fn hybrid_search_config_serde_round_trips_default() {
+        let config = HybridSearchConfig::default();
+        let json = serde_json::to_string(&config).expect("Default must serialize");
+        let parsed: HybridSearchConfig =
+            serde_json::from_str(&json).expect("serialized form must deserialize");
+        assert_eq!(parsed, config, "round-trip must preserve Default config");
+    }
+
     // T-068-008: weighted_rrf_fts_heavy_weight_reorders
     //
     // Validates that non-uniform weights actually shift ranking — a doc with

--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -638,4 +638,22 @@ mod tests {
             Err(SanitizeError::NoSearchableTerms)
         );
     }
+
+    // T-105-013: drop_dangling_operators_drops_operator_at_position_zero
+    //
+    // Boundary: a valid FTS5 operator at index 0 cannot have a left neighbour,
+    // so `has_left` is false and the operator must be dropped even when a
+    // non-operator follows. Pins the `i > 0` short-circuit against a future
+    // off-by-one rewrite that would let leading `AND` / `OR` slip through and
+    // form an invalid FTS5 expression.
+    #[test]
+    fn drop_dangling_operators_drops_operator_at_position_zero() {
+        let tokens: Vec<String> = vec!["AND".into(), "foo".into(), "bar".into()];
+        let result = drop_dangling_operators(&tokens);
+        assert_eq!(
+            result,
+            vec!["foo", "bar"],
+            "operator at index 0 has no left neighbour → must drop"
+        );
+    }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -116,4 +116,15 @@ mod tests {
         assert_eq!(fragments.len(), 1);
         assert_eq!(fragments[0], text);
     }
+
+    // T-105-007: split_text_returns_single_empty_fragment_for_empty_input
+    #[test]
+    fn split_text_returns_single_empty_fragment_for_empty_input() {
+        let fragments = split_text("", 100);
+        assert_eq!(
+            fragments,
+            vec![""],
+            "empty input must yield a single empty fragment, not Vec::new()"
+        );
+    }
 }


### PR DESCRIPTION
## What & Why

正常系の代表入力中心だった既存 unit test に対し、empty input / boundary condition の系統的カバレッジを 11 箇所に追加。`ChunkedEmbedding::new` non-empty や `delete_files` continues-on-error といった documented invariant を test で固定し、library contract の regression net を強化する。

## Changes

- **probe_env_to_paths** (`src/model_lifecycle.rs`): None / Err 分岐を embed/reranker 両 kind で対称テスト
- **fixtures** (`src/embed/fixtures.rs`): save/load の 0-doc round-trip と `compare(&[], &[])` 両方 empty
- **split_text** (`src/text.rs`): 空文字列入力で `vec![""]` 返却を pin
- **WeightedRrf** (`src/retrieval.rs`): merge / merge_with_recency に空 candidates
- **group_by_parent** (`src/retrieval.rs`): 空 hits バケット化
- **ChunkedEmbedding** (`src/embed.rs`, `src/embed/tests.rs`): `new(vec![])` invariant を test で具現化、docstring に Option β（caller responsibility）を明記
- **delete_files** (`src/artifacts.rs`): 最初のファイル削除失敗後も残りを試行する continues-on-error 契約を明示テスト
- **sort_results** (`src/reranker/tests.rs`): 空スコア配列
- **drop_dangling_operators** (`src/storage/search.rs`): position 0 の operator は left neighbor 不在で drop される境界

## Scope

- **Not included**: COV-006 (`rrf_merge(&[], &[])`) — Issue #104 で `storage::rrf_merge` 削除予定のため、recall 側 helper の test として recall#79 で扱う

## Design Decisions

- **`ChunkedEmbedding::new` は Option β 採用**: 非 fallible のまま caller responsibility を docstring で明示。call site が常に non-empty を保証する位置にあり、`Result` 化はインライン展開を阻害し既存コードの簡潔性を損なうため。test で `new(vec![])` の振る舞いを pin することで invariant の文書化と等価な保護を実現

## How to Test

1. `cargo test --workspace` → 335 件 pass を確認
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` → warnings なしを確認
3. 追加された 16 件の T-105-NNN test を `cargo test 105` で絞って確認

## Related

- Closes #105
