### PR TITLE
sandbox 検出を純粋判定関数に分離 (#106 TST-002)

### DIFF
--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -27,7 +27,14 @@ const SEATBELT_VALUE: &str = "seatbelt";
 
 /// Returns `true` when running under Codex Desktop's seatbelt sandbox.
 pub fn codex_seatbelt_sandbox_active() -> bool {
-    env::var(ENV_VAR).is_ok_and(|v| v == SEATBELT_VALUE)
+    is_seatbelt_env(env::var(ENV_VAR).ok().as_deref())
+}
+
+/// Pure decision function for sandbox detection — separated from `env::var`
+/// so unit tests can pin behavior without mutating process environment
+/// (Rust 2024 made `env::set_var` unsafe).
+pub(crate) fn is_seatbelt_env(value: Option<&str>) -> bool {
+    value == Some(SEATBELT_VALUE)
 }
 
 /// Exit the current smoke binary with [`SEATBELT_SKIP_EXIT`] when the Codex
@@ -55,4 +62,27 @@ pub fn require_unsandboxed_mlx_runtime() {
         !codex_seatbelt_sandbox_active(),
         "MLX runtime tests must run outside Codex seatbelt sandbox"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-106-001: is_seatbelt_env
+    #[test]
+    fn is_seatbelt_env_returns_true_when_value_matches() {
+        assert!(is_seatbelt_env(Some(SEATBELT_VALUE)));
+    }
+
+    // T-106-002: is_seatbelt_env
+    #[test]
+    fn is_seatbelt_env_returns_false_when_absent() {
+        assert!(!is_seatbelt_env(None));
+    }
+
+    // T-106-003: is_seatbelt_env
+    #[test]
+    fn is_seatbelt_env_returns_false_for_other_value() {
+        assert!(!is_seatbelt_env(Some("1")));
+    }
 }


### PR DESCRIPTION
## What & Why

`codex_seatbelt_sandbox_active` は `env::var` を直読みしており、Rust 2024 で `env::set_var` が unsafe 化したことで「seatbelt 値 / 他の値 / 無し」の 3 ケースを env mutation 無しで test できなかった。純粋判定関数 `is_seatbelt_env(Option<&str>) -> bool` を抽出し、`codex_seatbelt_sandbox_active` を thin wrapper 化することで env mutation 無しの unit test を可能にする。

## Changes

- `src/sandbox.rs`: `pub(crate) fn is_seatbelt_env(value: Option<&str>) -> bool` を追加
- `src/sandbox.rs`: `codex_seatbelt_sandbox_active` を `is_seatbelt_env(env::var(ENV_VAR).ok().as_deref())` の thin wrapper 化（public API 不変）
- 3 unit test 追加（T-106-001/002/003）: match / None / other value

## Scope

- **Not included**: TST-003 (`download_artifacts` の `Api::new` 注入) は別 PR。TST-009 (`Instant::now` × 8 callsite) は実 test 駆動が顕在化してから着手として defer

## Design Decisions

- **`is_seatbelt_env` は `pub(crate)`**: public API は `codex_seatbelt_sandbox_active` のみ。seam は内部に閉じ、外部 API を増やさない
- **thin wrapper パターン**: 既存 caller (`exit_if_seatbelt`, `require_unsandboxed_mlx_runtime`) のシグネチャ変更を避けるため、上層の wrapper を保持

## How to Test

1. `cargo test --workspace --lib is_seatbelt_env` → 3 件 pass
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` → warnings なし
3. 既存 caller (`exit_if_seatbelt`, `require_unsandboxed_mlx_runtime`) の挙動が変わらないこと（thin wrapper のみのため）

## Related

- Refs #106
