### PR TITLE
download_artifacts に download closure 注入 seam 追加 (#106 TST-003)

### DIFF
--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -497,11 +497,11 @@ mod tests {
 
     // ── download_artifacts_with seam tests ──────────────────────────────────
 
+    use crate::embed::ModelId;
+
     // T-106-004: download_artifacts_with
     #[test]
     fn download_artifacts_with_routes_success_to_caller() {
-        use crate::embed::ModelId;
-
         let dir = tempfile::tempdir().unwrap();
         let fake = ModelPaths::from_dir(dir.path());
         let expected = fake.model.clone();
@@ -517,8 +517,6 @@ mod tests {
     // T-106-005: download_artifacts_with
     #[test]
     fn download_artifacts_with_routes_error_to_caller() {
-        use crate::embed::ModelId;
-
         let err = download_artifacts_with(
             ModelId::default(),
             DOWNLOAD_TIMEOUT,
@@ -534,8 +532,6 @@ mod tests {
     // T-106-006: download_artifacts_with
     #[test]
     fn download_artifacts_with_returns_timeout_when_worker_exceeds_budget() {
-        use crate::embed::ModelId;
-
         let err = download_artifacts_with(
             ModelId::default(),
             Duration::from_millis(50),

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -174,44 +174,56 @@ fn make_repo(repo_id: &str, revision: &str) -> hf_hub::Repo {
 /// On the next invocation, [`artifacts_if_cached`] finds no valid pointer and
 /// returns `None`, so the download retries cleanly — no manual cache cleanup needed.
 pub fn download_artifacts<Id: ModelArtifact>(model: Id) -> Result<ModelPaths, ModelIoError> {
-    // Extract `&'static str` identifiers up-front so the worker closure does
-    // not need to carry the generic `Id` across the thread boundary (which
-    // would force a `Send + 'static` bound on every caller).
+    download_artifacts_with(model, DOWNLOAD_TIMEOUT, |repo_id, revision| {
+        let api =
+            Api::new().map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
+        let repo = api.repo(make_repo(repo_id, revision));
+        let get = |name: &str| {
+            repo.get(name)
+                .map_err(|e| ModelIoError::Download(format!("{name} download failed: {e}")))
+        };
+        Ok(ModelPaths {
+            model: get("model.safetensors")?,
+            config: get("config.json")?,
+            tokenizer: get("tokenizer.json")?,
+        })
+    })
+}
+
+/// Generic seam — worker closure decides how to materialize `ModelPaths`.
+///
+/// The orchestration (thread spawn / mpsc / `recv_timeout`) and the actual
+/// download are split here so unit tests can pin worker success / failure /
+/// timeout paths without driving real HF Hub I/O. Production calls go
+/// through [`download_artifacts`].
+pub(crate) fn download_artifacts_with<Id, F>(
+    model: Id,
+    timeout: Duration,
+    download: F,
+) -> Result<ModelPaths, ModelIoError>
+where
+    Id: ModelArtifact,
+    F: FnOnce(&str, &str) -> Result<ModelPaths, ModelIoError> + Send + 'static,
+{
     let repo_id: &'static str = model.repo_id();
     let revision: &'static str = model.revision();
 
     let (tx, rx) = mpsc::sync_channel(1);
     thread::spawn(move || {
-        let result = (|| -> Result<ModelPaths, ModelIoError> {
-            let api = Api::new()
-                .map_err(|e| ModelIoError::Download(format!("HF Hub init failed: {e}")))?;
-            let repo = api.repo(make_repo(repo_id, revision));
-
-            let get = |name: &str| {
-                repo.get(name)
-                    .map_err(|e| ModelIoError::Download(format!("{name} download failed: {e}")))
-            };
-
-            Ok(ModelPaths {
-                model: get("model.safetensors")?,
-                config: get("config.json")?,
-                tokenizer: get("tokenizer.json")?,
-            })
-        })();
-        let _ = tx.send(result);
+        let _ = tx.send(download(repo_id, revision));
     });
 
-    rx.recv_timeout(DOWNLOAD_TIMEOUT).map_err(|e| match e {
+    rx.recv_timeout(timeout).map_err(|e| match e {
         mpsc::RecvTimeoutError::Timeout => {
             tracing::error!(
                 repo_id,
                 revision,
-                timeout_secs = DOWNLOAD_TIMEOUT.as_secs(),
+                timeout_secs = timeout.as_secs(),
                 "download_artifacts: HF Hub download timed out"
             );
             ModelIoError::Download(format!(
                 "download exceeded {} second timeout (HF Hub may be unreachable or proxy stalled)",
-                DOWNLOAD_TIMEOUT.as_secs()
+                timeout.as_secs()
             ))
         }
         mpsc::RecvTimeoutError::Disconnected => {
@@ -481,5 +493,61 @@ mod tests {
 
         // Force at least one runtime assertion so the test body is not empty.
         assert_eq!(ModelId::default().repo_id(), "cl-nagoya/ruri-v3-310m");
+    }
+
+    // ── download_artifacts_with seam tests ──────────────────────────────────
+
+    // T-106-004: download_artifacts_with
+    #[test]
+    fn download_artifacts_with_routes_success_to_caller() {
+        use crate::embed::ModelId;
+
+        let dir = tempfile::tempdir().unwrap();
+        let fake = ModelPaths::from_dir(dir.path());
+        let expected = fake.model.clone();
+        let result = download_artifacts_with(
+            ModelId::default(),
+            DOWNLOAD_TIMEOUT,
+            move |_repo_id, _revision| Ok(fake),
+        )
+        .unwrap();
+        assert_eq!(result.model, expected);
+    }
+
+    // T-106-005: download_artifacts_with
+    #[test]
+    fn download_artifacts_with_routes_error_to_caller() {
+        use crate::embed::ModelId;
+
+        let err = download_artifacts_with(
+            ModelId::default(),
+            DOWNLOAD_TIMEOUT,
+            |_repo_id, _revision| Err(ModelIoError::Download("simulated".to_owned())),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ModelIoError::Download(ref s) if s == "simulated"),
+            "{err}"
+        );
+    }
+
+    // T-106-006: download_artifacts_with
+    #[test]
+    fn download_artifacts_with_returns_timeout_when_worker_exceeds_budget() {
+        use crate::embed::ModelId;
+
+        let err = download_artifacts_with(
+            ModelId::default(),
+            Duration::from_millis(50),
+            |_repo_id, _revision| {
+                thread::sleep(Duration::from_secs(2));
+                Err(ModelIoError::Download("unreachable".to_owned()))
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ModelIoError::Download(ref s) if s.contains("timeout")),
+            "expected timeout message, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## What & Why

`download_artifacts` は thread spawn / `Api::new()` / `repo.get()` × 3 / `recv_timeout` を 1 関数に詰めており、orchestration（spawn / timeout / mpsc）部分を独立して unit test できなかった。本 PR は worker closure を引数化した `download_artifacts_with(model, timeout, download)` を `pub(crate)` で追加し、production の `download_artifacts` を thin wrapper 化。これにより success / error / **timeout** の 3 path を mock-free で deterministic に test 可能になる。

## Changes

- `src/model_io.rs`: `pub(crate) fn download_artifacts_with<Id, F>(model, timeout, download)` を追加（`F: FnOnce(&str, &str) -> Result<ModelPaths, ModelIoError> + Send + 'static`）
- `src/model_io.rs`: `download_artifacts` を thin wrapper 化、`Api::new()` + `repo.get()` × 3 の本体を closure として `download_artifacts_with` に渡す（public API 不変）
- 3 unit test 追加（T-106-004/005/006）: success closure routing / error closure routing / **50ms timeout vs 2s sleep の deterministic timeout**
- `/polish` cleanup: `use crate::embed::ModelId;` を 3 test 関数から divider-scoped section header に lift（DRY）

## Scope

- **Not included**: TST-009 (`Instant::now` × 8 callsite) は実 test 駆動が顕在化してから着手として defer（Issue #106 の元方針通り）

## Design Decisions

### Option D (download closure) を選択

Issue 提案は `download_artifacts_with(api: &Api, model)` だったが、これは hf_hub::Api の mock が困難で「real Api を用意 → invalid repo で test」となり、実 network 試行 + CI flake のリスクがあった。

代替の **Option D** は `F: FnOnce(&str, &str) -> Result<ModelPaths, ModelIoError>` を受け取る形で、test 側が任意の closure（即 Ok / 即 Err / sleep + Ok）を渡せる。これで「production timeout 300s で CI で待てない → 現状 timeout path は untested」問題を解消、test 用 timeout を任意に短く設定して timeout path を deterministic に検証できるようになる。

### `timeout: Duration` も seam に含めた

Const `DOWNLOAD_TIMEOUT` のままだと test #3 が成立しない。caller が timeout を決める形にして、production は `download_artifacts` 内で `DOWNLOAD_TIMEOUT` を渡す。

### `Api::new()` を closure 内に保持

Issue 提案は `Api::new()` を spawn 外に push するスタイル。今回は closure 内に保持し、closure 全体を spawn する形。理由：closure 注入で `Api::new()` 失敗 path も含めて test 可能。spawn 外に出すと `&Api` を spawn に渡す必要が生じ、lifetime が複雑化。

## How to Test

1. `cargo test --workspace --lib download_artifacts_with` → 3 件 pass（timeout test 含む、~0.06s で完了）
2. `cargo clippy --workspace --all-targets --all-features -- -D warnings` → warnings なし
3. `cargo test --workspace --lib` → 341 件 pass（regression なし）

## Polish

`/polish` で並列レビュー（simplify / Codex / CodeRabbit / Gemini）を実施。Phase 1 全 reviewer 0 findings、Phase 2 cleanup で test 内の重複 import を 1 か所に集約。

## Related

- Refs #106
