### PR TITLE
fix(ci): advanced-issue-labeler.yml を redhat-plumbers v2 構文に (#161)

### DIFF
--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,5 +1,5 @@
 # Maps Issue Forms dropdown selections to labels.
-# See https://github.com/stefanbuck/advanced-issue-labeler for syntax.
+# See https://github.com/redhat-plumbers-in-action/advanced-issue-labeler for syntax.
 #
 # Per-repo extension: target repos can append additional `policy` entries
 # (e.g. for area:* labels) by editing this file directly. The shared base
@@ -9,12 +9,12 @@ policy:
       - bug.yml
       - feature.yml
     section:
-      - id: priority
-        block-list:
-          - high
-          - medium
-          - low
+      - id: [priority]
+        block-list: []
         label:
-          - priority:high
-          - priority:medium
-          - priority:low
+          - name: 'priority:high'
+            keys: ['high']
+          - name: 'priority:medium'
+            keys: ['medium']
+          - name: 'priority:low'
+            keys: ['low']


### PR DESCRIPTION
## 概要

PR #162 で `label-from-issue.yml` を `redhat-plumbers-in-action/advanced-issue-labeler@v2` に切り替えたが、policy file (`.github/advanced-issue-labeler.yml`) は古い stefanbuck v1 構文のまま残っていた。v2 は `name`/`keys` ペア構文を要求するため、PR #162 マージ後は label が貼られない潜在 bug があった。scout / guardrails で確定した golden master と整合させる。

## 変更内容

- `section.id` を scalar から array (`[priority]`) に
- `section.block-list` を value 列挙から空配列に (v2 では未使用)
- `label` を文字列配列から `name`/`keys` ペア配列に
- コメント内参照先を `stefanbuck/advanced-issue-labeler` → `redhat-plumbers-in-action/advanced-issue-labeler`

## マージ順序

**PR #162 → 本 PR の順でマージ推奨**。
本 PR を単独で先にマージしても regression は生まない (main の label 機能は元から ref 欠落で壊れている) が、PR #162 → 本 PR の順なら「壊れた → 直った」の単調進行になり、間の中間状態が無い。

## テスト計画

- [ ] PR #162 → 本 PR の順で main にマージ
- [ ] マージ後に test issue を起こして `priority:high` / `priority:medium` / `priority:low` が貼られることを確認

## 参考

- guardrails commit `9bd53aa` (本 fix の実装例)
- scout #69 (先行採用、commit `21651f0`)

Closes #161