### PR TITLE
fix(ci): rust-cache の cache-bin を false にして image roll 耐性を確保 (#164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
 
       - name: Check
         run: cargo check --workspace --features test-support,test-mlx
@@ -62,6 +64,7 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
+          cache-bin: false
           cache-targets: false
 
       - name: Install cargo-deny


### PR DESCRIPTION
## 概要

`Swatinem/rust-cache` の default `cache-bin: true` で `~/.cargo/bin/` の rustup shim を cache に含めていたため、macOS-15-arm64 runner image が **20260427 → 20260511** で fleet roll した際に cache poisoning が発生し、PR #163 の CI が `cargo check` を呼んだ瞬間 `rustup-init[EXE] [OPTIONS]` で fail した。

両 job (test / security) の `Cache Cargo` step に `cache-bin: false` を追加し、`~/.cargo/bin/` を cache 対象外にする。

## なぜこの fix で OK か

| 観点 | 現状 (`cache-bin: true`) | 修正後 (`cache-bin: false`) |
| --- | --- | --- |
| rustup shim の cache | 含まれる → image roll で poisoning | image の pre-install + `dtolnay/rust-toolchain` で毎回 install |
| compile artifact | cache される (target / registry) | cache される (target / registry) — 変わらず |
| `Install Rust` step の cost | unchanged 時は ~1 秒 | unchanged 時は ~1 秒 — 変わらず |
| image roll への耐性 | 無し (毎回 fleet roll で再発) | **有り (durable)** |

`prefix-key` を `v0 → v1` 等で bump する手も検討したが、次の image roll で再 poisoning するので根本治療にならない (調査時 advisor 指摘)。

## 証拠 chain (調査ログ)

| 条件 | 結果 |
| --- | --- |
| main `e83d1bc` (旧 image 20260427) + cache key `v0-rust-test-Darwin-arm64-9d946206-fd5b31e3` | ✅ SUCCESS |
| PR #163 (新 image 20260511) + 同 cache key (poisoned) | ❌ FAILURE |
| PR #163 + cache 完全削除 → cache miss → 新 image で新規 build | ✅ SUCCESS |

すべて同じ workflow file で実行、cache key も同一。違いは image version のみ。

## テスト計画

- [ ] 本 PR の CI が green (新規 cache が `cache-bin: false` で save される)
- [ ] マージ後の main で次の CI run が green
- [ ] 将来の image roll 時に `Install Rust` step がやり直されることで cache poisoning が再発しないことを観察

## 補足

guardrails / scout も `cache-bin: false` 設定はないが、両者 test job を ubuntu-latest で実行するため macOS image roll の影響を受けない。rurico は MLX feature の都合で test job を **macos-latest** で実行しており、この問題に該当する。3 リポ間で本ファイルが乖離するが、原因が rurico 固有のため許容する。

Closes #164