### PR TITLE
docs(audit): ADR 0001-0007 ドリフト scan レポート (#158)

### DIFF
--- a/docs/audit/2026-05-14-adr-drift.md
+++ b/docs/audit/2026-05-14-adr-drift.md
@@ -1,0 +1,152 @@
+# ADR Drift Scan: 2026-05-14
+
+Issue [#158](https://github.com/thkt/rurico/issues/158) — ADR 0001–0007 と現コードの整合性を `/audit-adr-drift` skill で機械的に verify した記録。実コード修正は本 scan の scope 外。
+
+## Summary
+
+| Metric            | Value |
+| ----------------- | ----- |
+| ADRs scanned      | 7     |
+| Drift findings    | 4     |
+| H priority        | 0     |
+| M priority        | 2     |
+| L priority        | 2     |
+| Unverifiable ADRs | 0     |
+
+すべての finding は **adr-update** (Note 追記レベル) もしくは **code-fix 1 行** で閉じる軽量 drift。public API 契約違反 (priority H) なし。
+
+## Methodology
+
+| Step | Action |
+| ---- | ------ |
+| 1    | `docs/decisions/` を ADR directory として固定 |
+| 2    | 各 ADR の Status を front-section から抽出 (Accepted / Superseded / Proposed) |
+| 3    | Decision section から code-identifier (function, type, module path) を抽出 |
+| 4    | `ugrep` / yomu で本 repo 内の参照を列挙、削除指示済 path の不在も確認 |
+| 5    | reviewer-rust / reviewer-design は skip (grep で挙証可能な existence/non-existence のみ) |
+| 6    | 各 finding に modification direction (`code-fix` / `adr-update` / `accept`) を付与 |
+| 7    | 各 finding に priority (`H` / `M` / `L`) を付与 |
+
+reviewer agent step を skip した根拠は本 scan の finding がすべて symbol レベルの existence / visibility に帰着しており、semantic gap (clippy / grep が掴めない契約違反) ではないため。Step 4 で挙証コストが reviewer 投入コストを十分に下回ると判断した。
+
+## Per-ADR Findings
+
+### ADR 0001: Adopt a Typed FTS Query Contract in `rurico`
+
+Status: Accepted
+
+| # | File:Line | Description | Direction | Priority |
+| - | --------- | ----------- | --------- | -------- |
+| 1 | `src/storage/search.rs:56,103,236` | `SanitizedFtsQuery`, `sanitize_fts_query`, `fts_expand_short_terms` は `pub(crate)`。ADR は「The storage API will move toward these types: `SanitizedFtsQuery`, `MatchFtsQuery`, `SanitizeError`」と書くが可視性は明示していない。downstream consumer は `prepare_match_query` (`pub fn`, `src/storage/search.rs:163`) と `MatchFtsQuery` (`pub`, line 66) 経由で完成済の `MATCH` 値を受け取る形に最適化されている。LANG.md `Visibility: Minimum required` と整合 | adr-update | L |
+
+`SanitizeError` の 4 variants (`EmptyInput` / `NoSearchableTerms` / `InvalidVocabTable(String)` / `VocabLookupFailed(String)`) は ADR 本文と完全一致 (`src/storage/search.rs:82-96`)。Migration Plan の downstream crate (`recall`, `sae`, `yomu`) 追従については本 repo の audit scope 外。
+
+### ADR 0002: GPU-side Pooling for the embed Pipeline
+
+Status: Accepted
+
+| # | File:Line | Description | Direction | Priority |
+| - | --------- | ----------- | --------- | -------- |
+| 1 | `src/embed/pooling.rs:26` ↔ `src/embed.rs:34` | `gpu_pool_and_normalize` は `pub fn` 宣言を保持しているが、`src/embed.rs:34` の re-export が `pub(crate) use` で外部到達を遮断している。ADR Sub-decision 2 は「Visibility is `pub` (not `pub(super)`) so the Phase 3a precursor probe binary can call it as a separate crate target」と理由付け。**Phase 3c で probe bin が削除** (`src/bin/gpu_pool_probe.rs` 不在) され、現状外部 caller は存在しない。LANG.md `Visibility: Minimum required` に従うと `pub(crate) fn` に narrow するのが正解 | code-fix もしくは adr-update | M |
+| 2 | `src/embed/mlx.rs:572`, `src/embed/pooling.rs:171/201/212` | ADR Consequences は FR-001a の defense-in-depth を「`validate_attention_mask` (upstream rejection) + probe bin (`is_finite` defensive guard)」の 2 拠点に分散と記述。probe bin 削除後、`is_finite` guard は production `split_pooled` (`src/embed/mlx.rs:572`) に移管され、defense-in-depth 自体は維持されている。ADR 本文の「probe bin が guard を持つ」記述だけが stale | adr-update | L |
+
+`forward_sub_batch` (`src/embed/mlx.rs:322`)、`embed_query_truncated` (`src/embed/mlx.rs:137`)、`release_inference_output` (`src/mlx_cache.rs:46`)、`validate_attention_mask` (`src/embed/mlx.rs:507`参照) は全て ADR Migration Plan 通りに残置・rewire 済。CPU pooling 関数 (`mean_pooling`, `l2_normalize`, `postprocess_embedding`, `unpack_batch_output`) は Phase 3c で完全削除 ✓。
+
+### ADR 0003: Search Quality Evaluation Methodology for `rurico`
+
+Status: Superseded by [`amici/docs/decisions/0002-evaluation-methodology.md`](https://github.com/thkt/amici/blob/main/docs/decisions/0002-evaluation-methodology.md) (ADR 0006 で migration 記録)
+
+**No drift findings.** Superseded ADR の本文最新化要否判断は **不要**。`Superseded by` link が下流の正本を指しており、本文は historical record として整合。Note (2026-05-08) で `rrf_merge` → `retrieval::WeightedRrf` の差分も明示済。
+
+注: 未コミット変更で本 ADR に `Scope: [rust, evaluation]` 1 行が追加されている (`docs/decisions/0003-evaluation-methodology.md`)。これは本 audit と一緒に commit 予定 (#158 follow-up)。
+
+### ADR 0004: Retrieval and Rerank Pipeline Contract for `rurico`
+
+Status: Accepted
+
+| # | File:Line | Description | Direction | Priority |
+| - | --------- | ----------- | --------- | -------- |
+| 1 | `src/retrieval.rs:1-9` (module doc) | ADR Decision の Stage 4 (`Rerank`) / Stage 5 (`Final`) は型 `RerankedHit { doc_id, score, source_scores, reranker_score, original_rank }` と `FinalHit` を契約として定義。本 repo に `RerankedHit` / `FinalHit` / `apply_reranker` シンボルは存在しない。module-level doc は「Plug-in points frozen by ADR 0004: Stage 3 aggregation [`Aggregator`] trait」とだけ謳い、Stage 2 (`MergeStrategy`/`WeightedRrf`) + Stage 3 (`Aggregator` trait + 4 impl) primitives のみ rurico 所有を表明している。ADR 0006 の `eval/pipeline.rs` → `amici` 移行で Stage 1/4/5 実装は downstream に流れたが、ADR 0004 本文には closure ノートがない | adr-update | M |
+
+ADR 0004 Migration Plan 内 Phase 3 implementation note には「Deferred from this ADR's wording: full `eval/pipeline.rs` → `src/retrieval.rs` rename」とあり、その後 ADR 0006 で `eval/pipeline.rs` 自体が amici へ移った。chain は途中段階で記録停止 — ADR 0003 が `rrf_merge` 用に書いた Note と同種の clarifier が必要。
+
+Stage 1 / 2 / 3 関連 symbol は全て確認 ✓:
+- `CandidateSource = { Fts, Vector }` closed-enum (`src/retrieval.rs:38`) ✓
+- `Candidate { source, doc_id, chunk_id, score, rank }` (`src/retrieval.rs:59`) ✓
+- `MergedHit { doc_id, chunk_id, score, source_scores }` (`src/retrieval.rs:88`) ✓
+- `MergeStrategy` trait + `WeightedRrf` + `HybridSearchConfig` + `RecencyConfig` + `merge_with_recency` (`src/retrieval.rs:149-260`) ✓
+- `Aggregator` trait + `IdentityAggregator` / `MaxChunkAggregator` / `DedupeAggregator` / `TopKAverageAggregator` (`src/retrieval.rs:338-`) ✓
+- `group_by_parent` (`src/retrieval.rs:135`) ✓
+- `ChunkedEmbedding.chunk_ids: Vec<String>` (`src/embed.rs:126`) ✓
+
+`prepare_match_query` / `Embed` / `Rerank` / `RankedResult` の primitive はいずれも不変で ADR の backward-compat 表通り ✓。
+
+### ADR 0005: Phase 6 Prefix-Ensemble Experiment — Not Adopted
+
+Status: Accepted
+
+**No drift findings.**
+
+- `embed_query_variants`: 不在 ✓ (実験コード revert 済)
+- `CandidateSource::PrefixEnsemble*` variants: 不在 ✓
+- `CandidateSource` enum は `{ Fts, Vector }` 2 variants 維持 (`src/retrieval.rs:38-43`) ✓
+- `QUERY_PREFIX = "検索クエリ: "` / `SEMANTIC_PREFIX = ""` / `TOPIC_PREFIX = "トピック: "` 全て `src/embed.rs:75-81` に存在 ✓
+- Phase 6 fixture files (`tests/fixtures/eval/phase6/*.json`): ADR 0006 migration で eval fixture ごと amici へ移動 ✓
+
+### ADR 0006: Migrate Search-Quality Evaluation Harness from `rurico` to `amici`
+
+Status: Accepted
+
+**No drift findings.** Migration Plan items 1-4 (`amici#24` → `amici#27` → `rurico#86` → `sae#77`) のうち rurico 側 deliverable (`rurico#86`) は完了:
+
+- `src/eval/` ディレクトリ削除 ✓
+- `src/bin/eval_harness.rs` 削除 ✓
+- `tests/eval_smoke.rs` 削除 ✓
+- `tests/fixtures/eval/` 削除 ✓
+- `eval-harness` feature 削除 (`Cargo.toml` 現存 features: `test-mlx`, `test-support`, `smoke` のみ) ✓
+- `justfile` `=== 検索評価ハーネス ===` recipe 群削除 (`justfile` 自体が repo に存在せず) ✓
+- `rrf_merge` legacy 関数削除 (`retrieval::WeightedRrf` が canonical RRF primitive) ✓
+- ADR 0003 Status 更新 `Superseded by amici/docs/decisions/0002-evaluation-methodology.md` ✓
+- `amici` dependency は `Cargo.toml` に不在 (依存方向 `amici → rurico` を維持し cyclic dep 回避) ✓
+
+注: `tests/fixtures/phase2_baseline/` は ADR 0002 の NFR-001 fixture で別軸、本 migration の scope 外。
+
+### ADR 0007: Library Logging Boundary
+
+Status: Accepted
+
+**No drift findings.** `log → tracing` 移行完了 + ADR が internal recovery として名指しした全サイトに `tracing::warn!` 配置済:
+
+- `log::warn!` / `log::error!` / `log::info!` / `log::debug!` / `log::trace!` 使用ゼロ ✓
+- `use log::` import ゼロ ✓
+- `embed.rs::truncate_for_query` → `src/embed.rs:174` ✓
+- `embed/mlx.rs::shrink_chunk_to_fit` → `src/embed/mlx.rs:471` ✓
+- `embed/mlx.rs::split_pooled` → `src/embed/mlx.rs:559,573` ✓
+- `mlx_cache.rs::clear_inference_cache` → `src/mlx_cache.rs:68,73,77` ✓
+- `modernbert/model.rs::forward` → `src/modernbert/model.rs:326` ✓
+- `model_probe.rs::wait_with_timeout` / `collect_pipe` → `src/model_probe.rs:472,500,508,562` ✓
+- `reranker/mlx.rs::truncate_pair` → `src/reranker/mlx.rs:220` ✓
+- `reranker/mlx.rs::score_batch` → `src/reranker/mlx.rs:115,128` ✓
+
+caller-boundary 側 (`embed/mlx.rs:178,352`、`EmbedInitError::backend`、`artifacts.rs` 系、`model_probe.rs::ProbeError` 返却部) は ADR 通り `rurico` 側 warn を出さない posture を維持。
+
+Field discipline (`tracing::warn!(error = %e, "<context>")` パターン) も `src/model_probe.rs:472,500` 等で実例として残存 ✓。
+
+## External ADR Dependencies
+
+| # | File:Line | External ADR ref | Recommended action |
+| - | --------- | ---------------- | ------------------ |
+| — | —         | (検出なし)       | —                  |
+
+`ADR-NNNN` / `adr-nnnn` パターンを `src/` / `tests/` / `Cargo.toml` / `README.md` / `crates/` 全体に対して scan した結果、外部 ADR (e.g. `dotclaude` meta ADR) への ref は不検出。
+
+ADR 0003 / 0006 が `amici/docs/decisions/0002-evaluation-methodology.md` を参照しているが、これは `Superseded by` link として ADR 内で明示済で、本 audit の「External ADR dependency」(コードから外部 ADR への参照) には該当しない。
+
+## Follow-up Issue Candidates
+
+H-priority drift なし。M-priority 2 件、L-priority 2 件 はいずれも軽量で follow-up issue 起票候補:
+
+- [ ] **ADR 0002 M**: probe bin 削除後の `gpu_pool_and_normalize` 可視性整理。`pub fn` → `pub(crate) fn` に narrow する **code-fix** か、ADR Sub-decision 2 に Note を追記する **adr-update** のいずれか
+- [ ] **ADR 0004 M**: Stage 4 (`RerankedHit`) / Stage 5 (`FinalHit`) / `apply_reranker` 契約は ADR 0006 で `amici` 側に移った旨を **adr-update Note** で記録 (ADR 0003 の `rrf_merge` Note 同様の clarifier)
+- [ ] **ADR 0002 L**: Consequences の「probe bin が `is_finite` guard を持つ」記述を「probe bin 削除後、guard は production `split_pooled` に移管」へ更新する **adr-update Note**
+- [ ] **ADR 0001 L**: `SanitizedFtsQuery` / `sanitize_fts_query` / `fts_expand_short_terms` の `pub(crate)` 可視性を ADR Decision の Note として記録 (downstream は `MatchFtsQuery` + `prepare_match_query` 経由で完成済値を取得する形)

--- a/docs/decisions/0003-evaluation-methodology.md
+++ b/docs/decisions/0003-evaluation-methodology.md
@@ -2,6 +2,7 @@
 
 - Status: Superseded by [`amici/docs/decisions/0002-evaluation-methodology.md`](https://github.com/thkt/amici/blob/main/docs/decisions/0002-evaluation-methodology.md) (migration recorded in [ADR 0006](./0006-eval-harness-migration-to-amici.md))
 - Date: 2026-04-25
+- Scope: [rust, evaluation]
 - Confidence: medium-high. Reference composition pattern is empirically established in `recall/src/hybrid.rs`; statistical significance via bootstrap CI on 140+ query fixtures is a well-known IR convention; the unknown is whether mlx inference f32 drift across machines / mlx-rs versions stays inside the regeneration tolerance already adopted by ADR 0002.
 
 > **Note (2026-05-08)**: `rrf_merge` references in this ADR are superseded by issue #104. The canonical RRF primitive is now `retrieval::WeightedRrf` (configurable via `HybridSearchConfig`, `WeightedRrf::default()` is bit-equal to the removed legacy fn).


### PR DESCRIPTION
## 概要

- `/audit-adr-drift` skill で ADR 0001-0007 の Decision section と現コードの整合性を verify、`docs/audit/2026-05-14-adr-drift.md` に記録
- あわせて ADR 0003 に `Scope: [rust, evaluation]` 行を追記 (header standardization)
- Findings 4 件 / H=0 / M=2 / L=2。public API 契約違反なし、Note 追加か `pub fn → pub(crate) fn` 1 行で閉じる軽量 drift

## 検出 drift 一覧

| ADR  | # | 内容 | Direction | Priority |
| ---- | - | ---- | --------- | -------- |
| 0001 | 1 | `SanitizedFtsQuery`/`sanitize_fts_query`/`fts_expand_short_terms` が `pub(crate)`。downstream は `MatchFtsQuery`+`prepare_match_query` 経由で完成済値を取得 | adr-update | L |
| 0002 | 1 | `gpu_pool_and_normalize` `pub fn` rationale stale (probe bin 削除済)。`pub(crate) fn` に narrow するか Note 追記 | code-fix or adr-update | M |
| 0002 | 2 | Consequences の FR-001a defense-in-depth 拠点記述が stale (`is_finite` guard は production `split_pooled` に移管済) | adr-update | L |
| 0004 | 1 | Stage 4 (`RerankedHit`) / Stage 5 (`FinalHit`) / `apply_reranker` 契約は ADR 0006 で amici に移行、closure ノートなし | adr-update | M |

ADR 0003 (Superseded) / 0005 / 0006 / 0007 は drift なし。

## 動作確認

- [x] 削除指示済 path (`src/eval/`、`src/bin/eval_harness.rs`、`src/bin/gpu_pool_probe.rs`、CPU pooling 関数群、`rrf_merge`) の不在を確認
- [x] ADR 内 named symbol の存在 (`MatchFtsQuery`、`gpu_pool_and_normalize`、`CandidateSource`、`Aggregator` 系、`WeightedRrf`、tracing recovery sites) を grep で挙証
- [x] External ADR ref pattern (`ADR-NNNN`/`adr-nnnn`) を `src/`/`tests/`/`Cargo.toml`/`README.md`/`crates/` 全体で scan
- [x] LANG.md `Visibility: Minimum required` との整合確認

Closes #158