### PR TITLE
refactor(embed): gpu_pool_and_normalize を pub(crate) に narrow (#158 followup)

### DIFF
--- a/docs/decisions/0002-gpu-side-pooling-embed.md
+++ b/docs/decisions/0002-gpu-side-pooling-embed.md
@@ -4,6 +4,10 @@
 - Date: 2026-04-24
 - Confidence: medium. The mlx-rs 0.25.3 Array API surface for reduction + broadcasting divide is unconfirmed, and the empirical precision margin over NFR-001 is unmeasured pre-prototype.
 
+> **Note (2026-05-14, post-Phase-3c)**: Sub-decision 2 originally justified `pub fn gpu_pool_and_normalize` on the need for the Phase 3a probe binary (`src/bin/gpu_pool_probe.rs`) to call it from a separate crate target. Phase 3c removed the probe binary; no external caller remains. The function is narrowed to `pub(crate) fn` to match LANG.md `Visibility: Minimum required`. The `[`pub use pooling::gpu_pool_and_normalize`](src/embed.rs) re-export was already `pub(crate) use` from Phase 3b — only the definition-site visibility lagged.
+
+> **Note (2026-05-14, FR-001a defense-in-depth update)**: Consequences originally described FR-001a's defense-in-depth as distributed across `validate_attention_mask` (upstream rejection) **plus the probe bin's `is_finite` guard**. With the probe bin removed in Phase 3c, the `is_finite` guard moved into production `split_pooled` (`src/embed/mlx.rs:572`), keeping the defense-in-depth posture intact. The pairing is now `validate_attention_mask` + `split_pooled::is_finite`.
+
 ## Context
 
 Phase 2 (length-bucket batching, PR #55-#61) reduced W3 `padding_ratio` from 2.316 to 1.165 and brought W2 and W3 into the primary SLA + padding thresholds. W1 (long-document mix, all three chunks at `seq_len ≈ 8K` resolving to bucket 3) stayed at `padding_ratio = 1.474` and batch/sequential `ratio = 1.254`. Bucket batching is a mechanical no-op for single-bucket workloads, so closing W1 needs a different lever.

--- a/src/embed/pooling.rs
+++ b/src/embed/pooling.rs
@@ -23,7 +23,7 @@ use mlx_rs::{Array, Dtype, error::Exception, ops::maximum};
 // drop-before-clear at compile time. `clippy` can't see that cross-function
 // intent, so suppress the lint here.
 #[allow(clippy::needless_pass_by_value)]
-pub fn gpu_pool_and_normalize(hidden: Array, mask: &Array) -> Result<Array, Exception> {
+pub(crate) fn gpu_pool_and_normalize(hidden: Array, mask: &Array) -> Result<Array, Exception> {
     let shape = mask.shape();
     let batch = shape[0];
     let seq = shape[1];


### PR DESCRIPTION
## 概要

- `gpu_pool_and_normalize` の定義側可視性を `pub fn` → `pub(crate) fn` に narrow
- ADR 0002 に Note 2 件追記し、Sub-decision 2 と Consequences の stale 記述を後追い記録
- #158 audit drift findings の M-priority #2 + L-priority #3 を closure

## 背景

ADR 0002 Sub-decision 2 は `pub fn` を選んだ唯一の rationale として「Phase 3a probe binary (`src/bin/gpu_pool_probe.rs`) が separate crate target から呼ぶ必要」を挙げていた。Phase 3c で probe binary が削除済、`src/embed.rs:34` の re-export も既に `pub(crate) use` で外部到達を遮断していたが、定義側の `pub fn` 宣言だけが取り残されていた lag を解消する。

LANG.md `Visibility: Minimum required` (`pub(super)` > `pub(crate)` > `pub`) と整合させる方向。

## 検証

- [x] `cargo check --workspace` 通過
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通過
- [x] crate 内 caller (`src/embed/mlx.rs:519`, `src/embed/pooling.rs` test mod) は `pub(crate)` で全てアクセス可能
- [x] crate 外 caller ゼロ確認 (`ugrep -rn 'gpu_pool_and_normalize' tests/ crates/` で 0 件)
- [x] pre-commit hook (`cargo fmt --check` + `cargo clippy`) 通過
- 補足: `cargo test --test visibility` (trybuild) はローカル Metal Toolchain 不在で skip、CI runner で評価

## ADR 0002 への追記

| Note | 内容 |
| ---- | ---- |
| `(2026-05-14, post-Phase-3c)` | Sub-decision 2 で `pub` とした rationale が probe 削除で消滅した経緯、`pub(crate)` への narrow 記録 |
| `(2026-05-14, FR-001a defense-in-depth update)` | Consequences の「probe bin の `is_finite` guard」拠点記述を「production `split_pooled::is_finite`」へ訂正 (実態は守られていたが本文だけが stale だった) |

immutable な ADR 本文を書き換えず Note 追記で living document として扱う方針 (ADR 0003 の `rrf_merge` Note と同じ pattern)。

Refs #158