### PR TITLE
docs(threat-model): SEC-002 wire format commitment を enumerate (#159 followup)

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -82,6 +82,42 @@ dynamic library lookups in the child.
   compared to the parent's full env. High-risk injection vectors not
   required by MLX (notably `DYLD_INSERT_LIBRARIES`) are excluded.
 
+## Wire format commitments
+
+The probe pathway exposes a small surface that downstream tooling (incident
+triage, log aggregation, monitoring) is allowed to grep. These are pinned
+contracts — changes are visible to consumers and need a deprecation cycle.
+
+### SEC-002: Probe setup-rejection stderr message format
+
+When the probe child rejects a path / env-vars during the setup phase, it
+writes `"probe setup rejected: <label>"` to stderr and exits with the
+matching `PROBE_EXIT_*` code. `<label>` is sourced from
+`SetupReason::label()` (`src/model_probe.rs:100-108`) and is one of:
+
+| Label                       | Exit code                          |
+| --------------------------- | ---------------------------------- |
+| `env incomplete`            | `PROBE_EXIT_ENV_INCOMPLETE` (3)    |
+| `path canonicalize failed`  | `PROBE_EXIT_CANONICALIZE_FAILED` (4) |
+| `path outside cache`        | `PROBE_EXIT_PATH_OUTSIDE_CACHE` (5)  |
+| `cache root invalid`        | `PROBE_EXIT_CACHE_ROOT_INVALID` (6)  |
+
+**Pinned by:** `setup_reason_label_is_stable_per_variant` (T-115-D,
+`src/model_probe/tests.rs:597`) — label drift breaks the test.
+
+**Why a commitment, not an accepted risk:** the stderr text is the only
+mechanism for an external observer to distinguish the four setup-phase
+rejection causes (the exit code triple SEC-003 already accepts is the
+oracle for "rejected vs. ok"; this anchor lets it be triaged further).
+A future maintainer who renames a label must update both the label table
+above and any downstream log-grep tooling — the rename is a breaking
+change to the wire.
+
+> **Note (2026-05-14, audit clarification)**: the
+> `docs/audit/2026-05-14-undocumented-decisions.md` report referred to
+> "SEC-001 / SEC-002 enumeration" but `SEC-001` is not a real identifier —
+> SEC-002 is the only orphaned anchor. This section closes the orphan.
+
 ## Reporting Vulnerabilities
 
 For potentially sensitive issues, contact the maintainers privately rather


### PR DESCRIPTION
## 概要

- `docs/THREAT_MODEL.md` に新 section `Wire format commitments` を追加し、SEC-002 を enumerate
- audit report (#159) の「SEC-001 / SEC-002」記述が実態と乖離していた点を訂正 (SEC-001 はソースなき identifier、SEC-002 単独の orphan が真相)

## 背景

#159 audit で「コード内に SEC-002 参照があるが THREAT_MODEL.md に記載なし」という orphaned identifier bug を検出していた。`b7e170c feat(model_probe): add typed SetupReason enum` で `SetupReason::label()` の forensic log wire format anchor として SEC-002 が pinned された経緯あり、コード 3 箇所が参照:

| 箇所                                  | 役割                                                |
| ------------------------------------- | --------------------------------------------------- |
| `src/model_probe.rs:99`               | `label()` rustdoc に forensic log anchor として明記 |
| `src/model_probe.rs:258`              | `compute_probe_exit` の wire format comment        |
| `src/model_probe/tests.rs:595` (T-115-D) | label 4 値 stability test (drift 検知)             |

実装は完成・test も pin 済だが、threat model 文書側だけ取り残されていた状態。

## 採用方針 (3 択から決定)

- ✅ **THREAT_MODEL.md に追加** (採用) — downstream incident triage / log grep が依存する wire format commitment として正式に位置付ける
- ⛔ コード側 SEC-002 参照削除 — wire format commitment が暗黙化、後退
- ⛔ SEC- prefix を `WIRE-` 等に rename — 3 箇所修正コスト + 既存 git history 検索性悪化

## 追加内容

新 section `Wire format commitments` は `Out-of-scope / Accepted Risks` の後・`Reporting Vulnerabilities` の前に挿入。SEC-002 entry には:

- Format: `"probe setup rejected: <label>"`
- 4 個の label と対応する `PROBE_EXIT_*` exit code の表
- Pinned by: T-115-D test reference
- Why a commitment, not an accepted risk: 拒絶理由を distinguish する唯一の mechanism (exit code 単独だと oracle として SEC-003 で扱っているが label までは区別不能)

## SEC-001 訂正

audit report (`docs/audit/2026-05-14-undocumented-decisions.md`) で「SEC-001 / SEC-002 enumeration 欠落」と複数形で書いていたが、git history 全 scan + repo grep で SEC-001 を参照する箇所は皆無であることを確認。私の audit report が推測ベースで複数形にしてしまった誤記述。本 PR の Note で disclosure し audit report 本文は historical snapshot として保持。

## 動作確認

- [x] `ugrep -rn 'SEC-001\|SEC-002' src/ tests/ docs/` で参照箇所網羅
- [x] `git log -S 'SEC-001'` で SEC-001 が過去にもソース由来でなかった点を確認
- [x] T-115-D test が label 4 値を pin している点を確認
- [x] section 追加位置: 既存 SEC-003/004 の下流、Reporting Vulnerabilities の上流に挟む
- 補足: docs 変更のみ、behavior change なし

Refs #159