### PR TITLE
docs(adr): 0008-0010 起票 — sqlite-vec ordering / BUCKET_BOUNDS / MASK_FILL (#159 followup)

### DIFF
--- a/docs/decisions/0008-adopt-process-level-sqlite-vec-auto-extension.md
+++ b/docs/decisions/0008-adopt-process-level-sqlite-vec-auto-extension.md
@@ -1,0 +1,83 @@
+---
+status: "accepted"
+date: 2026-05-14
+decision-makers: thkt
+---
+
+# Adopt process-level sqlite-vec auto-extension registration
+
+## Context and Problem Statement
+
+rurico の storage 層は sqlite-vec の vec0 仮想テーブルを使うが、sqlite-vec は **process-level auto-extension** として登録する idiom を取る (`sqlite_auto_extension` がプロセス内の全 `Connection::open` に対して以後自動 load する)。`src/storage.rs::ensure_sqlite_vec` (`pub fn`) が registration を行い、未完了の状態で開かれた Connection からは vec0 にアクセスできない。downstream CLI (`yomu` / `sae` / `amici`) は `Connection::open` 前に必ず `ensure_sqlite_vec` を呼ぶ必要があるが、この ordering 契約はコード型システムでは強制できず文書化に頼る。
+
+(Override note: select-adr-template.sh は "ordering" keyword で `process-change` を返したが、本 ADR は実装契約パターンの記録なので `architecture-pattern` を選択した)
+
+## Decision Drivers
+
+* downstream が `Connection::open` 前に `ensure_sqlite_vec` を呼ばないと vec0 仮想テーブルが silent fail (`no such module: vec0`)
+* sqlite-vec docs だけ読んでも auto-extension idiom には気づきにくい
+* per-connection で `load_extension` する代替案は libsqlite の FFI 拡張が必要、移植性低下
+* per-connection registration への切替は `pub fn ensure_sqlite_vec` の public API 互換性破壊変更
+
+## Considered Options
+
+* Adopt process-level auto-extension via `pub fn ensure_sqlite_vec` (status quo to be pinned)
+* Switch to per-connection `Connection::load_extension`
+* Hide registration behind a `StorageConnect` wrapper that enforces ordering at the type level
+
+## Decision Outcome
+
+Chosen option: **"Adopt process-level auto-extension via `pub fn ensure_sqlite_vec`"**, because sqlite-vec の primary idiom と整合し、追加 FFI surface を要求せず、downstream の Connection 管理に介入しないため。ordering 契約は ADR + rustdoc + README で明示し型システムでの強制は意図的に放棄する。
+
+### Consequences
+
+* Good, because sqlite-vec の primary idiom と整合、追加の FFI 拡張不要
+* Good, because downstream の Connection 管理 (pool / async etc.) に介入しない
+* Bad, because `Connection::open` 前に `ensure_sqlite_vec` を呼ぶ ordering 契約が型システムで強制されない
+* Bad, because per-connection registration への切替は public API の破壊変更となる (移行コスト)
+
+### Confirmation
+
+- `src/storage.rs::ensure_sqlite_vec` の rustdoc に「`Connection::open` 前に一度だけ呼ぶ」を明記
+- `README.md` ストレージ節 (L142-L145) で downstream へ同じ規約を伝達
+- registration 失敗時は `src/storage.rs:29` で `tracing::error!(rc, "sqlite-vec auto-extension registration failed")` を emit、downstream は `rurico=error` directive で検知可
+
+## Pros and Cons of the Options
+
+### Adopt process-level auto-extension via `pub fn ensure_sqlite_vec`
+
+`sqlite_auto_extension` がプロセス内の全 Connection に対して以後自動 load する。
+
+* Good, because sqlite-vec の primary idiom と整合
+* Good, because 追加 FFI 拡張不要 (rusqlite の `bundled` feature だけで足りる)
+* Good, because downstream の Connection 管理に介入しない
+* Bad, because ordering 契約は文書化と慣習でしか守れない
+
+### Switch to per-connection `Connection::load_extension`
+
+各 `Connection::open` 後に明示的に load。
+
+* Good, because per-connection 状態が明示的、テストの並列分離しやすい
+* Bad, because rusqlite で `load_extension` を呼ぶには `load_extension` feature が必須、追加 FFI surface
+* Bad, because 既存 downstream API が壊れる (breaking change)
+* Bad, because downstream が `Connection::open` を抽象化している場合に hook 困難
+
+### Hide registration behind a `StorageConnect` wrapper
+
+`StorageConnect::new() -> Self` 内で auto-extension 登録 + Connection 開設をまとめる。
+
+* Good, because ordering を型で強制
+* Bad, because downstream が独自の Connection pool / management を持つ場合に介入できない
+* Bad, because 1 ラッパーで全 storage ops を覆う必要、API surface 増
+
+## More Information
+
+### Implementation Guidelines
+
+- `ensure_sqlite_vec` は process 立ち上げ早期に呼ぶ (`main()` 冒頭が無難)
+- 並行 thread から `Connection::open` する場合、`ensure_sqlite_vec` が完了するまで barrier (`OnceLock` / `LazyLock` 等) で待つ
+- テストでは `serial_test::serial` で auto-extension registration の競合を避ける
+
+### Monitoring
+
+`ensure_sqlite_vec` 失敗時の `tracing::error!` (rc 値付き) で検知。downstream は `EnvFilter` に `rurico=error` を含めること。

--- a/docs/decisions/0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md
+++ b/docs/decisions/0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md
@@ -1,0 +1,80 @@
+---
+status: "accepted"
+date: 2026-05-14
+decision-makers: thkt
+---
+
+# Adopt BUCKET_BOUNDS as cross-module forward-pass invariant
+
+## Context and Problem Statement
+
+`src/model_io.rs::BUCKET_BOUNDS = [128, 512, 2048, MAX_SEQ_LEN]` は ModernBert forward の token length を 4 段階の bucket に丸める cross-module invariant。embed (`src/embed/mlx.rs::forward_sub_batch` / `embed_query_truncated`) と reranker (`src/reranker/mlx.rs::forward_sub_batch`) の全 caller が `assign_bucket` で round up し、`model.forward(_, _, _, bucket_len)` に渡す。同時に `src/modernbert/model.rs::ModernBert::local_mask_cache` はこの 4 値で keyed されており、cache size は **常に 4 entries** に bounded される。違反すると mask cache が膨らみ、MLX compile cache が呼び出しごとに新 kernel を JIT してメモリ暴発する。invariant は (a) `assign_bucket` panic、(b) `local_mask_cache` doc コメント、(c) `compute_sub_batch_size` test に分散しており、ADR で集約された記述はなかった。
+
+## Decision Drivers
+
+* 違反すると MLX compile cache に kernel が無限に蓄積し、production OOM の遠因になる
+* 4 つの magic number (`128 / 512 / 2048 / 8192`) の由来 (= モデル `max_position_embeddings`) を ADR なしで読み解くのは困難
+* `assign_bucket` panic は `len > MAX_SEQ_LEN` を防ぐが、「caller が round up を忘れて中間値で `forward()` する」regression は型・lint で守れない
+* bucket 値を 5 個に増やす / 値を変える設計変更は cross-module で影響、ADR がないと安全に検討できない
+
+## Considered Options
+
+* Adopt `BUCKET_BOUNDS = [128, 512, 2048, MAX_SEQ_LEN]` as a frozen cross-module invariant (status quo to be pinned)
+* Allow dynamic bucket sizing per call site (no fixed table)
+* Encode buckets as a type-level enum so non-bucket values are unrepresentable in `model.forward`
+
+## Decision Outcome
+
+Chosen option: **"Adopt `BUCKET_BOUNDS` as a frozen cross-module invariant"**, because 4 値の選定 (geometric-ish coverage with `MAX_SEQ_LEN` cap) は実測トレードオフの結果であり、cross-module で 3 caller (embed × 2 path + reranker × 1) と `local_mask_cache` 整合性に縛られているため。bucket 値の変更は ADR supersede 経由で行う。
+
+### Consequences
+
+* Good, because `local_mask_cache` が常に 4 entries に bounded され MLX compile cache も 4 kernel に収まる
+* Good, because 4 値の trade-off (バケット数 × 内 padding ratio) が文書化される
+* Bad, because runtime で bucket 数を可変にする最適化 (例: workload に応じて 5 段階) は ADR 改訂が必要
+* Bad, because invariant は型システムで強制できず、新規 caller が `assign_bucket` を経由せず生 `seq_len` を渡す regression は code review に委ねる
+
+### Confirmation
+
+- `src/model_io.rs:41-54` の `BUCKET_BOUNDS` const + `assign_bucket` doc が source of truth
+- `compute_sub_batch_size_matches_formula_per_bucket` (`src/model_io.rs:444-462`) test が `TOKEN_BUDGET / bucket_len` formula を pin
+- `src/modernbert/model.rs::ModernBert::local_mask_cache` doc が `BUCKET_BOUNDS` への intra-doc link で integrity を表明
+- 新規 forward caller を追加する PR では `BUCKET_BOUNDS` への round-up が code review checklist になる
+
+## Pros and Cons of the Options
+
+### Adopt `BUCKET_BOUNDS = [128, 512, 2048, MAX_SEQ_LEN]` as frozen invariant
+
+3 caller (`forward_sub_batch` embed / `embed_query_truncated` / `forward_sub_batch` reranker) が `assign_bucket` で round up、`local_mask_cache` も同じ 4 値で keyed。
+
+* Good, because compile cache + mask cache 両方が 4 entries に bounded
+* Good, because 4 値の trade-off が ADR で説明可能
+* Bad, because workload-adaptive bucket は不可
+
+### Allow dynamic bucket sizing per call site
+
+caller ごとに自分の最適 bucket 数を決める。
+
+* Good, because workload-specific 最適化が可能
+* Bad, because `local_mask_cache` が unbounded growth、MLX compile cache も同様
+* Bad, because bucket cache hit rate が caller 間で予測不能
+
+### Type-level bucket enum
+
+`enum Bucket { B128, B512, B2048, B8192 }` を作り `model.forward(_: Bucket)` に渡す。
+
+* Good, because invariant が型で強制される
+* Bad, because mlx-rs `Array::from_slice` の shape 引数 (`i32`) との橋渡しが冗長
+* Bad, because `BUCKET_BOUNDS` 値を変更する度に enum variant も同期する二重管理
+
+## More Information
+
+### Implementation Guidelines
+
+- 新規 `model.forward` caller は必ず `assign_bucket(seq_len)` → `BUCKET_BOUNDS[bucket_idx]` で round up してから渡す
+- `BUCKET_BOUNDS` の値を変更する場合は本 ADR を supersede し、4 値変更による (a) padding ratio 影響、(b) compile cache memory 影響、(c) `local_mask_cache` size を benchmark で測定して新 ADR の Consequences に記録する
+- `local_mask_cache` の cap を 4 以外に変える設計変更は本 ADR の Decision を破るため supersede 必須
+
+### Monitoring
+
+`forward_sub_batch` の `BatchMetrics::padding_ratio` が長期的に 1.5 以上に張り付く場合、現在の 4 値が workload と合っていない signal。`docs/benchmarks/phase{2,3}_result.md` の方法論で再計測し、本 ADR を supersede する。

--- a/docs/decisions/0010-adopt-maskfill-constant-to-avoid-metal-kernel-nan.md
+++ b/docs/decisions/0010-adopt-maskfill-constant-to-avoid-metal-kernel-nan.md
@@ -1,0 +1,87 @@
+---
+status: "accepted"
+date: 2026-05-14
+decision-makers: thkt
+---
+
+# Adopt MASK_FILL constant to avoid Metal kernel NaN
+
+## Context and Problem Statement
+
+ModernBert backbone (`src/modernbert/model.rs::prepare_4d_attention_mask`) は attention mask を `[batch, 1, 1, seq_len]` の f32 tensor に展開し、masked position に `MASK_FILL = -1e9` を埋め込む。一般的な PyTorch / Transformers 実装は `f32::NEG_INFINITY` を使うが、Apple Silicon の MLX Metal kernel は `seq_len ≲ 9` token 付近で softmax の中間計算が `0.0 * (-inf) = NaN` を引き起こし、forward 出力に NaN が混入する。これは下流の embedding L2 normalize で `0/0` を作り、検索品質を黙って壊す。`-1e9` は softmax で十分に exp underflow して masked rate ≈ 0、かつ `0.0 * (-1e9) = -0.0` で finite を保つ。この選定理由は `src/modernbert/model.rs:382-384` の inline comment にしかなく、新規メンテナが PyTorch 由来の慣習で `f32::NEG_INFINITY` に「直そう」とすると short-sequence NaN regression を再発させる。
+
+## Decision Drivers
+
+* Apple Silicon Metal kernel の `0.0 * (-inf) = NaN` ハザードは hardware-specific で `cargo test` だけでは事前に検知できない (smoke 環境必須)
+* math defaults は `-inf` 方向 (PyTorch / FlashAttention) なので "戻そう" 修正が起きやすい
+* NaN が混入すると `EmbedError::NonFiniteOutput` で fail-fast するが、その手前で L2 normalize の `0/0` を作って検索ベクトル全体が NaN になる被害が大きい
+
+## Considered Options
+
+* Adopt `MASK_FILL = -1e9` (status quo to be pinned)
+* Switch to `f32::NEG_INFINITY` (PyTorch / Transformers convention)
+* Adopt mixed-precision masking (`f32::MIN / 2` ≈ `-1.7e38` or `-1e30`)
+
+## Decision Outcome
+
+Chosen option: **"Adopt `MASK_FILL = -1e9`"**, because Apple Silicon Metal kernel が short-sequence で `0.0 * (-inf) = NaN` を生む実測ハザードを `-inf` は trip し、`-1e9` は softmax masking として十分でかつ `0.0 * (-1e9) = -0.0` (finite) を保つため。precision (softmax の数値誤差は約 `exp(-1e9) ≈ 0` で十分に underflow) と numerical stability (NaN 回避) の real trade-off の解。
+
+### Consequences
+
+* Good, because `seq_len ≲ 9` を含む全 forward path で NaN free
+* Good, because L2 normalize の `0/0` 経路が閉じ、`EmbedError::NonFiniteOutput` に頼らずに健全な出力を確保
+* Bad, because PyTorch 系の慣習と異なるため、新規メンテナは「`-inf` に戻そう」と思いがち
+* Bad, because `local attention mask` は別の経路 (`get_local_attention_mask`) で `f32::NEG_INFINITY` を使う (直接書き込みで mask 乗算経由しないため安全)、2 通りの fill 値が共存することによる読みづらさ
+
+### Confirmation
+
+- `src/modernbert/model.rs:384` の `const MASK_FILL` + inline comment が rationale 起点
+- 本 ADR が rationale の正本となり、`MASK_FILL` 関連 PR は本 ADR を参照する
+- smoke 経由の `mlx_smoke verify-fixture` (ADR 0002) で短 seq の NaN regression を捕捉できる
+- `local attention mask` 側で `-inf` を使い続ける理由 (mask 乗算経由しないため `0 * -inf` ハザード対象外) は `get_local_attention_mask` 関数の comment 内 (`src/modernbert/model.rs:466-467`) に明記
+
+## Pros and Cons of the Options
+
+### Adopt `MASK_FILL = -1e9`
+
+mask 乗算経由する global attention mask 専用の有限値。
+
+* Good, because Apple Silicon Metal kernel の NaN ハザードを回避
+* Good, because softmax masking として十分な大きさ (`exp(-1e9)` は f32 underflow)
+* Bad, because PyTorch 系の慣習 (`-inf`) と異なる
+
+### Switch to `f32::NEG_INFINITY`
+
+PyTorch / Transformers / FlashAttention の慣習。
+
+* Good, because mainstream の参照実装と一致、新規参加者が読みやすい
+* Bad, because Apple Silicon Metal kernel が短 sequence で `0.0 * (-inf) = NaN` を生成する実測ハザード
+* Bad, because NaN は L2 normalize 経由でベクトル全体を破壊、silent corruption
+
+### Adopt mixed-precision masking (`f32::MIN / 2`)
+
+`-1.7e38` 等の有限・大値を使う。
+
+* Good, because softmax masking としてさらに underflow、`-inf` 互換の数学的振る舞い
+* Good, because finite (NaN ハザード回避)
+* Bad, because mask + 残差 (`add` op) で f32 overflow を生む可能性、Metal kernel での実測未確認
+* Bad, because `-1e9` で実証済の rationale を上書きする実利なし
+
+## More Information
+
+### Implementation Guidelines
+
+- 新規 attention mask 経路を加える際、mask を **乗算** で reduce するなら `MASK_FILL = -1e9` を踏襲する
+- mask を **直接書き込み** で reduce する経路 (`get_local_attention_mask` のように `0 * fill` を経由しない) は `f32::NEG_INFINITY` 可
+- `MASK_FILL` を変える場合は本 ADR を supersede し、`mlx_smoke verify-fixture` で short / long seq 両方の cosine_min が ADR 0002 の許容範囲内に収まることを再確認
+
+### Monitoring
+
+`EmbedError::NonFiniteOutput` が production で発生したら本 ADR の前提 (mask fill が十分な underflow を生む) が破れている signal。`mlx_smoke verify-fixture` を最新の mlx-rs / macOS / Apple Silicon バージョンで再走する。
+
+### References
+
+- `src/modernbert/model.rs:384` (`MASK_FILL` const definition)
+- `src/modernbert/model.rs:414-426` (`prepare_4d_attention_mask` — `MASK_FILL` 適用箇所)
+- `src/modernbert/model.rs:466-467` (`get_local_attention_mask` — `f32::NEG_INFINITY` 直接書き込み)
+- ADR 0002 (GPU-side pooling — embedding pipeline numerical reproducibility)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -9,3 +9,6 @@
 | [0005](./0005-prefix-ensemble-experiment-not-adopted.md) | Phase 6 Prefix-Ensemble Experiment — Not Adopted | Accepted | 2026-04-27 |
 | [0006](./0006-eval-harness-migration-to-amici.md) | Migrate Search-Quality Evaluation Harness from `rurico` to `amici` | Accepted | 2026-04-27 |
 | [0007](./0007-library-logging-boundary.md) | Library Logging Boundary — `rurico` Emits Internal Recovery Warns, CLI Emits Caller Boundary Warns | Accepted | 2026-04-30 |
+| [0008](./0008-adopt-process-level-sqlite-vec-auto-extension.md) | Adopt process-level sqlite-vec auto-extension registration | Accepted | 2026-05-14 |
+| [0009](./0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md) | Adopt BUCKET_BOUNDS as cross-module forward-pass invariant | Accepted | 2026-05-14 |
+| [0010](./0010-adopt-maskfill-constant-to-avoid-metal-kernel-nan.md) | Adopt MASK_FILL constant to avoid Metal kernel NaN | Accepted | 2026-05-14 |


### PR DESCRIPTION
## 概要

#159 audit-undocumented の critic-design が `keep` 判定した 3 件を ADR 0008-0010 として起票。いずれも tool で守れない structural commitment で Adoption Gate 3 条件 (hard to reverse / surprising without context / real trade-off) 通過済。

| ADR | 主題 | 守る invariant |
| --- | ---- | -------------- |
| 0008 | `Adopt process-level sqlite-vec auto-extension registration` | `ensure_sqlite_vec` を `Connection::open` 前に一度だけ呼ぶ API contract、違反は vec0 silent failure |
| 0009 | `Adopt BUCKET_BOUNDS as cross-module forward-pass invariant` | `[128, 512, 2048, MAX_SEQ_LEN]` の 4 entries を全 forward caller が `assign_bucket` で round up、違反すると local_mask_cache + MLX compile cache が無限に蓄積 |
| 0010 | `Adopt MASK_FILL constant to avoid Metal kernel NaN` | `MASK_FILL = -1e9` (NEG_INFINITY 不可)、Apple Silicon Metal kernel の `0.0 * (-inf) = NaN` ハザード回避、`~9 token` 周辺で発火 |

## 検証

- [x] `/adr` skill の `pre-check.sh` で 0008/0009/0010 を auto-numbering
- [x] `/adr` skill の `validate-adr.sh` で 3 本とも errors=[] (warnings は markdown_lint のみ)
- [x] MADR v4 format (Frontmatter `status: accepted` + 4 必須 section + 3+ options + Decision Outcome)
- [x] `docs/decisions/README.md` 索引に 3 行追加 (手書き形式で 0001-0007 と整合)
- [x] `/adr` skill の `update-index.sh` 自動生成形式は 0001-0007 の古い frontmatter を読めず `proposed/Not set` に倒れたため採用せず、手書き形式を維持
- 補足: code change は無し、docs 追加のみ

## #159 critic-design verdict との対応

| # | critic-design verdict | 採用文言 (ADR に保存) |
| - | --------------------- | --------------------- |
| 3 (MASK_FILL) | "math defaults `-inf` から逆走 hard to reverse、precision vs NaN 回避 real trade-off" | ADR 0010 Decision Outcome 第 2 段落 + Pros/Cons NEG_INFINITY 項 |
| 6 (BUCKET_BOUNDS) | "違反すると MLX compile cache 暴発、4 magic number は ADR なしでは説明不能、固定 kernel 数 vs sequence 適応の trade-off" | ADR 0009 Decision Drivers + Pros/Cons dynamic-bucket 項 |
| 9 (ensure_sqlite_vec) | "`pub fn` で downstream が必ず `Connection::open` 前に呼ぶ API contract、違反は silent failure、per-connection registration への切替は breaking change" | ADR 0008 Decision Outcome + Pros/Cons per-connection 項 |

## Phase 2 (rest) について

本 PR は Phase 1 (ADR 3 本)。残り 6 件中の Note 追記 + THREAT_MODEL.md SEC-005 + FORWARD maintenance + doc-comment 補強 4 件は Phase 2 として別 PR で出す。両 PR merge 後に `/audit-adr-drift` 再走で新規 ADR とコードの整合性 verify する予定。

Refs #159