### PR TITLE
docs: audit followup Phase 2 — ADR Note + THREAT_MODEL + doc-comment 補強 (#158 #159)

### DIFF
--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -82,6 +82,66 @@ dynamic library lookups in the child.
   compared to the parent's full env. High-risk injection vectors not
   required by MLX (notably `DYLD_INSERT_LIBRARIES`) are excluded.
 
+### SEC-005: Probe child grandchild reader-thread leak
+
+`probe_via_subprocess_with` (`src/model_probe.rs:431-451`) spawns dedicated
+reader threads via `spawn_drain_pipe` to drain the child's stdout/stderr.
+`collect_pipe` (`src/model_probe.rs:487-512`) caps its `recv_timeout` at
+`COLLECT_PIPE_TIMEOUT = 2s`. When the direct child has exited but a
+grandchild has inherited the pipe FDs and keeps them open, the reader
+thread's `read_to_end` cannot see EOF and stays blocked indefinitely — the
+parent drops the channel after the 2s timeout and the reader thread leaks
+until the parent process exits.
+
+**Accepted because:**
+
+- Grandchild FD inheritance from the probe child requires the model-load
+  step to spawn its own subprocess; the current `Embedder::probe` /
+  `Reranker::probe` load paths do not do this, so the leak path is reached
+  only by a hostile or malformed probe handler. Such a handler is already
+  covered by `ProbeError::HandlerNotInstalled` triage.
+- The leaked thread is blocked on a kernel pipe read, so it consumes one
+  OS thread slot but no CPU. Across O(N) probes in a single process this
+  is bounded by the per-process thread limit, which is well above realistic
+  probe counts.
+- A `kill(grandchild)` mechanism would require enumerating descendants
+  (libproc on macOS, `/proc` on Linux) and reasoning about transient PIDs;
+  the cost is large relative to the exceptional nature of the scenario.
+
+The 2s `COLLECT_PIPE_TIMEOUT` is itself the safeguard — the parent's hot
+path is not delayed beyond that, regardless of whether the reader thread
+gets reaped.
+
+## Maintenance rules
+
+### FORWARD allowlist maintenance
+
+`FORWARD` (`src/model_probe.rs:345-387`) is the env-var allowlist applied
+to the probe child after `Command::env_clear`. The list is intentionally
+conservative — `Command::env_clear` plus this allowlist is the SEC-004
+mitigation surface.
+
+**When adding a new runtime dependency that reads environment variables:**
+
+| Step | Action |
+| ---- | ------ |
+| 1    | Identify which env vars the new dependency reads (check its crate-level docs + source) |
+| 2    | Add each var to `FORWARD` with an inline comment naming the dependency and the var's purpose |
+| 3    | Run the existing probe smoke (`just probe-embed` / `just probe-reranker`) to confirm the child can still load with the new entry |
+| 4    | Audit the new var for injection risk — if it can redirect dynamic loading, library lookup, or filesystem search (e.g. `LD_*`, `DYLD_*`, `_PATH`), document the trade-off in this file alongside SEC-004 |
+
+**When removing a runtime dependency:**
+
+| Step | Action |
+| ---- | ------ |
+| 1    | Search `FORWARD` for entries whose inline comment names the removed dependency |
+| 2    | Remove them unless another active dependency still reads the same var |
+| 3    | Run probe smoke to confirm no regression |
+
+The allowlist is a positive list — silently letting an env var through
+because "it might be needed" defeats SEC-004's hardening. Each entry must
+have an attributable need.
+
 ## Wire format commitments
 
 The probe pathway exposes a small surface that downstream tooling (incident

--- a/docs/decisions/0001-typed-fts-query-contract.md
+++ b/docs/decisions/0001-typed-fts-query-contract.md
@@ -4,6 +4,8 @@
 - Date: 2026-03-28
 - Confidence: high - The current API contract is ambiguous, and the migration path across downstream crates is clear.
 
+> **Note (2026-05-14, visibility clarification)**: `SanitizedFtsQuery`, `sanitize_fts_query`, and `fts_expand_short_terms` are `pub(crate)` (not `pub`). The downstream-visible surface is `MatchFtsQuery` + `prepare_match_query` only — intermediate sanitization types stay crate-private to match LANG.md `Visibility: Minimum required`. The Migration Plan below remains valid because downstream callers reach the typed contract through `prepare_match_query` regardless.
+
 ## Context
 
 `rurico::storage::sanitize_fts_query` currently returns a plain `String`. That leaves three contract gaps:

--- a/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -6,6 +6,8 @@
 
 > **Note (2026-05-08)**: `rrf_merge` references in this ADR are superseded by issue #104. The canonical RRF primitive is now `retrieval::WeightedRrf` — this ADR's own Stage-2 `MergeStrategy::WeightedRrf` (configurable via `HybridSearchConfig`, `WeightedRrf::default()` is bit-equal to the removed legacy fn).
 
+> **Note (2026-05-14, post-ADR-0006 stage ownership clarification)**: Stage 4 (Rerank) and Stage 5 (Final) types (`RerankedHit`, `FinalHit`, `apply_reranker`) do not exist in `rurico` today. The reference composition that originally hosted them in `src/eval/pipeline.rs` was migrated to `amici` by ADR 0006 (see [`amici/docs/decisions/0002-evaluation-methodology.md`](https://github.com/thkt/amici/blob/main/docs/decisions/0002-evaluation-methodology.md)). `rurico::retrieval` owns the Stage 2 (`MergeStrategy` / `WeightedRrf` / `HybridSearchConfig` / `RecencyConfig`) and Stage 3 (`Aggregator` trait + `IdentityAggregator` / `MaxChunkAggregator` / `DedupeAggregator` / `TopKAverageAggregator`) primitives only; Stage 1 / 4 / 5 contracts live downstream — `amici` for the reference eval composition, `recall` / `sae` / `yomu` for their production pipelines.
+
 ## Context
 
 Issue #53 plans a six-phase retrieval-quality programme. Phase 1 (#65, ADR 0003) delivered the evaluation harness; Phases 3–6 will implement aggregation (#67), hybrid weights (#68), query normalization (#69), and prefix ensemble (#70). Issue #66 (this ADR) freezes the **interfaces** Phases 3–6 will plug into.
@@ -168,6 +170,7 @@ Positive:
 - Phase 5 (#69) and Phase 6 (#70) gain explicit insertion points (Stage 1 query normalization, Stage 1 source variants).
 - Eval and production pipelines stop being parallel candidates — the eval baseline measures the same code Phase 3+ ships.
 - Downstream consumers (recall/sae/yomu) have a single migration target rather than per-Phase API churn.
+- All Stage 2 / 3 outputs are sorted by `score` descending, then `doc_id` ascending, then `chunk_id` ascending — a stable 3-key total order pinned by `weighted_rrf_default_breaks_ties_by_doc_id` (T-104-001) and the chunk-level aggregator tests; downstream pagination and tie-break assertions can rely on it.
 
 Negative:
 

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -19,10 +19,19 @@ use crate::modernbert::Config;
 // ── Kind markers ────────────────────────────────────────────────────────────
 
 /// Kind marker for embedding models (ruri-v3 embed variants).
+///
+/// **Sealed**: the private `()` field prevents external crates from constructing
+/// this marker, ensuring the kind ↔ model id binding (via
+/// [`ModelArtifact::Kind`](crate::model_io::ModelArtifact::Kind)) is enforced
+/// at the type level. Downstream callers cannot construct a kind unrelated to
+/// the model id they hold.
 #[derive(Debug)]
 pub struct EmbedKind(());
 
 /// Kind marker for reranker models (ruri-v3-reranker variants).
+///
+/// **Sealed**: same sealed-pattern as [`EmbedKind`] — the private `()` field
+/// blocks external construction, so kind ↔ model id binding stays type-level.
 #[derive(Debug)]
 pub struct RerankerKind(());
 

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -338,11 +338,12 @@ impl MergeStrategy for WeightedRrf {
 pub trait Aggregator {
     /// Aggregate `hits` into the form Stage 4 expects.
     ///
-    /// **Output MUST be sorted by `score` descending** (with deterministic
-    /// tiebreaking by `doc_id` when scores are equal). The pipeline truncates
-    /// the result to `config.k` after this call, so non-sorted output would
-    /// silently drop higher-scoring hits. Output length may be ≤ input
-    /// length (dedupe / max-chunk collapse duplicates).
+    /// **Output MUST be sorted by `score` descending**, then `doc_id`
+    /// ascending, then `chunk_id` ascending (3-key total order, matching the
+    /// `MergeStrategy::merge` contract in this module). The pipeline
+    /// truncates the result to `config.k` after this call, so non-sorted
+    /// output would silently drop higher-scoring hits. Output length may be
+    /// ≤ input length (dedupe / max-chunk collapse duplicates).
     fn aggregate(&self, hits: &[MergedHit]) -> Vec<MergedHit>;
 }
 


### PR DESCRIPTION
## 概要

#158 audit-adr-drift と #159 audit-undocumented (critic-design `downgrade` 判定 5 件) からの軽量 follow-up を 1 PR に集約。Phase 1 (PR #170 で merge 済の ADR 0008-0010 起票) と組み合わせ、#159 audit-undocumented の punch list を完了させる。

| 種別 | 編集 | 出典 |
| ---- | ---- | ---- |
| ADR Note | ADR 0001 に `pub(crate)` 可視性記録 Note 追加 | #158 audit drift L (#1) |
| ADR Note | ADR 0004 に Stage 4/5 amici 移行クロージャ Note 追加 | #158 audit drift M (#4) |
| ADR 本文 | ADR 0004 Consequences に sort 3-key total order 1 行追加 (score desc → doc_id asc → chunk_id asc) | #159 downgrade #12 |
| THREAT_MODEL | SEC-005 追加 (probe child grandchild reader-thread leak accepted-risk) | #159 downgrade #2 |
| THREAT_MODEL | Maintenance rules section 新設 + FORWARD allowlist 保守手順 | #159 downgrade #1 |
| doc-comment | `EmbedKind`/`RerankerKind` doc に Sealed pattern 明記 | #159 downgrade #11 |
| doc-comment | `Aggregator::aggregate` doc に sort 3-key 順を追記 (ADR 0004 と整合) | #159 downgrade #12 |

## 検証

- [x] `cargo check --workspace` 通過
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通過
- [x] pre-commit hook (`cargo fmt --check` + clippy) 通過
- [x] doc-comment 変更は behavior change なし、ADR は immutable rule に従い Note 追記 + Consequences 追補のみ (本文 rewrite なし)
- 補足: code 編集は `src/artifacts.rs` (doc only) + `src/retrieval.rs` (doc only)

## #159 critic-design downgrade verdict との対応

| # | downgrade target (critic-design 指示) | 本 PR の Edit |
| - | ------------------------------------- | ------------- |
| 1 | THREAT_MODEL.md に `FORWARD maintenance` section 追加 (SEC-004 隣) | `Maintenance rules` section を Out-of-scope の後に新設 |
| 2 | THREAT_MODEL.md に SEC-005 として reader thread leak 追加 | Out-of-scope / Accepted Risks 内に SEC-005 entry 追加 |
| 4 | (BUCKET_BOUNDS / local_mask_cache) → ADR 0009 に統合 | Phase 1 PR #170 で対応済 |
| 11 | `EmbedKind`/`RerankerKind` doc に "Sealed pattern" 明記 | `src/artifacts.rs:22-32` を編集 |
| 12 | (a) `Aggregator` doc に ascending + chunk_id 追記、(b) ADR 0004 Consequences に 1 行追加 | `src/retrieval.rs:339-345` + ADR 0004 Consequences 末尾の両方 |

## Phase 3 について

両 PR (#170 + 本 PR) merge 後、`/audit-adr-drift` を再走して新規 ADR 0008-0010 と既存コード + 追記 Note と既存ファイルの整合性を verify する。drift ゼロ期待。

Refs #158 #159