### PR TITLE
docs(adr): ADR 0008 冪等性 clarification Note 追加 (#158-#159 残務)

### DIFF
--- a/docs/decisions/0008-adopt-process-level-sqlite-vec-auto-extension.md
+++ b/docs/decisions/0008-adopt-process-level-sqlite-vec-auto-extension.md
@@ -6,6 +6,8 @@ decision-makers: thkt
 
 # Adopt process-level sqlite-vec auto-extension registration
 
+> **Note (2026-05-14, idempotency clarification)**: 本 ADR は ordering 契約を「`Connection::open` 前に呼ぶ」と表現するが、文中・Decision Outcome の "一度だけ呼ぶ" は実装挙動と細部が違う。`src/storage.rs::ensure_sqlite_vec` は `OnceLock` で gated されており、複数回呼び出しても 2 回目以降は no-op で返す idempotent な実装 (`ensure_sqlite_vec_idempotent` test が `src/storage.rs:47` で pin)。読者は **「`Connection::open` 前に呼ぶ必要があるが、複数回呼んでも害なし」** と読み替えてほしい。"一度だけ" は "registration が effective に成立するのは 1 度きり" の意味で、caller 側の呼び出し回数を縛るものではない。
+
 ## Context and Problem Statement
 
 rurico の storage 層は sqlite-vec の vec0 仮想テーブルを使うが、sqlite-vec は **process-level auto-extension** として登録する idiom を取る (`sqlite_auto_extension` がプロセス内の全 `Connection::open` に対して以後自動 load する)。`src/storage.rs::ensure_sqlite_vec` (`pub fn`) が registration を行い、未完了の状態で開かれた Connection からは vec0 にアクセスできない。downstream CLI (`yomu` / `sae` / `amici`) は `Connection::open` 前に必ず `ensure_sqlite_vec` を呼ぶ必要があるが、この ordering 契約はコード型システムでは強制できず文書化に頼る。


### PR DESCRIPTION
## 概要

PR #172 (audit rerun) で検出した L priority drift 1 件を closure。ADR 0008 Decision Outcome の「`Connection::open` 前に一度だけ呼ぶ」文言が `OnceLock` idempotent 実装と若干乖離していた点を Note で読み替え方を明示。

## 変更内容

`docs/decisions/0008-adopt-process-level-sqlite-vec-auto-extension.md` の Status block 直後に Note を追加:

> **Note (2026-05-14, idempotency clarification)**: 本 ADR は ordering 契約を「`Connection::open` 前に呼ぶ」と表現するが、文中・Decision Outcome の "一度だけ呼ぶ" は実装挙動と細部が違う。`src/storage.rs::ensure_sqlite_vec` は `OnceLock` で gated されており、複数回呼び出しても 2 回目以降は no-op で返す idempotent な実装 (`ensure_sqlite_vec_idempotent` test が `src/storage.rs:47` で pin)。読者は **「`Connection::open` 前に呼ぶ必要があるが、複数回呼んでも害なし」** と読み替えてほしい。"一度だけ" は "registration が effective に成立するのは 1 度きり" の意味で、caller 側の呼び出し回数を縛るものではない。

## 検証

- [x] ADR immutable rule に従い本文書き換えなし、Note 追記のみ
- [x] 既存 ADR 0001/0002/0004 の Note pattern (Status 直後に `> **Note (date, label)**:`) と整合
- [x] 実装 (`src/storage.rs:22-44`) + test (`ensure_sqlite_vec_idempotent`) を読み返して読み替え文言の正確性を確認

## #158-#159 audit cycle 完全閉幕

| PR | 内容 |
| -- | ---- |
| #166 | ADR 0001-0007 drift scan report |
| #167 | undocumented decisions audit report |
| #168 | `gpu_pool_and_normalize` `pub(crate)` narrow + ADR 0002 Note ×2 |
| #169 | THREAT_MODEL.md SEC-002 wire format commitment |
| #170 | ADR 0008-0010 起票 |
| #171 | ADR 0001/0004 Note + THREAT_MODEL SEC-005/Maintenance + doc-comment 補強 |
| #172 | audit rerun verification report |
| **#173 (本 PR)** | **ADR 0008 idempotency clarification Note** |

drift 4 件 + undocumented 12 件 → 全件 closure。outcome 観点では「downstream CLI 開発者が rustdoc + ADR + THREAT_MODEL から誤用なく利用」が前進、verbalize → verify ループ (`[[adr-as-verify-trigger]]`) が機能した実例として記録に残る。

Refs #158 #159