### PR TITLE
docs: TOKEN_BUDGET / visibility test / docs-issues の文書化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,20 @@ binary 版を直接呼ぶ場合:
 cargo run --features smoke --bin mlx_smoke
 ```
 
+### `visibility` integration test (trybuild + Metal Toolchain)
+
+`tests/visibility.rs` は trybuild で `tests/ui/*.rs` を compile_fail として exercise する。各 fixture の build に Metal Toolchain (Xcode Command Line Tools 同梱) を要する。
+
+- CI (macOS-latest runner): Xcode CLT 同梱、通常通り走る
+- ローカル環境で Metal Toolchain 不在: `cannot execute tool 'metal'` で trybuild が build fail する
+
+Toolchain 不在の環境で他テストだけ走らせる場合:
+
+```sh
+xcode-select --install                  # Metal Toolchain を導入する場合
+cargo test --workspace --lib --bins     # または trybuild test target を含めず走らせる
+```
+
 ## ブランチと commit
 
 - ブランチ名は `<type>/<short-topic>` 形式（例: `fix/foo-bar`, `ci/baz-qux`）。
@@ -49,3 +63,11 @@ PR 提出前に以下が通ることを確認する。
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo fmt -- --check
 ```
+
+## `docs/issues/`
+
+ローカル issue メモ用ディレクトリ。`.gitignore` で `docs/issues/` が指定されており、新規ファイルは git 追跡されない。
+
+- 個人の作業メモ・調査草稿などを置く場所
+- リポジトリに残したい issue / ADR / audit 結果は `docs/decisions/` (ADR) または `docs/audit/` (監査結果) に昇格させる
+- gitignore 追加前から追跡されていた既存ファイル (`docs/issues/typed-fts-query-contract-migration.md` 等) は継続追跡される (`git update-index --skip-worktree` していないため、編集すると diff が出る)

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -271,9 +271,17 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
 /// Token-count ceiling for a single forward pass through the bucketed
 /// inference path.
 ///
+/// 256K-position budget per sub-batch — chosen empirically to keep padded
+/// MLX tensors under safe Apple Silicon GPU memory ceilings and avoid
+/// Metal OOM (commit `3c86e90`). Combined with [`BUCKET_BOUNDS`], the
+/// derived `(TOKEN_BUDGET / bucket_len)` sub-batch sizes are
+/// `(2000, 500, 125, 31)` for bucket lengths `(128, 512, 2048, 8192)`,
+/// pinned by `compute_sub_batch_size_matches_formula_per_bucket`.
+///
 /// Embed and reranker callers both size their sub-batches against this budget
 /// so memory consumption is bounded by the same ceiling regardless of which
-/// path drives a given call.
+/// path drives a given call. See `docs/decisions/0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md`
+/// for the cross-module forward-pass invariant.
 pub(crate) const TOKEN_BUDGET: usize = 256_000;
 
 /// Sub-batch size that keeps each forward pass under [`TOKEN_BUDGET`] when


### PR DESCRIPTION
## 概要

`/audit-adr-drift` rerun (PR #172) の punch list 残 3 件 (機能変更ゼロの docs 系) を 1 PR にまとめて closure。`feedback_defer_bump_for_no_op_merge` ルール通り rev bump は次の機能変更マージで合流。

- **B**: `src/model_io.rs::TOKEN_BUDGET` の docstring に rationale を追加
  - 256K-position budget の Metal OOM 防止由来 (commit `3c86e90`)
  - `(TOKEN_BUDGET / bucket_len)` derived sub-batch size table `(2000, 500, 125, 31)`
  - ADR 0009 (cross-module forward-pass invariant) への path link
- **C**: `tests/visibility.rs` (trybuild + Metal Toolchain 要) のローカル build fail を CONTRIBUTING.md に注記
  - CI (macOS-latest) では Xcode CLT 同梱で問題なし
  - ローカル不在環境: `cannot execute tool 'metal'` で fail
  - 回避: `xcode-select --install` または `cargo test --workspace --lib --bins`
- **E**: `docs/issues/` が gitignore 指定であることを CONTRIBUTING.md に明文化
  - 新規ファイルは追跡されない (ローカル作業メモ用)
  - 既存追跡ファイル (`docs/issues/typed-fts-query-contract-migration.md` 等) は継続
  - 残したい内容は `docs/decisions/` (ADR) / `docs/audit/` (監査結果) に昇格

## 確認内容

- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` 通過
- [x] `cargo fmt -- --check` 通過 (pre-commit hook で確認済)
- [x] B の derivation: `git log -S "TOKEN_BUDGET"` で commit `3c86e90` を発見、commit body の "256K-position budget per sub-batch so large padded tensors never exceed safe GPU memory on Apple Silicon" を反映
- [x] B の sub-batch table: `compute_sub_batch_size_matches_formula_per_bucket` test (`src/model_io.rs:444-462`) で pin 済みの formula と整合
- [x] 機能変更ゼロ (docs/comment のみ)

## 対象外

- D (punch list 残): `/audit-adr-drift` 同日再走の命名規則 (`-rerun` suffix scalable でない) は skill 改修案件、rurico repo 外 issue
- TOKEN_BUDGET 数値更新 (新世代 M-series で memory ceiling 上昇可能性): 本 PR は文書化のみ、benchmark 再走 + 値更新は別 issue
- `tests/visibility.rs` を `#[cfg(target_os = "macos")]` で gate: Metal Toolchain は macOS でも明示 install 要なので OS gate では解決しない、注記 + 回避手順で対応