### PR TITLE
README drift fix と rev pin 統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Apple Silicon (MLX) 上で日本語テキストのembedding・reranking・類似
 
 ```toml
 [dependencies]
-rurico = { git = "https://github.com/thkt/rurico", tag = "v0.2.0" }
+rurico = { git = "https://github.com/thkt/rurico", rev = "cf13d32" }
 ```
 
-`tag` は [Cargo.toml の `version`](Cargo.toml) と同期する。新しい release を取り込む場合は [tag 一覧](https://github.com/thkt/rurico/tags) から最新 tag を確認して上書きする。
+`rev` は rurico の commit SHA で固定する。新しい更新を取り込む場合は [rurico の最新 commit](https://github.com/thkt/rurico/commits/main) から sha を確認して上書きする。
 
 MLXの初期化失敗はプロセスをabortする可能性がある。`probe` でモデルのロード可否を子プロセスで検証してからEmbedderを作成する。
 
@@ -84,7 +84,6 @@ for chunk_vec in &doc.chunks {
 | ---------------------- | ---------------- | ---------------------------------------------------------------------------------- |
 | `EMBEDDING_DIMS`       | `768`            | デフォルトモデル (310m) の出力次元数。実行時は `Embedder::embedding_dims()` で取得 |
 | `MAX_SEQ_LEN`          | `8192`           | モデル入力全体長（BOS + prefix + text + EOS）                                      |
-| `CHUNK_OVERLAP_TOKENS` | `2048`           | document chunk 間の overlap token 数                                               |
 | `QUERY_PREFIX`         | `"検索クエリ: "` | クエリ埋め込みときに先頭へ付加                                                     |
 | `DOCUMENT_PREFIX`      | `"検索文書: "`   | ドキュメント埋め込みときに先頭へ付加                                               |
 | `SEMANTIC_PREFIX`      | `""`             | semantic/clustering タスク用（プレフィックスなし）                                 |
@@ -323,6 +322,15 @@ stmt.execute(rusqlite::params![bytes])?;
 | `Tokenizer`           | tokenizer エンコード失敗                   |
 | `NonFiniteOutput`     | embedding 出力に NaN または Inf が含まれる |
 
+**`RerankerError`** — `Rerank` トレイトメソッド（reranker 推論）フェーズ
+
+| variant           | 発生条件                                                                  |
+| ----------------- | ------------------------------------------------------------------------- |
+| `Inference`       | MLX forward pass 失敗                                                     |
+| `Tokenizer`       | tokenizer エンコード失敗                                                  |
+| `NonFiniteOutput` | reranker 出力に NaN または Inf が含まれる                                 |
+| `InitFailed`      | `LazyReranker` 初回呼び出し時の初期化失敗（cache 参照・ロード・DL）       |
+
 公開APIの失敗契約はrustdocの `# Errors` に記載する。repoの運用ルールは
 [`docs/errors.md`](docs/errors.md) を参照。
 
@@ -350,12 +358,12 @@ require_unsandboxed_mlx_runtime();
 
 ```toml
 [dev-dependencies]
-rurico = { git = "https://github.com/thkt/rurico", rev = "main", features = ["test-support"] }
+rurico = { git = "https://github.com/thkt/rurico", rev = "cf13d32", features = ["test-support"] }
 ```
 
 | struct                | 振る舞い                                                                          |
 | --------------------- | --------------------------------------------------------------------------------- |
-| `MockEmbedder`        | 決定的な one-hot ベクトルを返す                                                   |
+| `MockEmbedder`        | 入力位置ごとに決定的な one-hot ベクトルを返す（バッチ時は入力順 `i`、単発は `0`） |
 | `FailingEmbedder`     | 設定に応じてエラーを返す                                                          |
 | `MismatchEmbedder`    | batch で入力より少ないベクトルを返す                                              |
 | `AlternatingEmbedder` | `embed_document` が成功と失敗を交互に返す（初回は失敗）                           |
@@ -365,7 +373,7 @@ rurico = { git = "https://github.com/thkt/rurico", rev = "main", features = ["te
 ```rust
 use rurico::embed::{Embed, MockEmbedder};
 
-let embedder = MockEmbedder;
+let embedder = MockEmbedder::default();
 let v = embedder.embed_query("テスト")?;
 assert_eq!(v.len(), 768);
 ```


### PR DESCRIPTION
## What & Why

README が現在のコードと 5 箇所で乖離しており、downstream consumer が `use rurico::...` する際に rustc コンパイル失敗・存在しない constant 参照・実態と異なる dependency 例の混乱を引き起こす状態だった。README は公開契約として実装と同期させる必要がある。

## Changes

- 定数 table から `CHUNK_OVERLAP_TOKENS` 行を削除 — `pub(crate)` で downstream 不可視
- エラー型に `RerankerError` table を追加 — `Inference / Tokenizer / NonFiniteOutput / InitFailed` の 4 variant
- dependency 例の `tag = "v0.2.0"` を `rev = "cf13d32"` に変更 — downstream 4 repo (amici/yomu/sae/recall) 全部が rev sha pin を使用、global `CARGO.md` rule と整合
- `MockEmbedder` 説明を「入力位置ごとに決定的な one-hot ベクトル（バッチ時は入力順 `i`、単発は `0`）」に修正 — `embed_documents_batch` が `one_hot(i, dims)` を返す挙動を反映
- `let embedder = MockEmbedder;` を `MockEmbedder::default();` に修正 — `dims` field が private で unit-struct 構文では作れない

## Scope

- Not included: OUTCOME.md L23 "tag 参照のみ" を "rev (commit sha) 参照のみ" に修正したが、`.claude/` が `.gitignore` 対象のため commit には含まれない。project-level な dependency pin policy の共有（ADR 化など）は別 PR で議論

## Design Decisions

- `tag = "v0.2.0"` ではなく `rev = "cf13d32"` を選択した根拠は実態。downstream 4 repo (amici/yomu/sae/recall) は全て `rev = "<sha>"` 形式で pin しており、誰も tag を使っていない。global `CARGO.md` も `rev = "<sha>"` を規定。README の `tag` 例だけが乖離していた
- `CHUNK_OVERLAP_TOKENS` を `pub` に昇格せず削除を選んだ根拠: downstream が overlap token 数を直接読む実需がなく、`ChunkedEmbedding.chunks` の挙動で十分。API surface を不必要に広げない

## How to Test

1. `grep -nE 'CHUNK_OVERLAP_TOKENS|rev = "main"|MockEmbedder;|tag = "v0\.2\.0"' README.md` を実行
2. 何も match しないことを確認（5 箇所の drift が全て修正済み）
3. `grep -n 'RerankerError' README.md` で新規 table が追加されている（1 hit）ことを確認
