### PR TITLE
ci: cargo test → cargo nextest run に移行

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+fail-fast = false
+
+[profile.ci]
+fail-fast = false
+slow-timeout = { period = "120s", terminate-after = 2 }
+final-status-level = "flaky"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,16 @@ jobs:
       - name: Check
         run: cargo check --workspace --features test-support,test-mlx
 
+      - name: Install nextest
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: cargo-nextest
+
       - name: Test
-        run: cargo test --workspace --features test-support,test-mlx
+        run: cargo nextest run --workspace --features test-support,test-mlx --profile ci
+
+      - name: Doctests
+        run: cargo test --doc --workspace --features test-support,test-mlx
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,11 @@
 CI で実行されるテスト一式は以下で再現できる。
 
 ```sh
-cargo test --workspace --features test-support,test-mlx
+cargo nextest run --workspace --features test-support,test-mlx
+cargo test --doc --workspace --features test-support,test-mlx
 ```
+
+`cargo nextest run` は doctest を走らせないため、`cargo test --doc` を別途実行する。nextest 未インストールの場合は `brew install cargo-nextest` または `cargo install cargo-nextest --locked`。
 
 `test-support` / `test-mlx` feature を有効にすることで、CI の clippy step (`cargo clippy --workspace --all-targets --all-features -- -D warnings`) が見ているコードを test 側でも exercise する。CI の test step もこの組み合わせで実行される。
 
@@ -16,7 +19,7 @@ cargo test --workspace --features test-support,test-mlx
 
 ```sh
 # 実モデルを HF Hub からダウンロードして tokenizer 動作を検証
-cargo test -- --ignored g_001_real_tokenizer_extract_prefix_tokens
+cargo nextest run --run-ignored=ignored-only g_001_real_tokenizer_extract_prefix_tokens
 ```
 
 `src/embed/tests.rs` の 3 件と、`src/reranker/tests.rs` 内 `mlx_runtime_tests` モジュールの test がこのカテゴリに該当する。
@@ -27,7 +30,7 @@ cargo test -- --ignored g_001_real_tokenizer_extract_prefix_tokens
 
 ```sh
 # ruri-v3 系モデルがローカル HF cache にあることを前提に走らせる
-cargo test --workspace --features smoke --test mlx_smoke -- --ignored
+cargo nextest run --workspace --features smoke --test mlx_smoke --run-ignored=ignored-only
 ```
 
 binary 版を直接呼ぶ場合:
@@ -46,8 +49,8 @@ cargo run --features smoke --bin mlx_smoke
 Toolchain 不在の環境で他テストだけ走らせる場合:
 
 ```sh
-xcode-select --install                  # Metal Toolchain を導入する場合
-cargo test --workspace --lib --bins     # または trybuild test target を含めず走らせる
+xcode-select --install                          # Metal Toolchain を導入する場合
+cargo nextest run --workspace --lib --bins     # または trybuild test target を含めず走らせる
 ```
 
 ## ブランチと commit

--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ This installs a pre-commit hook that runs `cargo fmt --all -- --check` and `carg
 ### Common commands
 
 ```sh
-cargo test --workspace                                                  # all tests
+cargo nextest run --workspace                                           # all tests (doctest を除く)
+cargo test --doc --workspace                                            # doctest (nextest は doctest を走らせない)
 cargo clippy --workspace --all-targets --all-features -- -D warnings    # lint (matches CI)
 cargo fmt --all -- --check                                              # format check
 ```
@@ -401,9 +402,9 @@ cargo fmt --all -- --check                                              # format
 ## テスト
 
 ```sh
-cargo test --workspace                                                   # MLX ランタイム不要のテスト
-cargo test --workspace --features test-mlx -- --ignored                  # MLX ランタイムテスト（通常 Terminal 推奨）
-cargo run --bin mlx_smoke --features smoke --release -- verify-fixture   # embed 数値同等性検証（smoke binary）
+cargo nextest run --workspace                                                  # MLX ランタイム不要のテスト
+cargo nextest run --workspace --features test-mlx --run-ignored=ignored-only   # MLX ランタイムテスト（通常 Terminal 推奨）
+cargo run --bin mlx_smoke --features smoke --release -- verify-fixture         # embed 数値同等性検証（smoke binary）
 ```
 
 Codex Desktop の `CODEX_SANDBOX=seatbelt` 環境では、MLX / Metal 初期化が abort することがあるため、

--- a/justfile
+++ b/justfile
@@ -13,7 +13,8 @@ default:
 check: test lint fmt-check
 
 test:
-    cargo test --workspace --all-features
+    cargo nextest run --workspace --all-features
+    cargo test --doc --workspace --all-features
 
 lint:
     cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -26,7 +27,7 @@ fmt:
 
 # Run only the chunk-level retrieval tests (T-076-001..008, MLX-free)
 chunk-test:
-    cargo test --lib chunk
+    cargo nextest run --lib chunk
 
 # === embed スピード + 数値同等性ハーネス (mlx_smoke, ADR 0002) ===
 


### PR DESCRIPTION
## What & Why

cli 配下リポで test runner を統一する一環として、rurico を `cargo test` から `cargo nextest run` に移行する。並列度向上と CI 出力の可読性が目的。doctest は nextest 非対応のため `cargo test --doc` を別 step として残す。

## Changes

- `.config/nextest.toml` を新規作成 (default / ci profile)
- `.github/workflows/ci.yml` の Test step を nextest install + nextest run + doctest の 3 段に置換
- `justfile` の `test` / `chunk-test` recipe を nextest 化
- `CONTRIBUTING.md` / `README.md` の `cargo test` 例を nextest 構文に統一、`--ignored` を `--run-ignored=ignored-only` に置換

## Design Decisions

- `taiki-e/install-action` を採用 (`cargo install` ではなく) — binary 配布で CI 数秒、SHA pin 可能で zizmor の unpinned-uses ポリシーに適合
- nextest profile を default / ci に分離 (ci は `slow-timeout = 120s`, `final-status-level = flaky`)
- `retries = N` は採用せず (既知の flaky テスト無し、YAGNI)
- ドキュメント (CONTRIBUTING.md / README.md) を同 PR で更新 (CI 再現性が contributor 体験の根幹)

## How to Test

1. `git pull && git checkout ci/nextest-migration`
2. `brew install cargo-nextest` (未インストール時)
3. `cargo nextest run --workspace --features test-support,test-mlx --profile ci` → 351 tests pass を確認
4. `cargo test --doc --workspace --features test-support,test-mlx` → 1 doctest pass を確認
5. CI が green になることを確認

※ `visibility::ui` はローカルで Metal Toolchain 未インストール時に fail するが、CI macos-latest では green。

## Related

cli 配下 nextest 移行 initiative の一環。follow-up issue:
sae #121 / yomu #167 / recall #85 / amici #99 / assay #6 / chronicler #9 / formatter #9 / gates #20 / guardrails #105 / kiku #4 / litmus #15 / notch #10 / reviews #11 / scout #106 / shields #16 / tally #3 / xr #10
