### PR TITLE
Dependabot cooldown を追加し supply-chain alert を解消

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci
@@ -15,6 +17,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - rust


### PR DESCRIPTION
## What & Why

`.github/dependabot.yml` の両 ecosystem (github-actions, cargo) に `cooldown.default-days: 7` を追加し、zizmor の `dependabot-cooldown` audit が指摘する 2 件の code-scanning alert を解消する。新規 release 直後の悪意あるバージョン取り込み (supply-chain attack) リスクを下げる。

## Changes

- `.github/dependabot.yml`: 両 update entry に `cooldown.default-days: 7` を追加 (zizmor デフォルト閾値)

## Scope

- **Not included**: `semver-major-days` 等の細粒度 cooldown 設定 (まず alert 解消を優先、必要が顕在化した時点で段階強化)

## Design Decisions

- 最小 fix (`default-days: 7` のみ) を採用。zizmor 閾値ちょうど、メンテ複雑度ゼロ。tier 化は実需が出た時点で別 PR (YAGNI)

## How to Test

1. ローカルで `zizmor .github/dependabot.yml` を実行
2. `No findings to report. Good job!` が表示されることを確認

## Related

- Resolves code-scanning alert #1 (`dependabot-cooldown` on github-actions)
- Resolves code-scanning alert #2 (`dependabot-cooldown` on cargo)
