### PR TITLE
taiki-e/install-action の SHA pin を v2.78.2 に同期

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: cargo check --workspace --features test-support,test-mlx
 
       - name: Install nextest
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
         with:
           tool: cargo-nextest
 


### PR DESCRIPTION
## What & Why

`.github/workflows/ci.yml` line 40 の `taiki-e/install-action` の SHA pin (`184183c2...`) と `# v2` コメントが乖離していたため、zizmor の `ref-version-mismatch` audit が code-scanning alert #3 を出していた。SHA を `v2` タグ現在の `3771e22a...` (= v2.78.2) に bump し、comment も具体版数 `# v2.78.2` 化することで mismatch を解消する。

## Changes

- `.github/workflows/ci.yml`: `taiki-e/install-action` の SHA `184183c2...` → `3771e22a...`、comment `# v2` → `# v2.78.2`

## Scope

- **Not included**: 他 workflow の moving ref comment (`# stable` 等) の整理。今回 alert に出てない範囲は触らず

## Design Decisions

- SHA bump + comment 具体版数化を選択。`# v2` のままにすると将来 v2 tag が動く度に mismatch alert が再発するが、具体 `v2.78.2` 形なら tag 移動の影響を受けない (zizmor docs の good example と整合)

## How to Test

1. PR の CI (Test job) が green であることを確認 (nextest 実行成功)
2. PR merge 後、zizmor-action workflow 再 run で alert #3 が `fixed` になることを確認

## Related

- Resolves code-scanning alert #3 (`ref-version-mismatch` on ci.yml line 40)
