### PR TITLE
chore(deps): openssl 0.10.79 → 0.10.80 / openssl-sys 0.9.115 → 0.9.116 を更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1510,9 +1510,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## 概要

- `cargo update` で取り込んだトランジティブ依存のパッチ更新
- 直接依存は無し。`hf-hub` / `reqwest` / `ureq` 経由の `native-tls` から引っ張られる

## 変更

| crate | from | to |
|---|---|---|
| openssl | 0.10.79 | 0.10.80 |
| openssl-sys | 0.9.115 | 0.9.116 |

## 検証

- `cargo build --workspace --all-targets`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: OK
- `cargo nextest run --workspace`: 351 passed / 1 failed / 3 skipped
  - failed 1 件は `rurico::visibility ui`。`mlx-sys` の Metal Toolchain 未インストール環境による既知の failure (`xcodebuild -downloadComponent MetalToolchain` が必要)。本変更とは無関係

## テスト計画

- [ ] CI green