### PR TITLE
docs(adr): ADR-0004 References セクションの line-range drift 解消

### DIFF
--- a/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
+++ b/docs/decisions/0004-retrieval-and-rerank-pipeline-contract-for-rurico.md
@@ -223,10 +223,10 @@ Negative:
 - Phase 3 issue #67 (aggregation), Phase 4 #68 (weights), Phase 5 #69 (normalization), Phase 6 #70 (prefix ensemble)
 - ADR 0001 (`docs/decisions/0001-typed-fts-query-contract.md`) — typed FTS query primitive
 - ADR 0003 (`docs/decisions/0003-evaluation-methodology.md`) — Phase 1 reference composition + cyclic-dep posture
-- `src/eval/pipeline.rs` — Phase 1c reference composition (Phase 3 promotion target)
-- `src/storage/search.rs:146-198` — `rrf_merge`, `prepare_match_query` primitives
+- `amici/src/eval/pipeline.rs` — Phase 1c reference composition (migrated to `amici` per ADR 0006 — see Note 2026-05-14)
+- `src/storage/search.rs` — `prepare_match_query` primitive (`rrf_merge` removed; superseded by `src/retrieval.rs::WeightedRrf` — see Note 2026-05-08)
 - `src/embed/embedder.rs` — `Embed` trait surface
-- `src/reranker.rs:202-219` — `Rerank` trait + `RankedResult`
+- `src/reranker.rs` — `Rerank` trait + `RankedResult`
 - `recall/src/search.rs:352-429` — downstream hybrid pipeline (structural reference)
 - `recall/src/hybrid.rs` — recency boost helper (downstream-owned for now)
 - `recall/Cargo.toml:19` — `recall → rurico` git-ref dependency (cyclic constraint)


### PR DESCRIPTION
## 概要

- ADR-0004 References セクションの line-range drift 3 件を解消 (Closes #184)
- `src/eval/pipeline.rs` → `amici/src/eval/pipeline.rs` (ADR-0006 で migration 済を明記)
- `src/storage/search.rs:146-198` → line range 削除 + `rrf_merge` 削除済を注記 (後継 `retrieval::WeightedRrf`)
- `src/reranker.rs:202-219` → line range 削除 (`Rerank` trait は line 137-154 に移動済)
- 将来 drift 抑制のため References は symbol + module path のみの形式に統一

## テスト計画

- [x] `ls src/eval` → No such file or directory (amici 移行確認済)
- [x] `grep "rrf_merge" src/storage/search.rs` → 不在確認、`prepare_match_query` は line 163 に存在
- [x] `grep "trait Rerank" src/reranker.rs` → line 137、`RankedResult` は line 124
- [x] ADR 冒頭 Note (2026-05-08 / 2026-05-14) で historical context カバー済を確認