### PR TITLE
ci: diff coverage gate を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,57 @@ jobs:
       - name: Format check
         run: cargo fmt -- --check
 
+  coverage:
+    # Diff coverage gate: fail when coverage of the lines this PR adds or
+    # changes drops below the threshold, so new uncovered code (pub fn /
+    # branches) cannot merge untested. No overall-percent floor (which would
+    # flag existing unreachable code); no base-vs-PR double measurement.
+    # Rationale: ported from yomu (Issue #223), THRESHOLDS.md "Coverage".
+    # Runs on macos like the test job: mlx-sys (MLX FFI) needs BLAS + Apple
+    # silicon and cannot build on Linux. Coverage mirrors the test job's
+    # feature set so the measured behavior matches what the tests exercise.
+    runs-on: macos-latest
+    timeout-minutes: 60
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate lcov coverage
+        run: cargo llvm-cov --workspace --features test-support,test-mlx --lcov --output-path lcov.info
+
+      - name: Diff coverage gate (changed lines >= 95%)
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          # diff-cover is a Python tool; isolate it in a venv to avoid PEP 668
+          # (externally-managed environments) regardless of the runner's Python.
+          python3 -m venv /tmp/diff-cover-venv
+          /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
+          /tmp/diff-cover-venv/bin/diff-cover lcov.info \
+            --compare-branch=origin/main \
+            --fail-under=95
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 docs/issues/
 target/
 workspace/
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/lcov.info


### PR DESCRIPTION
## 概要

PR の変更行カバレッジが 95% を下回ると fail する `coverage` job を CI に追加する。未テストの新規 `pub fn` / 分岐が merge されるのを防ぐ。全体 percent の floor は持たない（到達不可コードを誤検知しないため）。

yomu (#223) で本番稼働している diff coverage 方式を rurico の構成に移植したもの。

## 方式

- `cargo llvm-cov --workspace --features test-support,test-mlx --lcov` でカバレッジ測定。test job と同じ feature set にして、測定対象の挙動をテストが実際に exercise する範囲と一致させる
- `diff-cover --compare-branch=origin/main --fail-under=95` で **PR の変更行のみ**を判定（全体 percent 比較ではない）
- mlx-sys が BLAS + Apple silicon を要求し Linux ビルド不可のため `macos-latest`（test job と同じ）
- diff-cover は PEP 668 回避のため venv に隔離
- `if: pull_request` で PR 時のみ実行

## 検証

- ローカル (macos) で `cargo llvm-cov --workspace --features test-support,test-mlx --lcov` が lcov 生成まで通ることを確認済み（全テスト pass / exit 0）
- **この PR 自体は ci.yml / .gitignore のみ変更で Rust 行ゼロ** → diff-cover が「変更行なし」で N/A pass する想定（＝ケース(a) の実測）
- 未カバー行での fail 挙動は yomu の同一 invocation で実証済み

## 関連

- 移植元: yomu #223 (diff coverage gate)
- THRESHOLDS.md "Coverage" 節
