### PR TITLE
test: coverage gate の fail を検証 (throwaway, 要削除)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,57 @@ jobs:
       - name: Format check
         run: cargo fmt -- --check
 
+  coverage:
+    # Diff coverage gate: fail when coverage of the lines this PR adds or
+    # changes drops below the threshold, so new uncovered code (pub fn /
+    # branches) cannot merge untested. No overall-percent floor (which would
+    # flag existing unreachable code); no base-vs-PR double measurement.
+    # Rationale: ported from yomu (Issue #223), THRESHOLDS.md "Coverage".
+    # Runs on macos like the test job: mlx-sys (MLX FFI) needs BLAS + Apple
+    # silicon and cannot build on Linux. Coverage mirrors the test job's
+    # feature set so the measured behavior matches what the tests exercise.
+    runs-on: macos-latest
+    timeout-minutes: 60
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          components: llvm-tools-preview
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: false
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@3771e22aa892e03fd35585fae288baad1755695c # v2.78.2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate lcov coverage
+        run: cargo llvm-cov --workspace --features test-support,test-mlx --lcov --output-path lcov.info
+
+      - name: Diff coverage gate (changed lines >= 95%)
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          # diff-cover is a Python tool; isolate it in a venv to avoid PEP 668
+          # (externally-managed environments) regardless of the runner's Python.
+          python3 -m venv /tmp/diff-cover-venv
+          /tmp/diff-cover-venv/bin/pip install --quiet diff-cover
+          /tmp/diff-cover-venv/bin/diff-cover lcov.info \
+            --compare-branch=origin/main \
+            --fail-under=95
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 docs/issues/
 target/
 workspace/
+
+# Coverage artifacts (cargo llvm-cov)
+*.profraw
+/lcov.info

--- a/src/coverage_probe.rs
+++ b/src/coverage_probe.rs
@@ -1,0 +1,8 @@
+// Throwaway probe: verifies the diff coverage gate fails on an uncovered
+// line. DELETE once verified. Not part of the public API.
+
+/// Returns `n + 1`, saturating at [`usize::MAX`]. Intentionally untested so
+/// the diff coverage gate reports its body as a missing line.
+pub fn probe(n: usize) -> usize {
+    n.saturating_add(1)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 
 /// Typed artifact verification: [`CandidateArtifacts`](embed::CandidateArtifacts) → [`VerifiedArtifacts`](artifacts::VerifiedArtifacts).
 pub mod artifacts;
+/// Throwaway coverage-gate probe (DELETE after verifying the gate fails).
+pub mod coverage_probe;
 /// Top-level probe dispatch wiring embed and reranker domains.
 pub mod dispatch;
 /// Embedding models and the [`Embed`](embed::Embed) trait.


### PR DESCRIPTION
## 目的（throwaway / 検証後に close + 削除）

diff coverage gate が **rurico の Rust 変更行を照合して実際に fail する**（no-op でない）ことを確認するための probe PR。

#195 (gate 本体) の CI はケース(a)「Rust 変更ゼロ → N/A pass」は実証したが、**diff-cover が rurico のソースパスを lcov と照合できるか**は未検証だった（変更が ci.yml/.gitignore のみで Rust 行ゼロのため）。この PR は未カバーの `pub fn` を1つ足し、gate が fail することを確認する。

## 期待される結果

`coverage` job が **fail**:
- `src/coverage_probe.rs` の `probe()` 本体行は未カバー
- diff-cover が diff 0% を検出 → `--fail-under=95` 未達 → exit 非0

## 確認後

この PR を close、`test/coverage-gate-probe` を削除。`src/coverage_probe.rs` と lib.rs の mod 宣言は本番に残さない。
