### PR TITLE
実装言い換えテストの排除

### DIFF
--- a/docs/decisions/0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md
+++ b/docs/decisions/0009-adopt-bucketbounds-as-cross-module-forward-pass-invariant.md
@@ -37,7 +37,7 @@ Chosen option: **"Adopt `BUCKET_BOUNDS` as a frozen cross-module invariant"**, b
 ### Confirmation
 
 - `src/model_io.rs:41-54` の `BUCKET_BOUNDS` const + `assign_bucket` doc が source of truth
-- `compute_sub_batch_size_matches_formula_per_bucket` (`src/model_io.rs:444-462`) test が `TOKEN_BUDGET / bucket_len` formula を pin
+- `compute_sub_batch_size_matches_formula_per_bucket` (`src/model_io.rs:450-460`) test が各 bucket の具体的 sub-batch サイズ `(2000, 500, 125, 31)` を pin
 - `src/modernbert/model.rs::ModernBert::local_mask_cache` doc が `BUCKET_BOUNDS` への intra-doc link で integrity を表明
 - 新規 forward caller を追加する PR では `BUCKET_BOUNDS` への round-up が code review checklist になる
 

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -194,13 +194,6 @@ mod tests {
         assert_eq!(m.padding_ratio(), 0.0);
     }
 
-    #[test]
-    fn phase_metrics_new_sets_kind() {
-        let m = PhaseMetrics::new(EmbedKind::Query);
-        assert_eq!(m.kind, EmbedKind::Query);
-        assert_eq!(m.padded_tokens, 0);
-    }
-
     // T-MET-001: log() emits named fields for the bucket histogram so
     // subscribers can read per-bucket counts without parsing a format string.
     #[traced_test]

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -185,9 +185,9 @@ fn shrink_chunk_to_fit_short_text_returns_immediately() {
 // T-001: max_content_equals_max_seq_len_minus_2_minus_prefix_len
 #[test]
 fn max_content_equals_max_seq_len_minus_2_minus_prefix_len() {
-    // [T-001] FR-001, FR-002: max_content(10) == 8180, 8180 + 10 + 2 == 8192
+    // [T-001] FR-001, FR-002: max_content reserves BOS(1) + EOS(1) + prefix.
+    // 8180 = MAX_SEQ_LEN(8192) - 2 - prefix_len(10).
     assert_eq!(max_content(10), 8180);
-    assert_eq!(8180 + 10 + 2, MAX_SEQ_LEN);
 }
 
 /// Requires HF Hub model download (network access).
@@ -275,15 +275,6 @@ fn truncate_for_query_zero_max_len_returns_unchanged() {
     assert_eq!(seq_len, 4);
     assert_eq!(ids, expected_ids, "max_len=0 should return unchanged");
     assert_eq!(mask, expected_mask);
-}
-
-// T-014: mock_chunked_embedder_returns_multi_chunk
-#[test]
-fn mock_chunked_embedder_returns_multi_chunk() {
-    let embedder = super::MockChunkedEmbedder::new(3);
-    let result = embedder.embed_document("some text").unwrap();
-    assert_eq!(result.chunks.len(), 3);
-    assert_eq!(result.chunks[0].len(), EMBEDDING_DIMS);
 }
 
 // --- Regression: prefix boundary merge cases ---
@@ -417,26 +408,11 @@ fn embed_documents_batch_empty_returns_empty() {
 // --- 1+3 prefix scheme ---
 
 #[test]
-fn embed_text_returns_correct_dimensionality_for_all_prefixes() {
+fn embed_text_returns_embedding_dims() {
+    // MockEmbedder ignores prefix, so a single call exercises the dim contract.
     let e = super::MockEmbedder::default();
-    for prefix in [SEMANTIC_PREFIX, TOPIC_PREFIX, QUERY_PREFIX, DOCUMENT_PREFIX] {
-        let vec = e.embed_text("テスト", prefix).unwrap();
-        assert_eq!(
-            vec.len(),
-            EMBEDDING_DIMS,
-            "wrong dims for prefix: {prefix:?}"
-        );
-    }
-}
-
-#[test]
-fn embed_text_propagates_error() {
-    let e = super::FailingEmbedder::all_fail("embed_text error");
-    let err = e.embed_text("テスト", SEMANTIC_PREFIX).unwrap_err();
-    assert!(
-        matches!(err, EmbedError::Inference(ref msg) if msg.contains("embed_text error")),
-        "{err}"
-    );
+    let vec = e.embed_text("テスト", SEMANTIC_PREFIX).unwrap();
+    assert_eq!(vec.len(), EMBEDDING_DIMS);
 }
 
 #[test]

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -447,26 +447,16 @@ mod tests {
 
     // ── compute_sub_batch_size tests ────────────────────────────────────────
 
-    // Pin the canonical sub-batch formula `(TOKEN_BUDGET / bucket_len).max(1)`
-    // so embed and reranker callers cannot drift apart silently.
+    // Pin the concrete per-bucket sub-batch sizes, not the formula: asserting
+    // against `TOKEN_BUDGET / BUCKET_BOUNDS[i]` would track both sides and stay
+    // green even if TOKEN_BUDGET drifted. 256_000 / (128, 512, 2048, 8192) =
+    // (2000, 500, 125, 31); embed and reranker callers share this function.
     #[test]
     fn compute_sub_batch_size_matches_formula_per_bucket() {
-        assert_eq!(
-            compute_sub_batch_size(BUCKET_BOUNDS[0]),
-            TOKEN_BUDGET / BUCKET_BOUNDS[0],
-        );
-        assert_eq!(
-            compute_sub_batch_size(BUCKET_BOUNDS[1]),
-            TOKEN_BUDGET / BUCKET_BOUNDS[1],
-        );
-        assert_eq!(
-            compute_sub_batch_size(BUCKET_BOUNDS[2]),
-            TOKEN_BUDGET / BUCKET_BOUNDS[2],
-        );
-        assert_eq!(
-            compute_sub_batch_size(BUCKET_BOUNDS[3]),
-            TOKEN_BUDGET / BUCKET_BOUNDS[3],
-        );
+        assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[0]), 2000);
+        assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[1]), 500);
+        assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[2]), 125);
+        assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[3]), 31);
     }
 
     // `max(1)` floor: pathological bucket_len > TOKEN_BUDGET cannot happen in

--- a/src/model_probe/tests.rs
+++ b/src/model_probe/tests.rs
@@ -610,15 +610,19 @@ fn setup_reason_label_is_stable_per_variant() {
 // T-115-E
 #[test]
 fn setup_reason_display_combines_code_and_label() {
+    // Full literal (code 5 == PROBE_EXIT_PATH_OUTSIDE_CACHE) so a change to
+    // Display's format string is caught, not mirrored by rebuilding it here.
     assert_eq!(
         format!("{}", SetupReason::PathOutsideCache),
-        format!("code {PROBE_EXIT_PATH_OUTSIDE_CACHE}: path outside cache"),
+        "code 5: path outside cache",
     );
 }
 
-// T-012: FORWARD list contains exactly the 22 expected keys
+// T-012: FORWARD is exactly this allowlist, in declaration order. Equality
+// (not len + contains) so an extra key — an env-injection vector — fails the
+// test instead of slipping past a containment-only check.
 #[test]
-fn forward_list_contains_expected_22_keys() {
+fn forward_list_is_exact_allowlist() {
     let expected: &[&str] = &[
         "PATH",
         "HOME",
@@ -643,13 +647,7 @@ fn forward_list_contains_expected_22_keys() {
         "RUST_LOG",
         "RUST_BACKTRACE",
     ];
-    assert_eq!(super::FORWARD.len(), 22);
-    for key in expected {
-        assert!(
-            super::FORWARD.contains(key),
-            "FORWARD list missing key {key}"
-        );
-    }
+    assert_eq!(super::FORWARD, expected);
 }
 
 // T-013: child_env_for_spawn forwards HF_HOME, drops attacker-injected env

--- a/src/reranker/tests.rs
+++ b/src/reranker/tests.rs
@@ -206,19 +206,6 @@ fn sigmoid_nan_returns_nan() {
     assert!(sigmoid(f32::NAN).is_nan());
 }
 
-#[test]
-fn mock_reranker_score_batch_empty_returns_ok_empty() {
-    let r = MockReranker::default();
-    assert!(r.score_batch(&[]).unwrap().is_empty());
-}
-
-#[test]
-fn mock_reranker_score_returns_configured_value() {
-    let r = MockReranker::with_score(0.7);
-    let s = r.score("q", "d").unwrap();
-    assert!((s - 0.7).abs() < 1e-6, "expected 0.7, got {s}");
-}
-
 /// MLX runtime tests — run with `cargo test --features test-mlx -- --ignored`
 /// outside Codex seatbelt.
 #[cfg(feature = "test-mlx")]

--- a/src/storage/query_normalize.rs
+++ b/src/storage/query_normalize.rs
@@ -113,22 +113,6 @@ mod tests {
     }
 
     #[test]
-    fn default_is_all_on() {
-        let c = QueryNormalizationConfig::default();
-        assert!(c.nfkc);
-        assert!(c.ascii_lowercase);
-        assert!(c.collapse_whitespace);
-    }
-
-    #[test]
-    fn disabled_is_all_off() {
-        let c = QueryNormalizationConfig::disabled();
-        assert!(!c.nfkc);
-        assert!(!c.ascii_lowercase);
-        assert!(!c.collapse_whitespace);
-    }
-
-    #[test]
     fn pre_phase_5_disabled_matches_disabled() {
         assert_eq!(pre_phase_5_disabled(), QueryNormalizationConfig::disabled());
     }


### PR DESCRIPTION
## 概要・背景

実装をただ言い換えただけのテスト(mock の往復確認・トートロジー・実装式の再現)を排除する。これらは実装をリファクタすると追従して壊れるだけで、振る舞いの独立した検証になっていない。テストが「実装の鏡」ではなく「契約の pin」になることを目的とする。

## 変更内容

削除 7件(mock 往復 / 構造体リテラル直読み):

- `reranker`: `mock_reranker_score_returns_configured_value`, `mock_reranker_score_batch_empty_returns_ok_empty` — MockReranker の設定値往復。`Rerank` trait にデフォルト実装がなく共有契約の pin にならない。空入力契約は `lazy.rs` のデリゲートテストが実利用文脈でカバー
- `embed`: `mock_chunked_embedder_returns_multi_chunk`, `embed_text_propagates_error` — mock の設定値 / エラー文字列の往復
- `embed/metrics`: `phase_metrics_new_sets_kind` — コンストラクタ代入のトートロジー(`phase_metrics_default_padding_ratio_is_zero` と重複)
- `query_normalize`: `default_is_all_on`, `disabled_is_all_off` — bool フィールド直読み(`run()` 経由の振る舞いテスト群でカバー済み)

書き換え 3件(実装式の再現 → 具体値 / リテラル契約):

- `compute_sub_batch_size`: 式 `TOKEN_BUDGET / BUCKET_BOUNDS[i]` の再現 → 具体値 `(2000, 500, 125, 31)`。式だと両辺連動で `TOKEN_BUDGET` の drift を検出できないため、具体値で固定
- `SetupReason` Display: format 式の再構築 → 完全リテラル `"code 5: path outside cache"`(format 文字列変更を検出。`contains` のみの T-011 は完全フォーマットを pin しない)
- `FORWARD`: `len()==22` + `contains` ループ → 集合一致 `assert_eq!(FORWARD, expected)`(余剰キー = env-injection vector を検出)

その他:

- `max_content` テストの式逆再現 `8180 + 10 + 2 == MAX_SEQ_LEN` を削除し、`8180` の由来をコメント化
- `embed_text` の prefix を無視する無意味な4プレフィックスループを1呼び出しに縮小
- ADR-0009 Confirmation を「formula を pin」→「具体値を pin」に追従(line range も更新)

## スコープ

- **含まない**: 削除した mock テストの「production 版 always-run テスト」追加。`Reranker` / `Embedder` 構築が MLX 必須で always-run では書けず、production の振る舞いは純粋ロジック(`truncate_for_query` 等、always-run)+ MLX gated smoke で既にカバー済みのため
- mock 定義(`MockReranker` / `MockChunkedEmbedder` / `FailingEmbedder`)は test-support feature で downstream 公開のため残置

## 設計判断

- **削除 vs 書き換え**: wire format(`PROBE_EXIT_*`)/ security allowlist(`FORWARD`)/ cross-module invariant(`BUCKET_BOUNDS`)を pin しているテストは、トートロジー的な書き方でも削除せず、具体値・リテラル・集合一致へ書き換えて契約を保持
- **テスト名 `compute_sub_batch_size_matches_formula_per_bucket` は維持**: ADR-0009 と audit 2件から参照されるため。コメントで「具体値を pin」の意図を明示
- **ADR-0009 は更新、audit 2件は据え置き**: ADR は生きた決定記録、audit は日付入りの時点スナップショット

## テスト方法

1. `cargo nextest run` → 344 passed / 3 skipped(MLX gated)
2. `cargo clippy --all-targets` → warning なし
