### PR TITLE
ci: visibility (trybuild) テストの nextest timeout を 600s に緩和

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,3 +5,13 @@ fail-fast = false
 fail-fast = false
 slow-timeout = { period = "120s", terminate-after = 2 }
 final-status-level = "flaky"
+
+# visibility::ui is a trybuild test: it compiles tests/ui/*.rs as a separate
+# target, cold-building the whole workspace dependency graph (including mlx-sys's
+# C++ FFI), so it takes 120-240s. The fleet-standard 240s ceiling leaves almost
+# no margin and CI load jitter terminates it (main passes at ~133s by a hair).
+# Widen the ceiling for this binary only; the default 240s still guards the
+# model_probe timeout-verification tests against real hangs.
+[[profile.ci.overrides]]
+filter = 'binary(visibility)'
+slow-timeout = { period = "300s", terminate-after = 2 }


### PR DESCRIPTION
## 背景

dependabot PR #198 / #199 / #200 と #201 の `test` job が、いずれも `visibility::ui` テストの **240s timeout** で落ちていた。`test` 以外（coverage / security / zizmor）は緑。

## 根本原因

- `visibility::ui` は trybuild テスト (`tests/ui/*.rs` を別ターゲットとしてコンパイルし `pub(crate)` 境界違反をコンパイルエラーで検証する)
- このコンパイルが mlx-sys (C++ FFI) を含む workspace 全依存を**コールドビルド**するため本質的に 120-240s かかる
- nextest CI profile の ceiling は `120s × 2 = 240s`。main は ~133s で辛うじて PASS していたがマージンがほぼ無く、CI 負荷の揺らぎで超過 → terminate
- dependabot 3件のうち #200 (taiki-e/install-action) と #198 (zizmor-action) は **Cargo.lock 不変の GitHub Action bump** なのに同症状 → 依存内容は無関係と確定

実測:
- main 成功 run: `SLOW [>120.000s]` → `PASS [133.169s] visibility ui`
- 落ちた run: `TIMEOUT [240.012s] visibility ui` → `1 timed out`

## 修正

`.config/nextest.toml` に `binary(visibility)` 限定の override を追加し ceiling を **600s** (`300s × 2`) に拡張。default 240s は `model_probe` の timeout 検証テストの hang 検出用にそのまま維持する。

## 検証

- `cargo nextest list --profile ci -E 'binary(visibility)'` → `rurico::visibility ui` 1件にマッチ (filter が silent no-op にならないことを確認)
- TOML / filter 構文 valid (nextest がパース成功)

## 影響

このPRが main にマージされれば、dependabot 3件は rebase で・#201 は main 取り込みで override を拾い、`test` job が緑になる。

## 残課題 (このPRの対象外)

trybuild が毎 run mlx-sys を再ビルドする 2-4分は残る。CI 緑の outcome は達成済みのため、最適化は顕在化時に対応する。
