### PR TITLE
[Docs] MLX_CACHE_LOCK の poison 回復における安全性主張を明確化

### DIFF
--- a/crates/rurico-ffi/src/mlx.rs
+++ b/crates/rurico-ffi/src/mlx.rs
@@ -11,9 +11,10 @@
 ///   (see `rurico::mlx_cache::MLX_CACHE_LOCK`).
 #[allow(unsafe_code)]
 pub fn mlx_clear_cache() -> i32 {
-    // SAFETY: mlx_clear_cache is a stateless global cache flush.
-    // The caller must ensure no MLX arrays are borrowed at this point
-    // and that concurrent calls are serialized via MLX_CACHE_LOCK.
+    // SAFETY: the caller must ensure no MLX arrays are borrowed at this point
+    // and that concurrent calls are serialized via MLX_CACHE_LOCK. MLX mutates
+    // process-global cache state internally; this wrapper makes no post-panic
+    // consistency guarantee beyond forwarding the MLX return code.
     unsafe { mlx_sys::mlx_clear_cache() }
 }
 

--- a/src/mlx_cache.rs
+++ b/src/mlx_cache.rs
@@ -25,8 +25,11 @@ impl Component {
 
 /// Process-global lock for [`mlx_sys::mlx_clear_cache`] and [`mlx_sys::mlx_detail_compile_clear_cache`] calls.
 ///
-/// Recover from poison: cache-clear is stateless (guards `()`), safe to
-/// proceed after a panic in another thread.
+/// Poison recovery is best-effort. The Rust-side guard is stateless (`()`), but
+/// the protected MLX cache state is process-global FFI state and may be
+/// internally inconsistent after a panic during a prior cache-clear call.
+/// Continuing is acceptable because the worst expected failure mode is a
+/// leaked compile-cache entry, not a Rust memory-safety violation.
 pub(crate) static MLX_CACHE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Consume an MLX output array and attempt to clear the GPU cache.


### PR DESCRIPTION
## Summary

MLX cache lock の poison 回復説明が Rust 側の `Mutex<()>` だけを根拠に安全性を強く主張していたため、MLX の process-global FFI state は post-panic に不透明であることを明記しました。

- `MLX_CACHE_LOCK` の doc comment を best-effort recovery として書き換え
- `rurico-ffi` の `mlx_clear_cache` safety comment から stateless global cache flush という過大な表現を除去

## Verification

- `cargo fmt -- --check`
- `git diff --check`
- pre-commit: `cargo fmt --all -- --check`
- pre-commit: `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Closes #191