### PR TITLE
chore(deps): rusqlite を 0.39 → 0.40 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "mach-sys"
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ bytemuck = "1"
 hf-hub = "0.5"
 mlx-rs = "0.25"
 mlx-sys = "0.2"
-rusqlite = { version = "0.39", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlite-vec = "0.1.9"


### PR DESCRIPTION
## 概要
rusqlite 0.39 → 0.40（libsqlite3-sys 0.38 / bundled SQLite 3.53.1）。API純度束（#205 系）の次 breaking rev に相乗りし、downstream 追従を1ラウンドに集約する。

## 変更
- `Cargo.toml`: rusqlite `"0.39"` → `"0.40"`
- `Cargo.lock`: rusqlite 0.40.0 / libsqlite3-sys 0.38.0、加えて先行 cargo update 由来の semver-compat patch bump（bitflags 2.12.1 / log 0.4.31 / unicode-segmentation 1.13.3）

## 破壊的変更の影響
0.40 の破壊的変更は VTab API のみ。rurico は `Connection` / `CachedStatement` / `Error` / `ffi` 再エクスポート（`sqlite3` / `sqlite3_api_routines` / `sqlite3_auto_extension`）のみ使用のため**影響なし**。libsqlite3-sys は rurico 内で単独消費のため共存衝突なし、sqlite-vec は cc 依存で SQLite 本体と疎結合。

## 検証
- **MSRV**: resolver が「1.96 compatible」を明示、rust-version 警告なし
- **build**: workspace 全体 OK（FFI 型互換）
- **extension ABI**: `sqlite_vec_register_enables_vec_version_function` PASS（bundled SQLite 3.53.1 で `vec_version()` 動作）
- **FTS5**: `storage::search` 42 tests + `ensure_sqlite_vec_idempotent` PASS
- **clippy**: `--all-features` 含め警告ゼロ（pre-commit 通過）

## downstream 追従
sae#181 / yomu#281 / recall#132 / amici#140 を起票済。各リポは rusqlite を複数経路（自前 + rurico経由 + amici経由）で引くため、`links = "sqlite3"` 衝突回避には全経路同時 0.40 化（amici 先行）が必須。