### PR TITLE
WeightedRrf の rrf_k ガードと #212-216 の API docs 整合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,13 @@ RerankerKind`), which lets `download_model(model)` return
   with the document prefix to avoid token boundary mismatch from prefix
   merging. Chunk boundaries are adjusted to fit within `MAX_SEQ_LEN` without
   truncation.
+
+### Fixed
+
+- **`WeightedRrf` no longer emits non-finite fused scores.** A
+  `HybridSearchConfig` with `rrf_k <= 0`, NaN, or ±inf could drive the RRF
+  denominator (`rrf_k + rank`) non-positive or non-finite, producing `inf` or
+  NaN `MergedHit.score` values that corrupt Stage 3/4 ranking and JSON output.
+  Such contributions are now dropped (same handling as a zero-weight source),
+  and the valid range for `rrf_k` is documented on `HybridSearchConfig::rrf_k`.
+  Default `rrf_k = 60.0` is unaffected (bit-equal).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ RerankerKind`), which lets `download_model(model)` return
 - **`EmbedError::Inference` and `EmbedError::Tokenizer` are struct variants
   with source chains.** Match on `message` / `source` fields instead of the old
   tuple payload.
-- **MSRV bump to 1.95.** `rust-version` in `Cargo.toml` is now `1.95`.
+- **MSRV bump to 1.96.** `rust-version` in `Cargo.toml` is now `1.96`
+  (`assert_matches!`, stabilized in 1.96, is now used in tests).
   Downstream crates pinning an older toolchain must upgrade.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ RerankerKind`), which lets `download_model(model)` return
 
 ### Fixed
 
-- **`WeightedRrf` no longer emits non-finite fused scores.** A
+- **`WeightedRrf` no longer emits `rrf_k`-induced non-finite fused scores.** A
   `HybridSearchConfig` with `rrf_k <= 0`, NaN, or ±inf could drive the RRF
   denominator (`rrf_k + rank`) non-positive or non-finite, producing `inf` or
   NaN `MergedHit.score` values that corrupt Stage 3/4 ranking and JSON output.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Apple Silicon (MLX) 上で日本語テキストのembedding・reranking・類似
 | `storage`         | SQLite + sqlite-vec のベクトル検索プリミティブ（FTS sanitize / `MatchFtsQuery`、`QueryNormalizationConfig`）                                          |
 | `retrieval`       | 5-stage retrieval pipeline contract — `Candidate` / `MergedHit` / `MergeStrategy` / `Aggregator` / `HybridSearchConfig` / `RecencyConfig`             |
 | `text`            | テキスト分割（段落 > 行 > 文字境界で UTF-8 安全に分割）                                                                                               |
-| `artifacts`       | モデルファイルの型付き検証パイプライン（`CandidateArtifacts<K>` → `VerifiedArtifacts<K>`）                                                            |
+| `artifacts`       | モデルファイルの型付き検証。downstream は `VerifiedArtifacts<K>` を受け取る（`CandidateArtifacts<K>` は内部 staging）                                 |
 | `model_init`      | embed / reranker 共通の初期化エラー型 `ModelInitError`                                                                                                |
 | `model_lifecycle` | kind 汎用の `download_model` / `cached_artifacts`（`embed` / `reranker` からも re-export）                                                            |
 | `model_probe`     | サブプロセス probe 基盤（`ProbeStatus`、`Embedder::probe` / `Reranker::probe` の実装基盤）                                                            |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Apple Silicon (MLX) 上で日本語テキストのembedding・reranking・類似
 ## 要件
 
 - macOS (Apple Silicon) — MLX backend必須
-- Rust 1.95+ (edition 2024)
+- Rust 1.96+ (edition 2024)
 
 ## 使い方
 

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -1,9 +1,9 @@
 //! Typed artifact verification for ruri-v3 model files.
 //!
-//! Provides a two-phase pipeline: per-module
-//! [`CandidateArtifacts`](crate::artifacts::CandidateArtifacts) (unverified) →
-//! [`VerifiedArtifacts<K>`](crate::artifacts::VerifiedArtifacts) (verified,
-//! kind-checked).
+//! Provides a two-phase pipeline: the crate builds an internal
+//! [`CandidateArtifacts`](crate::artifacts::CandidateArtifacts) (unverified) and
+//! verifies it into [`VerifiedArtifacts<K>`](crate::artifacts::VerifiedArtifacts)
+//! (verified, kind-checked) — the type downstream actually receives.
 //!
 //! Consumers use the domain aliases:
 //! - [`embed::Artifacts`](crate::embed::Artifacts) = `VerifiedArtifacts<EmbedKind>`

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -39,8 +39,11 @@ pub struct RerankerKind(());
 
 /// Verified model artifacts, bound to a specific model kind `K`.
 ///
-/// Constructed via [`embed::CandidateArtifacts::verify`](crate::embed::CandidateArtifacts::verify)
-/// or [`reranker::CandidateArtifacts::verify`](crate::reranker::CandidateArtifacts::verify).
+/// Obtained from the model lifecycle entry points
+/// [`download_model`](crate::model_lifecycle::download_model) /
+/// [`cached_artifacts`](crate::model_lifecycle::cached_artifacts), which build
+/// and verify the artifacts internally. Pass the result to the kind's runtime
+/// constructor (`Embedder::new` / `Reranker::new`).
 ///
 /// Guarantees:
 /// - All three artifact files exist on disk.
@@ -183,10 +186,17 @@ impl ModelKind for RerankerKind {
 
 /// Unverified model artifact paths bound to a kind marker `K`.
 ///
-/// Construct with [`from_paths`](Self::from_paths) (or [`from_dir`](Self::from_dir)
-/// in test contexts), then call [`verify`](Self::verify) to obtain a
-/// [`VerifiedArtifacts<K>`] that can be passed to the kind's runtime
-/// constructor (e.g. `Embedder::new` / `Reranker::new`).
+/// Internal staging type in the verification pipeline. The model lifecycle
+/// entry points ([`download_model`](crate::model_lifecycle::download_model) /
+/// [`cached_artifacts`](crate::model_lifecycle::cached_artifacts)) build a
+/// `CandidateArtifacts` from a download or the local cache, then call
+/// [`verify`](Self::verify) to obtain a [`VerifiedArtifacts<K>`] that feeds the
+/// kind's runtime constructor (`Embedder::new` / `Reranker::new`).
+///
+/// Downstream crates receive `VerifiedArtifacts<K>` directly from those entry
+/// points and do not construct `CandidateArtifacts` themselves: the
+/// constructors are crate-internal by design (the `pub(crate)` visibility of
+/// `from_paths` is pinned by `tests/ui/from_paths_pub_crate.rs`).
 pub struct CandidateArtifacts<K> {
     pub(crate) paths: ModelPaths,
     _kind: PhantomData<K>,

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -1,7 +1,9 @@
 //! Typed artifact verification for ruri-v3 model files.
 //!
-//! Provides a two-phase pipeline: per-module [`CandidateArtifacts`] (unverified)
-//! → [`VerifiedArtifacts<K>`] (verified, kind-checked).
+//! Provides a two-phase pipeline: per-module
+//! [`CandidateArtifacts`](crate::artifacts::CandidateArtifacts) (unverified) →
+//! [`VerifiedArtifacts<K>`](crate::artifacts::VerifiedArtifacts) (verified,
+//! kind-checked).
 //!
 //! Consumers use the domain aliases:
 //! - [`embed::Artifacts`](crate::embed::Artifacts) = `VerifiedArtifacts<EmbedKind>`
@@ -22,7 +24,7 @@ use crate::modernbert::Config;
 ///
 /// **Sealed**: the private `()` field prevents external crates from constructing
 /// this marker, ensuring the kind ↔ model id binding (via
-/// [`ModelArtifact::Kind`](crate::model_io::ModelArtifact::Kind)) is enforced
+/// `ModelArtifact::Kind`) is enforced
 /// at the type level. Downstream callers cannot construct a kind unrelated to
 /// the model id they hold.
 #[derive(Debug)]

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -81,7 +81,7 @@ impl Embedder {
     /// Re-execs the current binary as a probe subprocess (via `Command`), so a
     /// crash is contained and reported as [`ProbeStatus::BackendUnavailable`].
     ///
-    /// The host binary must call [`crate::model_probe::handle_probe_if_needed`] at the start of `main()`.
+    /// The host binary must call [`crate::handle_probe_if_needed`] at the start of `main()`.
     ///
     /// # Errors
     ///

--- a/src/embed/metrics.rs
+++ b/src/embed/metrics.rs
@@ -29,7 +29,7 @@ impl EmbedKind {
     }
 }
 
-/// Public batch-level metrics snapshot mirroring the `"batch"` [`PhaseMetrics`]
+/// Public batch-level metrics snapshot mirroring the `"batch"` `PhaseMetrics`
 /// record. Returned alongside embeddings by
 /// [`Embedder::embed_documents_batch_with_metrics`](super::Embedder::embed_documents_batch_with_metrics)
 /// so callers (smoke harness, downstream indexers) can observe padding,

--- a/src/model_lifecycle.rs
+++ b/src/model_lifecycle.rs
@@ -3,9 +3,11 @@
 //! Provides the three kind-generic entry points that replace the per-module
 //! duplicates that previously lived in `embed.rs` / `reranker.rs`:
 //!
-//! - [`download_model`] -- fetch HF Hub artifacts and verify them as `Id::Kind`.
-//! - [`cached_artifacts`] -- inspect the local HF cache for `Id::Kind` artifacts.
-//! - [`probe_env_to_paths`] -- resolve probe env vars into a kind-bound candidate.
+//! - [`download_model`](crate::model_lifecycle::download_model) -- fetch HF Hub
+//!   artifacts and verify them as `Id::Kind`.
+//! - [`cached_artifacts`](crate::model_lifecycle::cached_artifacts) -- inspect
+//!   the local HF cache for `Id::Kind` artifacts.
+//! - `probe_env_to_paths` -- resolve probe env vars into a kind-bound candidate.
 //!
 //! The single `Id::Kind` associated type binds the model identifier to its
 //! kind marker so wrong-kind combinations (e.g. an embed identifier returning

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -188,7 +188,7 @@ pub enum ProbeStatus {
 pub enum ProbeError {
     /// Probe handler not installed in host binary.
     #[error(
-        "probe handler not installed; call rurico::model_probe::handle_probe_if_needed() \
+        "probe handler not installed; call rurico::handle_probe_if_needed() \
          at the start of main()"
     )]
     HandlerNotInstalled,

--- a/src/model_probe.rs
+++ b/src/model_probe.rs
@@ -3,8 +3,9 @@
 //! Host binaries call [`handle_probe_if_needed`](crate::handle_probe_if_needed)
 //! once at the start of `main()` — that lives in [`crate::dispatch`] because it
 //! needs to know about both embed and reranker domains. Individual modules
-//! (embed, reranker) call [`probe_via_subprocess`] to re-exec the current
-//! binary as an isolated probe.
+//! (embed, reranker) call
+//! [`probe_via_subprocess`](crate::model_probe::probe_via_subprocess) to re-exec
+//! the current binary as an isolated probe.
 //!
 //! # Probe child exit codes
 //!

--- a/src/reranker.rs
+++ b/src/reranker.rs
@@ -234,7 +234,7 @@ impl Reranker {
     /// crash is contained and reported as [`ProbeStatus::BackendUnavailable`].
     ///
     /// The host binary must call
-    /// [`model_probe::handle_probe_if_needed`](crate::model_probe::handle_probe_if_needed)
+    /// [`handle_probe_if_needed`](crate::handle_probe_if_needed)
     /// at the start of `main()`.
     pub fn probe(artifacts: &Artifacts) -> Result<ProbeStatus, ModelInitError> {
         probe_via_subprocess(artifacts)

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -1,12 +1,16 @@
 //! Retrieval pipeline contract (ADR 0004, Issue #67 / Phase 3).
 //!
 //! Plug-in points frozen by ADR 0004:
-//! - Stage 3 aggregation: [`Aggregator`] trait between merge and rerank.
-//!   Default impl is [`IdentityAggregator`].
+//! - Stage 3 aggregation: [`Aggregator`](crate::retrieval::Aggregator) trait
+//!   between merge and rerank. Default impl is
+//!   [`IdentityAggregator`](crate::retrieval::IdentityAggregator).
 //!
-//! Concrete strategies ([`MaxChunkAggregator`], [`DedupeAggregator`],
-//! [`TopKAverageAggregator`]) live alongside the trait; downstream crates can
-//! also supply their own `impl Aggregator` for domain-specific dedupers.
+//! Concrete strategies
+//! ([`MaxChunkAggregator`](crate::retrieval::MaxChunkAggregator),
+//! [`DedupeAggregator`](crate::retrieval::DedupeAggregator),
+//! [`TopKAverageAggregator`](crate::retrieval::TopKAverageAggregator)) live
+//! alongside the trait; downstream crates can also supply their own
+//! `impl Aggregator` for domain-specific dedupers.
 
 use std::collections::HashMap;
 use std::f64::consts::LN_2;

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -175,8 +175,8 @@ pub struct HybridSearchConfig {
     ///
     /// Must be finite and keep `rrf_k + rank` positive for every candidate
     /// rank; a positive `rrf_k` always suffices. A candidate whose
-    /// `rrf_k + rank` is non-positive or non-finite (e.g. `rrf_k <= 0`, NaN,
-    /// or ±inf) has its contribution dropped — the same handling as a
+    /// `rrf_k + rank` is non-positive or non-finite (NaN, ±inf, or
+    /// `rrf_k <= -rank`) has its contribution dropped — the same handling as a
     /// zero-weight source — so the fused score never becomes inf or NaN.
     pub rrf_k: f64,
     /// Per-source weights. Missing entries are treated as `0.0`.

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -168,6 +168,12 @@ pub trait MergeStrategy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct HybridSearchConfig {
     /// RRF damping constant. Default `60.0`.
+    ///
+    /// Must be finite and keep `rrf_k + rank` positive for every candidate
+    /// rank; a positive `rrf_k` always suffices. A candidate whose
+    /// `rrf_k + rank` is non-positive or non-finite (e.g. `rrf_k <= 0`, NaN,
+    /// or ±inf) has its contribution dropped — the same handling as a
+    /// zero-weight source — so the fused score never becomes inf or NaN.
     pub rrf_k: f64,
     /// Per-source weights. Missing entries are treated as `0.0`.
     pub source_weights: HashMap<CandidateSource, f64>,
@@ -304,7 +310,18 @@ impl MergeStrategy for WeightedRrf {
             }
             #[allow(clippy::cast_precision_loss)]
             let rank_f = cand.rank as f64;
-            let contribution = weight / (self.config.rrf_k + rank_f);
+            let denom = self.config.rrf_k + rank_f;
+            // A non-finite or non-positive denominator (rrf_k is NaN/±inf, or
+            // rrf_k + rank <= 0) would emit inf/NaN fused scores that poison
+            // Stage 3/4 ranking, JSON output, and debug surfaces. Drop the
+            // contribution — same posture as a zero-weight source — so a
+            // misconfigured rrf_k degrades to "candidate skipped" rather than a
+            // non-finite score. Default rrf_k = 60.0 keeps denom >= 60, so valid
+            // configs stay bit-equal.
+            if !denom.is_finite() || denom <= 0.0 {
+                continue;
+            }
+            let contribution = weight / denom;
             let key = (cand.doc_id.as_str(), cand.chunk_id.as_deref());
             let entry = acc.entry(key).or_default();
             entry.score += contribution;

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -177,7 +177,8 @@ pub struct HybridSearchConfig {
     /// rank; a positive `rrf_k` always suffices. A candidate whose
     /// `rrf_k + rank` is non-positive or non-finite (NaN, ±inf, or
     /// `rrf_k <= -rank`) has its contribution dropped — the same handling as a
-    /// zero-weight source — so the fused score never becomes inf or NaN.
+    /// zero-weight source — so a misconfigured `rrf_k` never drives the fused
+    /// score to inf or NaN.
     pub rrf_k: f64,
     /// Per-source weights. Missing entries are treated as `0.0`.
     pub source_weights: HashMap<CandidateSource, f64>,

--- a/src/retrieval/tests.rs
+++ b/src/retrieval/tests.rs
@@ -324,6 +324,94 @@ fn weighted_rrf_zero_weight_drops_source() {
     assert!((output[0].score - 1.0 / 60.0).abs() < f64::EPSILON);
 }
 
+// T-214-001: weighted_rrf_drops_contribution_when_denominator_is_zero
+//
+// rrf_k = 0 with a rank-0 candidate makes the denominator (rrf_k + rank) zero,
+// which without the guard emits an `inf` fused score. The contribution must be
+// dropped (like a zero-weight source) so the lone candidate yields no hit.
+#[test]
+fn weighted_rrf_drops_contribution_when_denominator_is_zero() {
+    let config = HybridSearchConfig {
+        rrf_k: 0.0,
+        ..HybridSearchConfig::default()
+    };
+    let strategy = WeightedRrf::new(config);
+    let output = strategy.merge(&[candidate(CandidateSource::Fts, "d1", 0)]);
+    assert!(
+        output.is_empty(),
+        "rrf_k=0 with rank=0 must drop the contribution, got: {output:?}"
+    );
+}
+
+// T-214-002: weighted_rrf_drops_contribution_for_non_positive_denominator
+//
+// A negative rrf_k can zero the denominator (rank cancels it) or drive it
+// negative; both must be dropped so no negative or infinite fused score escapes.
+#[test]
+fn weighted_rrf_drops_contribution_for_non_positive_denominator() {
+    let config = HybridSearchConfig {
+        rrf_k: -1.0,
+        ..HybridSearchConfig::default()
+    };
+    let strategy = WeightedRrf::new(config);
+    let output = strategy.merge(&[
+        candidate(CandidateSource::Fts, "zero_denom", 1), // -1 + 1 = 0
+        candidate(CandidateSource::Fts, "neg_denom", 0),  // -1 + 0 = -1
+    ]);
+    assert!(
+        output.is_empty(),
+        "non-positive denominators must be dropped, got: {output:?}"
+    );
+}
+
+// T-214-003: weighted_rrf_drops_contribution_for_non_finite_rrf_k
+//
+// A NaN or infinite rrf_k makes the denominator non-finite; the guard drops the
+// contribution so no NaN/inf score escapes merge.
+#[test]
+fn weighted_rrf_drops_contribution_for_non_finite_rrf_k() {
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let config = HybridSearchConfig {
+            rrf_k: bad,
+            ..HybridSearchConfig::default()
+        };
+        let strategy = WeightedRrf::new(config);
+        let output = strategy.merge(&[candidate(CandidateSource::Fts, "d1", 0)]);
+        assert!(
+            output.is_empty(),
+            "non-finite rrf_k {bad} must drop the contribution, got: {output:?}"
+        );
+    }
+}
+
+// T-214-004: weighted_rrf_partial_drop_keeps_valid_denominator_hits
+//
+// With a negative rrf_k, only candidates whose rank pushes the denominator
+// positive survive; survivors keep finite scores while invalid ones are dropped.
+#[test]
+fn weighted_rrf_partial_drop_keeps_valid_denominator_hits() {
+    let config = HybridSearchConfig {
+        rrf_k: -1.0,
+        ..HybridSearchConfig::default()
+    };
+    let strategy = WeightedRrf::new(config);
+    let output = strategy.merge(&[
+        candidate(CandidateSource::Fts, "dropped", 0), // -1 + 0 = -1 → drop
+        candidate(CandidateSource::Fts, "kept", 2),    // -1 + 2 = 1 → keep
+    ]);
+    assert_eq!(
+        output.len(),
+        1,
+        "only the valid-denominator candidate survives"
+    );
+    assert_eq!(output[0].doc_id, "kept");
+    assert!(
+        output[0].score.is_finite() && (output[0].score - 1.0).abs() < f64::EPSILON,
+        "surviving score must be finite (weight 1.0 / denom 1.0 = 1.0), got: {}",
+        output[0].score
+    );
+}
+
 // T-068-007: weighted_rrf_records_per_source_contributions
 #[test]
 fn weighted_rrf_records_per_source_contributions() {


### PR DESCRIPTION
## What & Why

`WeightedRrf` が非正・非有限の `rrf_k` で `inf`/`NaN` の fused score を生成しうる bug を guard し(#214)、あわせて #212-216 バッチの API docs 不整合(MSRV 表記、probe path、CandidateArtifacts 契約、rustdoc broken link)を解消する。downstream が公開 API と rustdoc だけで誤用なく利用できる状態へ寄せる。

## Changes

- **#214 (fix)**: `WeightedRrf::merge()` に denominator guard(`!denom.is_finite() || denom <= 0.0` で寄与を drop)。default `rrf_k=60.0` は bit-equal 維持。regression test 4本 + CHANGELOG Fixed。
- **#213 (docs)**: probe doc を存在しない `model_probe::handle_probe_if_needed` から crate-root re-export `crate::handle_probe_if_needed` に統一(embedder/reranker/model_probe の3箇所)。
- **#212 (docs)**: README/CHANGELOG を `rust-version = 1.96` に整合(`assert_matches!` が 1.96 安定化、commit b2c5791 で採用済)。
- **#215 (docs)**: `CandidateArtifacts` を internal staging type として明文化。production downstream は `download_model`/`cached_artifacts` から `VerifiedArtifacts<K>` を直接受領(constructor は意図的に pub(crate)、tests/ui で pin)。
- **#216 (docs)**: rustdoc broken intra-doc link 16件を解消。lib.rs 宣言 doc 付き module の `//!` doc は crate-root スコープ解決ゆえ full path、private item は code span。
- **audit 追従 (15d15bb)**: /audit で確定した doc 欠陥3件 — rrf_k doc の例を `rrf_k <= -rank` に正確化、README module table と artifacts module doc を #215 と整合。

## Scope

- **Not included**: 非有限な `source_weights`/`recency.weight`/`half_life_days`(#214 と同クラスの pre-existing failure mode → #217 で follow-up)。RRF formula 再設計、weight tuning policy。

## Design Decisions

- `merge()` は `Vec<MergedHit>`(`Result` でない)を返し `HybridSearchConfig` は pub field + `Default` のため、reject も validating constructor も構造的に不可。guard(寄与 drop)が唯一の道で、zero-weight source の既存 skip と同 posture。
- `CandidateArtifacts` は #215 で pub 維持(型として検証パイプラインが見える)+ docs reframe を選択(plan B)。pub(crate) 化(breaking)は不採用。

## How to Test

1. `cargo nextest run --workspace` → 352 passed(T-214-001..004 含む)
2. `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps` → exit 0(#216 gate)
3. `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `cargo fmt --all -- --check` → pass

## Related

- Closes #212
- Closes #213
- Closes #214
- Closes #215
- Closes #216
- Follow-up: #217(非有限 weight/half_life、#214 と同クラス、別 PR)
