### PR TITLE
WeightedRrf の非有限 weight / recency boost ガード

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,17 @@ RerankerKind`), which lets `download_model(model)` return
   Such contributions are now dropped (same handling as a zero-weight source),
   and the valid range for `rrf_k` is documented on `HybridSearchConfig::rrf_k`.
   Default `rrf_k = 60.0` is unaffected (bit-equal).
+- **`WeightedRrf` no longer emits weight- or recency-induced non-finite fused
+  scores.** Follow-up to the `rrf_k` guard above: non-finite (NaN, ±inf)
+  weights slipped past the `== 0.0` guards under IEEE 754, and a non-finite
+  decay (NaN `half_life_days`, or `+inf` half-life with a `+inf` age from the
+  caller's `age_days_for` closure) leaked through the boost arithmetic — all
+  contaminating `MergedHit.score` with values that corrupt Stage 3/4 ranking
+  and JSON output. The guards now close each path:
+  - a non-finite `HybridSearchConfig::source_weights` entry has its source's
+    contribution dropped (same handling as a zero weight);
+  - a non-finite `RecencyConfig::weight` disables the recency boost;
+  - a per-hit non-finite boost (`weight × decay`) is skipped, retaining the
+    RRF score.
+    `half_life_days = +inf` with a finite age keeps its full boost (decay
+    exactly `1.0`), and all-finite configurations are unaffected (bit-equal).

--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -21,6 +21,11 @@ use serde::{Deserialize, Serialize};
 ///
 /// Negative `age_days` is clamped to 0 (returns 1.0).
 /// Returns 0.0 when `half_life_days <= 0.0` (avoids division by zero).
+///
+/// May return NaN for non-finite inputs (NaN `half_life_days`, or `age_days`
+/// and `half_life_days` both `+inf`). The sole production caller
+/// ([`WeightedRrf::merge_with_recency`]) clamps the resulting boost with
+/// `is_finite()`; new callers must clamp likewise or move the clamp here.
 pub(crate) fn recency_decay(age_days: f64, half_life_days: f64) -> f64 {
     if half_life_days <= 0.0 {
         return 0.0;
@@ -180,7 +185,10 @@ pub struct HybridSearchConfig {
     /// zero-weight source — so a misconfigured `rrf_k` never drives the fused
     /// score to inf or NaN.
     pub rrf_k: f64,
-    /// Per-source weights. Missing entries are treated as `0.0`.
+    /// Per-source weights. Missing entries are treated as `0.0`. A non-finite
+    /// weight (NaN, ±inf) has its source's contribution dropped — the same
+    /// handling as a zero weight — so a misconfigured weight never drives the
+    /// fused score to inf or NaN.
     pub source_weights: HashMap<CandidateSource, f64>,
 }
 
@@ -208,9 +216,14 @@ impl Default for HybridSearchConfig {
 /// the strategy itself does not query any storage.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecencyConfig {
-    /// Recency boost magnitude. `0.0` disables the boost.
+    /// Recency boost magnitude. `0.0` disables the boost, as does a
+    /// non-finite value (NaN, ±inf) — a non-finite magnitude would poison
+    /// every boosted score.
     pub weight: f64,
-    /// Half-life in days controlling the exponential decay.
+    /// Half-life in days controlling the exponential decay. `+inf` applies a
+    /// full boost (decay `1.0`) for any finite age; a boost that would come
+    /// out non-finite (NaN half-life, or half-life and age both `+inf`) is
+    /// skipped per hit, leaving the RRF score.
     pub half_life_days: f64,
 }
 
@@ -237,7 +250,9 @@ impl WeightedRrf {
     /// Calls [`Self::merge`] first, then layers `recency.weight *
     /// recency_decay(age, recency.half_life_days)` onto each hit whose
     /// `age_days_for` lookup returns `Some(age)`. Hits with `None` age are
-    /// left at their RRF score. Output is re-sorted after the boost.
+    /// left at their RRF score, as is any hit whose boost would come out
+    /// non-finite (see [`RecencyConfig`]). Output is re-sorted after the
+    /// boost.
     ///
     /// `source_scores` continues to record only per-source RRF
     /// contributions — the recency component lives in `score` only, since
@@ -252,13 +267,21 @@ impl WeightedRrf {
         F: Fn(&str) -> Option<f64>,
     {
         let mut hits = self.merge(candidates);
-        if recency.weight == 0.0 {
+        // A non-finite weight (NaN, ±inf) slips past `== 0.0` under IEEE 754
+        // and would poison every boosted score, so it disables the boost the
+        // same way as `weight = 0.0`.
+        if recency.weight == 0.0 || !recency.weight.is_finite() {
             return hits;
         }
         for hit in &mut hits {
             if let Some(age) = age_days_for(hit.doc_id.as_str()) {
-                let decay = recency_decay(age, recency.half_life_days);
-                hit.score += recency.weight * decay;
+                let boost = recency.weight * recency_decay(age, recency.half_life_days);
+                // A non-finite boost (NaN half_life, or half_life and age both
+                // +inf) would poison the fused score: skip it and keep the RRF
+                // score.
+                if boost.is_finite() {
+                    hit.score += boost;
+                }
             }
         }
         hits.sort_by(|a, b| {
@@ -309,8 +332,10 @@ impl MergeStrategy for WeightedRrf {
             // Zero-weight sources are disabled: skipping prevents docs that only
             // hit the disabled source from leaking into the merged set with a
             // score of 0.0, which would otherwise survive truncate-to-k and
-            // reach the reranker as if they were valid candidates.
-            if weight == 0.0 {
+            // reach the reranker as if they were valid candidates. A non-finite
+            // weight (NaN, ±inf) slips past `== 0.0` under IEEE 754 and would
+            // emit a non-finite fused score, so it is dropped the same way.
+            if weight == 0.0 || !weight.is_finite() {
                 continue;
             }
             #[allow(clippy::cast_precision_loss)]

--- a/src/retrieval/tests.rs
+++ b/src/retrieval/tests.rs
@@ -412,6 +412,39 @@ fn weighted_rrf_partial_drop_keeps_valid_denominator_hits() {
     );
 }
 
+// T-217-001: weighted_rrf_drops_non_finite_source_weight
+//
+// A NaN or infinite source weight slips through the `weight == 0.0` guard via
+// IEEE 754 (`NaN == 0.0` is false), so `weight / denom` poisons the fused score.
+// Sibling of the #214 denominator guards: a non-finite source weight must drop
+// that source's contribution (same posture as weight=0.0). The FTS-only doc d1
+// disappears; the Vector doc d2 (weight 1.0) survives with a finite score.
+#[test]
+fn weighted_rrf_drops_non_finite_source_weight() {
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let mut config = HybridSearchConfig::default();
+        config.source_weights.insert(CandidateSource::Fts, bad);
+        let strategy = WeightedRrf::new(config);
+        let candidates = vec![
+            candidate(CandidateSource::Fts, "d1", 0),
+            candidate(CandidateSource::Vector, "d2", 0),
+        ];
+        let output = strategy.merge(&candidates);
+        assert!(
+            !output.iter().any(|h| h.doc_id == "d1"),
+            "non-finite FTS weight {bad} must drop the FTS-only doc d1, got: {output:?}"
+        );
+        assert!(
+            output.iter().any(|h| h.doc_id == "d2"),
+            "Vector doc d2 (weight 1.0) must survive non-finite FTS weight {bad}, got: {output:?}"
+        );
+        assert!(
+            output.iter().all(|h| h.score.is_finite()),
+            "every fused score must be finite under non-finite FTS weight {bad}, got: {output:?}"
+        );
+    }
+}
+
 // T-068-007: weighted_rrf_records_per_source_contributions
 #[test]
 fn weighted_rrf_records_per_source_contributions() {
@@ -501,6 +534,103 @@ fn weighted_rrf_recency_skips_missing_age() {
     // d1 boosted by 1.0; d2 only has RRF
     assert!((d1.score - (1.0 / 60.0 + 1.0)).abs() < f64::EPSILON);
     assert!((d2.score - 1.0 / 61.0).abs() < f64::EPSILON);
+}
+
+// T-217-002: weighted_rrf_recency_non_finite_weight_returns_unboosted
+//
+// A NaN or infinite recency weight slips through the `recency.weight == 0.0`
+// early return (`NaN == 0.0` is false), so every hit gets `weight * decay`
+// added and the score goes non-finite. A non-finite recency weight disables the
+// boost for all hits, so the output must equal the plain merge() result.
+#[test]
+fn weighted_rrf_recency_non_finite_weight_returns_unboosted() {
+    for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let strategy = WeightedRrf::default();
+        let candidates = vec![
+            candidate(CandidateSource::Fts, "d1", 0),
+            candidate(CandidateSource::Fts, "d2", 1),
+        ];
+        let recency = RecencyConfig {
+            weight: bad,
+            half_life_days: 30.0,
+        };
+        let with_recency = strategy.merge_with_recency(&candidates, &recency, |_| Some(0.0));
+        assert_eq!(
+            with_recency,
+            strategy.merge(&candidates),
+            "non-finite recency weight {bad} must return the unboosted merge() result"
+        );
+    }
+}
+
+// T-217-003: weighted_rrf_recency_nan_half_life_keeps_finite_score
+//
+// half_life=NaN slips through `half_life_days <= 0.0` (`NaN <= 0.0` is false),
+// so recency_decay returns NaN and `score += weight * NaN` poisons the hit.
+// With a finite recency weight, the boost-clamp must skip the non-finite boost
+// and retain each hit's RRF score, keeping every score finite.
+#[test]
+fn weighted_rrf_recency_nan_half_life_keeps_finite_score() {
+    let strategy = WeightedRrf::default();
+    let candidates = vec![
+        candidate(CandidateSource::Fts, "d1", 0),
+        candidate(CandidateSource::Fts, "d2", 1),
+    ];
+    let recency = RecencyConfig {
+        weight: 1.0,
+        half_life_days: f64::NAN,
+    };
+    let output = strategy.merge_with_recency(&candidates, &recency, |_| Some(10.0));
+    assert!(
+        output.iter().all(|h| h.score.is_finite()),
+        "NaN half_life must skip the boost and keep every score finite, got: {output:?}"
+    );
+}
+
+// T-217-004: weighted_rrf_recency_inf_half_life_inf_age_keeps_finite_score
+//
+// half_life=+inf is harmless with a finite age (decay = exp(-0.0) = 1.0), but
+// age=+inf makes recency_decay compute (-inf / +inf).exp() = NaN, so the boost
+// goes non-finite. The boost-clamp on `weight * decay` must absorb this and
+// keep scores finite.
+#[test]
+fn weighted_rrf_recency_inf_half_life_inf_age_keeps_finite_score() {
+    let strategy = WeightedRrf::default();
+    let candidates = vec![candidate(CandidateSource::Fts, "d1", 0)];
+    let recency = RecencyConfig {
+        weight: 1.0,
+        half_life_days: f64::INFINITY,
+    };
+    let output = strategy.merge_with_recency(&candidates, &recency, |_| Some(f64::INFINITY));
+    assert!(
+        output.iter().all(|h| h.score.is_finite()),
+        "+inf half_life with +inf age must clamp the NaN boost and keep scores finite, got: {output:?}"
+    );
+}
+
+// T-217-005: weighted_rrf_recency_inf_half_life_finite_age_keeps_full_boost
+//
+// Regression guard (green before and after the fix): half_life=+inf with a
+// finite age decays to exp(-0.0)=1.0, so the hit must receive the full
+// recency.weight (1.0) boost on top of its RRF score (1/60). This pins that the
+// boost-clamp must NOT regress the finite-age full-boost case — only non-finite
+// boosts get skipped, never a legitimately finite 1.0 boost.
+#[test]
+fn weighted_rrf_recency_inf_half_life_finite_age_keeps_full_boost() {
+    let strategy = WeightedRrf::default();
+    let candidates = vec![candidate(CandidateSource::Fts, "d1", 0)];
+    let recency = RecencyConfig {
+        weight: 1.0,
+        half_life_days: f64::INFINITY,
+    };
+    let output = strategy.merge_with_recency(&candidates, &recency, |_| Some(10.0));
+    let d1 = output.iter().find(|h| h.doc_id == "d1").unwrap();
+    let expected = 1.0 / 60.0 + 1.0;
+    assert!(
+        d1.score.is_finite() && (d1.score - expected).abs() < f64::EPSILON,
+        "finite age under +inf half_life must keep full boost (RRF 1/60 + 1.0), got: {}",
+        d1.score
+    );
 }
 
 // T-076-001: weighted_rrf_fuses_chunks_separately_when_chunk_id_differs


### PR DESCRIPTION
## 背景と目的

`WeightedRrf` の非有限 (NaN/±inf) な source weight・`RecencyConfig::weight`、および非有限 decay (NaN `half_life_days`、または caller の `age_days_for` closure 由来の +inf age × +inf half-life) が IEEE 754 セマンティクスで `== 0.0` / `<= 0.0` ガードをすり抜け、`MergedHit.score` を NaN/inf 汚染して Stage 3/4 ranking と JSON 出力を破壊する (#217、#214 と同クラスの pre-existing failure mode)。#214 の rrf_k ガードと同じ posture (寄与 drop) で Stage 2 の各経路を閉じる。

## 変更内容

- **`merge()`**: 非有限 source weight はその source の寄与を drop (zero weight と同扱い)
- **`merge_with_recency()`**: 非有限 `recency.weight` は recency boost 全体を無効化 (早期 return)
- **`merge_with_recency()`**: per-hit boost (`weight × decay`) が非有限なら skip し RRF score を維持 (boost-clamp)
- **rustdoc**: `source_weights` / `RecencyConfig::weight` / `half_life_days` / `merge_with_recency` / `recency_decay` に非有限時の契約を明記
- regression tests **T-217-001..005** + CHANGELOG Fixed エントリ

## スコープ

- **含まない**: `recency_decay` の関数内クランプ (production caller は boost-clamp site の 1 箇所のみ。新規 caller 向け契約は rustdoc に明記)。`rrf_k` 経路 (#214 で対応済み)。src/mlx_cache.rs の既存 `mlx_sys::` intra-doc link 2件 (未変更ファイル、`--document-private-items` build のみ顕在化、CI 相当の public build は pass)。

## 設計判断

- **boost-clamp**: half_life の入力 guard (`is_nan()`) ではなく出力 (`weight × decay`) を chokepoint 1 箇所で `is_finite()` clamp。critic-design が発見した leak (finite weight + half_life=+inf + age=+inf → decay NaN) を含め、weight 起因・decay 起因の非有限を一括吸収する。
- **half_life_days = +inf + finite age はフルブースト維持** (decay は正確に `1.0`、T-217-005 が exact 比較で固定)。汚染しない入力を黙って無効化しない。
- **all-finite 構成は bit-equal**: guard は arithmetic 前に短絡するため既存スコアに演算差分なし (既存アンカー T-068-005/T-068-008 green)。

## テスト方法

1. `cargo nextest run` → 356 passed (T-217-001..005 含む、skip 3 は MLX-gated smoke)
2. `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check` → pass (pre-commit hook 通過済み)
3. `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` → exit 0

## 関連

- Closes #217
- Follow-up to #214 (8739300, PR #218)