### PR TITLE
fix(storage): FTS5 MATCH クエリの連結を explicit AND に変更

### DIFF
--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -265,7 +265,10 @@ pub(crate) fn fts_expand_short_terms(
         };
         parts.push(expanded.unwrap_or_else(|| fts_quote(token)));
     }
-    Ok(MatchFtsQuery(parts.join(" ")))
+    // Join with explicit AND: FTS5 implicit adjacency rejects parenthesised
+    // groups as operands (`(a OR b) c` is a syntax error); explicit AND
+    // accepts them with identical semantics.
+    Ok(MatchFtsQuery(parts.join(" AND ")))
 }
 
 #[cfg(test)]

--- a/src/storage/search/tests.rs
+++ b/src/storage/search/tests.rs
@@ -66,14 +66,14 @@ fn expand_operator_like_terms_are_quoted_not_expanded() {
     // not expanded via vocab (e.g. OR must not become "order" OR ...).
     let result =
         fts_expand_short_terms(&conn, &sanitized("NOT secret"), "fts_chunks_vocab").unwrap();
-    assert_eq!(result.as_str(), "\"NOT\" \"secret\"");
+    assert_eq!(result.as_str(), "\"NOT\" AND \"secret\"");
 
     let result = fts_expand_short_terms(&conn, &sanitized("OR"), "fts_chunks_vocab").unwrap();
     assert_eq!(result.as_str(), "\"OR\"");
 
     let result =
         fts_expand_short_terms(&conn, &sanitized("foo or bar"), "fts_chunks_vocab").unwrap();
-    assert_eq!(result.as_str(), "\"foo\" \"or\" \"bar\"");
+    assert_eq!(result.as_str(), "\"foo\" AND \"or\" AND \"bar\"");
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn expand_special_chars_escaped() {
 fn expand_without_vocab_table_degrades() {
     let conn = Connection::open_in_memory().unwrap();
     let result = fts_expand_short_terms(&conn, &sanitized("au login"), "fts_chunks_vocab").unwrap();
-    assert_eq!(result.as_str(), "\"au\" \"login\"");
+    assert_eq!(result.as_str(), "\"au\" AND \"login\"");
 }
 
 #[test]
@@ -116,6 +116,29 @@ fn prepare_match_query_end_to_end() {
     assert!(result.as_str().contains(" OR "), "{}", result.as_str());
 }
 
+// #224: a vocab-expanded group adjacent to another token must form a valid
+// FTS5 expression. Implicit AND rejects parenthesised groups as operands
+// (`(a OR b) c` is an fts5 syntax error), so the query must execute, not
+// just look right as a string.
+#[test]
+fn prepare_match_query_expanded_group_is_executable() {
+    let conn = setup_fts_db();
+    let query = prepare_match_query(&conn, "au login", "fts_chunks_vocab", &no_norm()).unwrap();
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM fts_chunks WHERE fts_chunks MATCH ?1",
+            [query.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap_or_else(|e| panic!("MATCH rejected {:?}: {e}", query.as_str()));
+    assert_eq!(
+        count,
+        1,
+        "expected exactly 'authentication login session' to match, query: {:?}",
+        query.as_str()
+    );
+}
+
 #[test]
 fn prepare_match_query_empty_input() {
     let conn = setup_fts_db();
@@ -129,7 +152,7 @@ fn prepare_match_query_empty_input() {
 fn prepare_match_query_operators_are_quoted() {
     let conn = setup_fts_db();
     let result = prepare_match_query(&conn, "foo OR bar", "fts_chunks_vocab", &no_norm()).unwrap();
-    assert_eq!(result.as_str(), "\"foo\" \"OR\" \"bar\"");
+    assert_eq!(result.as_str(), "\"foo\" AND \"OR\" AND \"bar\"");
 }
 
 #[test]
@@ -189,7 +212,7 @@ fn expand_surfaces_non_missing_vocab_errors() {
 fn prepare_match_query_with_missing_vocab_degrades() {
     let conn = Connection::open_in_memory().unwrap();
     let result = prepare_match_query(&conn, "au login", "fts_chunks_vocab", &no_norm()).unwrap();
-    assert_eq!(result.as_str(), "\"au\" \"login\"");
+    assert_eq!(result.as_str(), "\"au\" AND \"login\"");
 }
 
 #[test]


### PR DESCRIPTION
## 概要

`fts_expand_short_terms` が token を space (implicit AND) で連結していたため、短 token が vocab 展開で括弧グループになり他の token と共存すると `("audit" OR "authentication") "login"` 形式となり、FTS5 が syntax error で拒否していた。FTS5 の implicit 連接は phrase / NEAR のみを operand に許容し、括弧グループを置けない。explicit AND は同一セマンティクスで括弧グループを受け付けるため、連結を `" AND "` に変更する。

Closes #224

## 変更内容

- src/storage/search.rs: `parts.join(" ")` → `parts.join(" AND ")`。FTS5 文法制約を示すコメントを追加
- src/storage/search/tests.rs:
  - 追加: `prepare_match_query_expanded_group_is_executable` — 生成クエリを実際に FTS5 MATCH へ渡す統合テスト (修正前は `fts5: syntax error near ""login""` で red を確認済み)
  - 期待値更新4テスト: operator quote 済み挙動と vocab 不在時 degrade を AND 連結形式へ (`"foo" AND "OR" AND "bar"` / `"au" AND "login"` など)

## 検証

- cargo nextest: 357 tests pass
- cargo clippy --all-targets: clean (pre-commit の -D warnings 込み)
- quoted operator 入り出力 (`"foo" AND "OR" AND "bar"`) を sqlite3 で MATCH 実行し valid を確認

## downstream 影響

出力形式の変更が4リポの消費側に波及しないことを確認済み。

| リポ | 消費形態 | 結果 |
| --- | --- | --- |
| yomu | MATCH 直渡し + keyword 間を自前 `join(" AND ")` | 新形式と整合。旧形式 `(A OR B) C` は yomu でこそ syntax error の実害経路で、本修正が解消する |
| recall / sae | `clean_for_trigram` 経由 | 形式パースは amici に集約 |
| amici | `clean_for_trigram` が出力をパース | parser は `(` と `"` のみ拾いベア AND は透過。本ブランチを path patch して fts テスト9本 (live 統合テスト含む) 全 pass |

## 出典

goal-driven code review session 2026-06-10 で表出した #224 の対応。
