### PR TITLE
ModernBert::forward の mask cache 成長契約を rustdoc に明記

### DIFF
--- a/src/modernbert/model.rs
+++ b/src/modernbert/model.rs
@@ -276,6 +276,14 @@ impl ModernBert {
 
     /// Run a forward pass, returning final hidden states `[batch_size, seq_len, hidden_size]`.
     ///
+    /// Each distinct `seq_len` caches an `O(seq_len^2)` local attention mask
+    /// inside the model for its lifetime, with no eviction. Keep `seq_len`
+    /// aligned to a small fixed set of lengths: internal callers round up to
+    /// the bucket ceilings `128`, `512`, `2048`, and `8192`, which bounds the
+    /// cache at four entries. Calling with many distinct sequence lengths
+    /// grows memory monotonically (one cached mask at `seq_len = 8192` is
+    /// about 256 MiB).
+    ///
     /// # Errors
     ///
     /// Returns an MLX [`Exception`] if:


### PR DESCRIPTION
## 概要と理由

`ModernBert::forward` は seq_len ごとに O(seq_len^2) の local attention mask を無期限キャッシュするが、公開 rustdoc にこの成長特性と bucket 整列前提の記載がなかった。rustdoc だけを読む利用者は、bucket 外の多様な seq_len で呼ぶとメモリリーク相当の挙動になると知る手段がない。forward の rustdoc にキャッシュ契約を明記する。

## 変更内容

- `forward()` の rustdoc にキャッシュ成長特性を追記: seq_len ごとの O(seq_len^2) マスク無期限キャッシュ、bucket ceiling (128/512/2048/8192) 整列で 4 エントリに収まること、多様な seq_len では単調増加すること (seq_len=8192 のマスク 1 枚で約 256 MiB)

## スコープ

- **含まない**: キャッシュ上限 / eviction の実装 (#225 の案 2)。doc 明記で OUTCOME の Behavior を満たすため見送り

## 設計判断

- 案 1 (doc 明記) を案 2 (eviction 実装) より優先: OUTCOME の Behavior「rustdoc だけから誤用なく利用できる」は doc で直接満たせる。機能変更ゼロのため downstream rev bump も次の機能変更マージまで defer できる
- 定数 BUCKET_BOUNDS への intra-doc link は張らず具体値で記載: `model_io` が pub(crate) のため公開 doc からリンク不可

## テスト方法

1. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rurico` が warning なしで通る
2. 生成された `ModernBert::forward` の doc にキャッシュ成長と bucket 整列の記載が表示される

## 関連

- Closes #225