### PR TITLE
MergeStrategy::merge の sort 契約記述を 3-key に揃える

### DIFF
--- a/src/retrieval.rs
+++ b/src/retrieval.rs
@@ -158,8 +158,9 @@ pub fn group_by_parent<'a>(hits: &'a [MergedHit]) -> HashMap<&'a str, Vec<&'a Me
 pub trait MergeStrategy {
     /// Fuse `candidates` from multiple sources into Stage 3 input.
     ///
-    /// **Output MUST be sorted by `score` descending** (with deterministic
-    /// tiebreaking by `doc_id` ascending when scores are equal). Each
+    /// **Output MUST be sorted by `score` descending**, then `doc_id`
+    /// ascending, then `chunk_id` ascending (3-key total order, matching
+    /// the [`Aggregator::aggregate`] contract in this module). Each
     /// returned [`MergedHit`]'s `source_scores` records the per-source
     /// contributions to the fused score so downstream UIs can display
     /// score breakdown.
@@ -252,7 +253,9 @@ impl WeightedRrf {
     /// `age_days_for` lookup returns `Some(age)`. Hits with `None` age are
     /// left at their RRF score, as is any hit whose boost would come out
     /// non-finite (see [`RecencyConfig`]). Output is re-sorted after the
-    /// boost.
+    /// boost; the re-sort compares `score` then `doc_id` only, but stable
+    /// sorting plus the per-doc (not per-chunk) boost preserves the 3-key
+    /// order guaranteed by [`MergeStrategy::merge`].
     ///
     /// `source_scores` continues to record only per-source RRF
     /// contributions — the recency component lives in `score` only, since


### PR DESCRIPTION
## 概要と理由

`MergeStrategy::merge` の trait doc は 2-key sort (score desc, doc_id asc) を契約として記述していたが、実装 `WeightedRrf::merge` と `Aggregator::aggregate` の doc は 3-key total order (score desc → doc_id asc → chunk_id asc) を使っており、三者で契約記述が食い違っていた。`MergeStrategy` は downstream 拡張点であり、2-key doc どおりに custom 実装を書くと同 doc・同 score の chunk 順序が非決定的になり truncate-to-k 境界で結果が揺れる。doc を実装に合わせて 3-key に揃える。

## 変更内容

- `MergeStrategy::merge` の契約を 3-key に更新し、`Aggregator::aggregate` への intra-doc link で相互参照を明示
- `merge_with_recency` に「re-sort は 2-key だが stable sort + doc 単位 boost により 3-key 順が保存される」補足を追記 (#228 の任意項目)。2-key sort コードを見た読み手の契約違反誤読を防ぐ

## スコープ

- **含まない**: sort 実装の変更。実装は元から 3-key で正しく、doc のみ修正

## テスト方法

1. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rurico` が warning なしで通る
2. 生成 doc で `MergeStrategy::merge` と `Aggregator::aggregate` の sort 契約が同一の 3-key 記述になっている

## 関連

- Closes #228