### PR TITLE
probe error helper doc の variant 記述を実態に合わせる

### DIFF
--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -202,10 +202,12 @@ pub(crate) fn assert_cache_lookup_returns_none_when_empty<Id: ModelArtifact>(mod
 
 /// Generic helper for `from_probe_error_maps_correctly`.
 ///
-/// Asserts that all four [`ProbeError`](crate::model_probe::ProbeError) variants
-/// map to the expected [`ModelInitError`](crate::model_init::ModelInitError)
-/// variant. Kind-agnostic because `ModelInitError` is unified across embed and
-/// reranker (FR-002).
+/// Asserts that three [`ProbeError`](crate::model_probe::ProbeError) variants
+/// (`HandlerNotInstalled` / `ModelLoadFailed` / `SubprocessFailed`) map to the
+/// expected [`ModelInitError`](crate::model_init::ModelInitError) variant.
+/// `SetupRejected` is covered separately by `model_init/tests.rs` (T-008 /
+/// T-125-B), which also pin the source chain. Kind-agnostic because
+/// `ModelInitError` is unified across embed and reranker (FR-002).
 pub(crate) fn assert_from_probe_error_maps_correctly() {
     let err: ModelInitError = ProbeError::HandlerNotInstalled.into();
     assert!(


### PR DESCRIPTION
## 概要と理由

`assert_from_probe_error_maps_correctly` の doc は「all four `ProbeError` variants」を検証すると主張するが、実装が assert するのは `HandlerNotInstalled` / `ModelLoadFailed` / `SubprocessFailed` の 3 つのみ。`SetupRejected` の検証は model_init/tests.rs (T-008 / T-125-B) に分担されており、doc を信頼して T-008/T-125-B を冗長として削除するリファクタリングが起きると検証が消える。doc を分担の実態に合わせる。

## 変更内容

- helper doc を 3 variant の列挙に修正し、`SetupRejected` は T-008 / T-125-B が source chain ごとカバーすることを明記 (T-008/T-125-B の実在は model_init/tests.rs:35,75 で確認済み)

## スコープ

- **含まない**: helper への `SetupRejected` assert 追加 (#229 の代替案)。テストカバレッジに穴はなく、doc 修正が分担の現状を正しく記録するため見送り

## テスト方法

1. `cargo clippy --workspace --all-targets --all-features -- -D warnings` が通る
2. doc の列挙 3 variant が helper 実装の assert と一致している

## 関連

- Closes #229