### PR TITLE
pad_sequences の masks 長さ検証を release ビルドでも有効化する

### DIFF
--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -311,7 +311,7 @@ pub(crate) fn pad_sequences(
     masks: Option<&[Vec<u32>]>,
     target_len: Option<usize>,
 ) -> (Vec<u32>, Vec<u32>, usize, usize) {
-    debug_assert!(
+    assert!(
         masks.is_none_or(|m| m.len() == ids.len()),
         "masks length {} != ids length {}",
         masks.map_or(0, <[Vec<u32>]>::len),

--- a/src/model_io/tests.rs
+++ b/src/model_io/tests.rs
@@ -104,6 +104,22 @@ fn pad_sequences_target_len_keeps_actual_max_when_smaller() {
     assert_eq!(flat_mask, vec![1, 1, 1, 1, 1, 1, 0, 0]);
 }
 
+#[test]
+#[should_panic(expected = "masks length 1 != ids length 2")]
+fn pad_sequences_panics_when_masks_shorter_than_ids() {
+    let ids = vec![vec![1, 2], vec![3]];
+    let masks = vec![vec![1, 1]];
+    pad_sequences(&ids, Some(&masks), None);
+}
+
+#[test]
+#[should_panic(expected = "masks length 3 != ids length 2")]
+fn pad_sequences_panics_when_masks_longer_than_ids() {
+    let ids = vec![vec![1, 2], vec![3]];
+    let masks = vec![vec![1, 1], vec![1], vec![1]];
+    pad_sequences(&ids, Some(&masks), None);
+}
+
 // ── compute_sub_batch_size tests ────────────────────────────────────────
 
 // Pin the concrete per-bucket sub-batch sizes, not the formula: asserting


### PR DESCRIPTION
## 概要と理由

`pad_sequences` の rustdoc `# Panics` は「masks の長さが ids と一致しなければ panic する」と約束するが、実装は `debug_assert!` のため release ビルドでは検証が消える。長さ不一致の masks は `zip` で黙って切り詰められ、不正な attention mask のまま埋め込み結果が壊れる。実装を契約に合わせ、`assert!` に格上げして release でも panic させる (#227)。

## 変更内容

- `src/model_io.rs`: `pad_sequences` の masks 長さ検証を `debug_assert!` から `assert!` に変更 (1 行)
- `src/model_io/tests.rs`: should_panic テスト 2 件追加 (masks が ids より短い / 長い)

## スコープ

- 対象: `pad_sequences` の masks 長さ検証のみ
- 対象外: 他の検証ロジック、`# Panics` doc 本文 (記述は既に契約どおりで変更不要)

## 設計判断

- doc 側を「release では検証なし」へ弱める案もあったが、検証コストは O(1) の len 比較のみで hot path への影響は無視できるため、実装を契約に合わせる側を選択
- `should_panic(expected = ...)` には実際の長さ込みメッセージを指定し、別箇所の panic を誤って green にしない

## テスト方法

- `cargo nextest run` — 359 passed / 3 skipped
- `cargo nextest run --release` — should_panic 2 件が release でも pass (`debug_assert!` のままでは masks が長い側は panic せず fail することを格上げ前に確認済み)

## 関連

- Closes #227