### PR TITLE
Config::validate の検証漏れを補完する (layers / FFN / local attention / eps)

### DIFF
--- a/src/modernbert/config.rs
+++ b/src/modernbert/config.rs
@@ -40,13 +40,14 @@ pub struct Config {
 }
 
 impl Config {
-    /// Validate invariants (non-zero sizes, divisibility).
+    /// Validate invariants (non-zero sizes, divisibility, finite positive epsilon).
     ///
     /// # Errors
     ///
-    /// Returns an opaque validation message if any required size is zero or
-    /// `hidden_size` is not divisible by `num_attention_heads`. The exact
-    /// message text is not part of the stable API contract.
+    /// Returns an opaque validation message if any required size is zero,
+    /// `hidden_size` is not divisible by `num_attention_heads`, or
+    /// `layer_norm_eps` is not finite and positive. The exact message text
+    /// is not part of the stable API contract.
     pub fn validate(&self) -> Result<(), String> {
         // `hidden_size * 3` is computed during Wqkv construction.
         validate_i32_bound("hidden_size", self.hidden_size, 3)?;
@@ -63,6 +64,9 @@ impl Config {
                 self.hidden_size, self.num_attention_heads
             ));
         }
+        if self.num_hidden_layers == 0 {
+            return Err("num_hidden_layers must be > 0".into());
+        }
         if self.global_attn_every_n_layers == 0 {
             return Err("global_attn_every_n_layers must be > 0".into());
         }
@@ -72,6 +76,9 @@ impl Config {
         }
         // `intermediate_size * 2` is computed during Wi construction.
         validate_i32_bound("intermediate_size", self.intermediate_size, 2)?;
+        if self.intermediate_size == 0 {
+            return Err("intermediate_size must be > 0".into());
+        }
         validate_i32_bound("max_position_embeddings", self.max_position_embeddings, 1)?;
         if self.max_position_embeddings == 0 {
             return Err("max_position_embeddings must be > 0".into());
@@ -85,6 +92,12 @@ impl Config {
             return Err(format!(
                 "local_attention must be <= {max_local} (local_attention / 2 must fit in i32)"
             ));
+        }
+        if self.local_attention == 0 {
+            return Err("local_attention must be > 0".into());
+        }
+        if !self.layer_norm_eps.is_finite() || self.layer_norm_eps <= 0.0 {
+            return Err("layer_norm_eps must be finite and > 0".into());
         }
         Ok(())
     }

--- a/src/modernbert/config.rs
+++ b/src/modernbert/config.rs
@@ -40,14 +40,15 @@ pub struct Config {
 }
 
 impl Config {
-    /// Validate invariants (non-zero sizes, divisibility, finite positive epsilon).
+    /// Validate invariants (size bounds, divisibility, finite positive epsilon).
     ///
     /// # Errors
     ///
-    /// Returns an opaque validation message if any required size is zero,
-    /// `hidden_size` is not divisible by `num_attention_heads`, or
-    /// `layer_norm_eps` is not finite and positive. The exact message text
-    /// is not part of the stable API contract.
+    /// Returns an opaque validation message if any required size is zero or
+    /// too large for the MLX backend's `i32` dimensions, `hidden_size` is not
+    /// divisible by `num_attention_heads`, or `layer_norm_eps` is not finite
+    /// and positive after conversion to `f32`. The exact message text is not
+    /// part of the stable API contract.
     pub fn validate(&self) -> Result<(), String> {
         // `hidden_size * 3` is computed during Wqkv construction.
         validate_i32_bound("hidden_size", self.hidden_size, 3)?;
@@ -96,8 +97,13 @@ impl Config {
         if self.local_attention == 0 {
             return Err("local_attention must be > 0".into());
         }
-        if !self.layer_norm_eps.is_finite() || self.layer_norm_eps <= 0.0 {
-            return Err("layer_norm_eps must be finite and > 0".into());
+        // layer_norm_eps is consumed as f32 (`layer_norm_eps_f32` in model.rs), so
+        // validate the post-cast value: 1e39 overflows to inf and 1e-50 flushes to
+        // 0.0 even though both pass an f64 check. The f32 check subsumes the f64 one.
+        #[allow(clippy::cast_possible_truncation)]
+        let eps = self.layer_norm_eps as f32;
+        if !eps.is_finite() || eps <= 0.0 {
+            return Err("layer_norm_eps must be finite and > 0 after f32 conversion".into());
         }
         Ok(())
     }

--- a/src/modernbert/config/tests.rs
+++ b/src/modernbert/config/tests.rs
@@ -72,6 +72,41 @@ fn config_validate_zero_max_position_embeddings() {
 }
 
 #[test]
+fn config_validate_zero_num_hidden_layers() {
+    assert_rejects(|c| c.num_hidden_layers = 0, "num_hidden_layers");
+}
+
+#[test]
+fn config_validate_zero_intermediate_size() {
+    assert_rejects(|c| c.intermediate_size = 0, "intermediate_size");
+}
+
+#[test]
+fn config_validate_zero_local_attention() {
+    assert_rejects(|c| c.local_attention = 0, "local_attention");
+}
+
+#[test]
+fn config_validate_rejects_nan_layer_norm_eps() {
+    assert_rejects(|c| c.layer_norm_eps = f64::NAN, "layer_norm_eps");
+}
+
+#[test]
+fn config_validate_rejects_infinite_layer_norm_eps() {
+    assert_rejects(|c| c.layer_norm_eps = f64::INFINITY, "layer_norm_eps");
+}
+
+#[test]
+fn config_validate_rejects_zero_layer_norm_eps() {
+    assert_rejects(|c| c.layer_norm_eps = 0.0, "layer_norm_eps");
+}
+
+#[test]
+fn config_validate_rejects_negative_layer_norm_eps() {
+    assert_rejects(|c| c.layer_norm_eps = -1e-5, "layer_norm_eps");
+}
+
+#[test]
 fn config_validate_rejects_hidden_size_above_i32_max_div_3() {
     assert_rejects(
         |c| c.hidden_size = (i32::MAX / 3) as usize + 1,

--- a/src/modernbert/config/tests.rs
+++ b/src/modernbert/config/tests.rs
@@ -106,6 +106,18 @@ fn config_validate_rejects_negative_layer_norm_eps() {
     assert_rejects(|c| c.layer_norm_eps = -1e-5, "layer_norm_eps");
 }
 
+// 1e39 is finite in f64 but overflows to inf after the runtime f32 cast.
+#[test]
+fn config_validate_rejects_layer_norm_eps_overflowing_f32() {
+    assert_rejects(|c| c.layer_norm_eps = 1e39, "layer_norm_eps");
+}
+
+// 1e-50 is positive in f64 but flushes to 0.0 after the runtime f32 cast.
+#[test]
+fn config_validate_rejects_layer_norm_eps_underflowing_f32() {
+    assert_rejects(|c| c.layer_norm_eps = 1e-50, "layer_norm_eps");
+}
+
 #[test]
 fn config_validate_rejects_hidden_size_above_i32_max_div_3() {
     assert_rejects(


### PR DESCRIPTION
## 概要と理由

`Config::validate` の rustdoc は「any required size is zero を拒否」と宣言するが、`num_hidden_layers` / `intermediate_size` / `local_attention` の zero を検証していなかった。zero が通ると空の layer stack・幅 0 の FFN・対角のみの attention mask として silent に「動いてしまい」、埋め込み品質の劣化が型でもエラーでも検出できない。`layer_norm_eps` は検証自体がなく、NaN や負値は後段の `NonFiniteOutput` として表面化し根本原因 (config 破損) がエラーから見えなかった (#226)。

ruri-v3 ピン済み config では発生しないため現状の実害はゼロだが、`CandidateArtifacts::verify` はローカルの任意 config.json を受けるため、検証網を validate 側で閉じる。

## 変更内容

- `src/modernbert/config.rs`: validate に 4 検証を追加
  - `num_hidden_layers == 0` / `intermediate_size == 0` / `local_attention == 0` を拒否
  - `layer_norm_eps` は f32 変換後の値で finite かつ > 0 を要求
  - rustdoc の契約文に layer_norm_eps の invariant と i32 上限超過の拒否クラスを追記
- `src/modernbert/config/tests.rs`: テスト 9 件追加
  - zero 系 3 件 (num_hidden_layers / intermediate_size / local_attention)
  - layer_norm_eps 6 件 (NaN / inf / 0 / 負 / 1e39 / 1e-50 — 複合条件の各オペランドと f32 境界をカバー)

## スコープ

- 対象: `Config::validate` の検証追加のみ
- 対象外: `num_hidden_layers` への i32 bound (range iterator でしか使われず i32 キャスト箇所がないため不要 — issue の分析どおり)

## 設計判断

- 検証の配置は既存の「validate_i32_bound → zero チェック」順に合わせ、`num_hidden_layers` は layer 系 (`global_attn_every_n_layers`) の隣に配置
- issue 提案はテスト 4 件だが、`layer_norm_eps` の条件は `!is_finite() || <= 0.0` の複合条件のため、各オペランドを独立に検証する 4 ケースに展開
- `layer_norm_eps` の検証は f32 変換後の値で行う。実行時は `layer_norm_eps_f32` (model.rs) が f32 で消費するため、f64 のまま検証すると 1e39 (f32 で inf) や 1e-50 (f32 で 0.0) が素通りし、追加した検証が実行時表現に対して無効になる (/polish レビューの codex 指摘)。f32 検証は f64 検証を包含するため置換で足りる

## テスト方法

- `cargo nextest run` — 366 passed / 3 skipped
- `cargo nextest run -E 'test(config_validate)'` — 22 件 (既存 13 + 新規 9) pass
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p rurico` — 警告なし

## 関連

- Closes #226