### PR TITLE
docs(search): FTS5 wire-format に amici ADR-0008 相互参照マーカーを追加

### DIFF
--- a/src/storage/search.rs
+++ b/src/storage/search.rs
@@ -62,6 +62,18 @@ impl SanitizedFtsQuery {
 }
 
 /// A fully expanded and quoted FTS5 query string, safe to pass to `MATCH`.
+///
+/// # Cross-repo wire-format contract (amici ADR-0008)
+///
+/// The MATCH string emitted here is a wire-format contract consumed by amici's
+/// `parse_fts_segments` (`src/storage/fts.rs`): `"..."` quoting for fixed terms,
+/// `( ... )` for OR-groups, ` OR ` as the in-group separator, and ` AND ` as the
+/// top-level separator (see `fts_expand_short_terms`). amici parses this format
+/// rather than a typed API, so a separator or quoting change here is a contract
+/// change requiring a coordinated update to `parse_fts_segments`. Neither repo's
+/// compiler or unit tests can enforce this; amici's round-trip test
+/// (`src/storage/fts/tests.rs`, `parse_fts_segments_recovers_rurico_or_group_wire_format`)
+/// detects drift at rurico rev-bump time. Tracking issue: thkt/amici#159.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchFtsQuery(String);
 
@@ -268,6 +280,12 @@ pub(crate) fn fts_expand_short_terms(
     // Join with explicit AND: FTS5 implicit adjacency rejects parenthesised
     // groups as operands (`(a OR b) c` is a syntax error); explicit AND
     // accepts them with identical semantics.
+    //
+    // Wire-format contract (amici ADR-0008): this ` AND ` separator and the
+    // `"..."` / `( ... )` / ` OR ` shapes are parsed by amici's
+    // `parse_fts_segments`. Changing them is a cross-repo contract change;
+    // amici's round-trip test surfaces drift at rev-bump time. See
+    // [`MatchFtsQuery`].
     Ok(MatchFtsQuery(parts.join(" AND ")))
 }
 


### PR DESCRIPTION
## 背景

amici ADR-0008 は `prepare_match_query` / `MatchFtsQuery` が emit する FTS5 trigram wire-format (`"..."` quoting + `( ... )` OR-group + ` OR ` / ` AND ` 区切り) を amici `parse_fts_segments` が消費する cross-repo 契約として pin している。amici 側には round-trip test があるが producer 側 (rurico) にマーカーが無く、format 変更が rurico のコンパイル/テストを壊さずに amici を silent break しうる。

## 変更

- `MatchFtsQuery` struct doc に amici ADR-0008 wire-format 契約マーカーを追加 (consumer: amici `parse_fts_segments`、drift 検出: amici round-trip test、追跡 issue: thkt/amici#159)
- serialization 箇所 (`fts_expand_short_terms` の `parts.join(" AND ")`) に format 変更が cross-repo 契約変更である旨と round-trip test 検出の注記を追加

docs-only・挙動変更なし。新規 rustdoc warning は code span 化で解消済 (残る2件は既存の mlx_sys、無関係)。

## 弱点

マーカーはレビュー認知に依存する受動的ガード。ADR-0008 follow-up の rurico producer → amici parser ラウンドトリップ統合テストが land するまで機械的 drift 検出は amici 側単独に留まる。

Closes #249

https://claude.ai/code/session_01KVWpSfh5idmcEdkkyDDbKP