### PR TITLE
test: 実行されない型確認テストの実質化 (#256)

### DIFF
--- a/src/model_lifecycle/tests.rs
+++ b/src/model_lifecycle/tests.rs
@@ -19,30 +19,22 @@ fn write_embed_safetensors(path: &Path) {
     write_fake_safetensors(path, &[FAKE_BACKBONE_KEY]);
 }
 
-/// Compile-time signature assertion helper. The function body is unused;
-/// the `where` clause forces the type checker to confirm `F` returns `T`.
-fn assert_returns<F, T>(_f: F)
-where
-    F: FnOnce() -> T,
-{
-}
-
-// T-010: download_model(ModelId::DEFAULT) returns Result<VerifiedArtifacts<EmbedKind>, ArtifactError>
-#[test]
-fn download_model_for_embed_id_returns_verified_artifacts_of_embed_kind() {
-    // Compile-time signature check only; do not invoke (would hit network).
-    assert_returns::<_, Result<VerifiedArtifacts<EmbedKind>, ArtifactError>>(|| {
-        download_model(ModelId::DEFAULT)
-    });
-}
-
-// T-011: download_model(RerankerModelId::default()) returns Result<VerifiedArtifacts<RerankerKind>, ArtifactError>
-#[test]
-fn download_model_for_reranker_id_returns_verified_artifacts_of_reranker_kind() {
-    assert_returns::<_, Result<VerifiedArtifacts<RerankerKind>, ArtifactError>>(|| {
-        download_model(RerankerModelId::default())
-    });
-}
+// T-010 / T-011: each model identifier monomorphises `download_model` to the
+// `VerifiedArtifacts<K>` matching its kind — embed → EmbedKind, reranker →
+// RerankerKind — and a wrong-kind pairing fails to compile.
+//
+// Enforced at compile time by pinning each monomorphisation's full function
+// signature to a typed fn pointer. The prior `#[test]` form never executed:
+// it only type-checked a closure that was deliberately never called (invoking
+// it would hit the network), so it reported as a passing test while verifying
+// nothing at run time. Taking the function item's address checks the identical
+// contract — return type included — without the misleading runtime entry, and
+// T-012/T-013 below exercise the same kind dispatch at run time via a fake
+// cache.
+const _: fn(ModelId) -> Result<VerifiedArtifacts<EmbedKind>, ArtifactError> =
+    download_model::<ModelId>;
+const _: fn(RerankerModelId) -> Result<VerifiedArtifacts<RerankerKind>, ArtifactError> =
+    download_model::<RerankerModelId>;
 
 // T-012: cached_artifacts(ModelId::DEFAULT) with all artifacts present → Ok(Some(VerifiedArtifacts<EmbedKind>))
 #[test]

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -1,7 +1,19 @@
 use super::*;
 
+use rusqlite::Connection;
+
 #[test]
 fn ensure_sqlite_vec_idempotent() {
+    // First call registers the sqlite-vec auto-extension; the second must be a
+    // no-op that still returns Ok — the idempotency contract of the OnceLock.
     ensure_sqlite_vec().unwrap();
     ensure_sqlite_vec().unwrap();
+
+    // Outcome: a connection opened after registration actually has the vec
+    // extension loaded — `vec0` resolves as a virtual-table module and a real
+    // vector table can be created. Without registration this CREATE errors with
+    // "no such module: vec0".
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch("CREATE VIRTUAL TABLE vec_probe USING vec0(embedding float[4])")
+        .expect("vec0 module must be available after ensure_sqlite_vec registers the extension");
 }


### PR DESCRIPTION
Closes #256.

## 背景
#256 は Zenn 記事のレンズで「実行されない/出力未検証の型確認テスト」3件を実質化(削除でなく実行+出力検証)する依頼。サンプリング推定のため、各テストの意図を確認した上で対応。

## 変更
- **model_lifecycle T-010/T-011** (`download_model` の "do not invoke")
  - `#[test]` だが呼ばれないクロージャを型検査するだけで、実行時には何も検証せず passing 表示になっていた(実体は `Id::Kind` 型束縛のコンパイル時保証)。`download_model` はネットワーク必須で実行不可。
  - 提案①「ビルド時チェックへ移す」を採用。anonymous-const の fn ポインタ束縛で各単相化の完全シグネチャ(`ModelId → EmbedKind` / `RerankerModelId → RerankerKind`、戻り型含む)をコンパイル時に固定。誤った kind 対応はコンパイル不能。dead code 化した `assert_returns` ヘルパを削除。
  - 実行時の kind dispatch は既存 T-012/T-013 が fake cache で担保済み。
- **storage `ensure_sqlite_vec_idempotent`**
  - 提案②を採用。2回呼び出し(両方 Ok=idempotency)に加え、新規 in-memory connection で `vec0` 仮想テーブル作成が成功することを assert。auto-extension が実際に登録・使用可能という outcome を検証(未登録なら "no such module: vec0")。

## 据え置き(false positive)
- **artifacts `read_safetensors_keys_returns_expected_keys`**: `write_fake_safetensors` は実 safetensors バイナリ(LE ヘッダ長 + JSON ヘッダ + tensor バイト)を生成し、テストは実パーサで読み戻して `__metadata__` 除外を assert。mock 素通しではなく round-trip。#256 の「サンプリング推定/意図確認後に変更」の注記どおり過検出と判断。

## 検証
`cargo nextest run -p rurico storage:: model_lifecycle:: artifacts::` → 97 passed。const アサーションがコンパイル成立=型束縛が正しいことの証明。pre-commit (fmt / clippy --all-features -D warnings) 通過。

https://claude.ai/code/session_01HVK7oZzbM16691sHZvF22d