### PR TITLE
feat(embed): EmbedOptions 追加 — token_budget 上書きと per-forward pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -35,6 +35,7 @@ pub(crate) use pooling::gpu_pool_and_normalize;
 
 use crate::artifacts;
 use crate::model_io::{ModelArtifact, truncate_with_eos};
+use std::time::Duration;
 use std::{error::Error, fmt};
 
 /// Probe env-var key for the embedding model weights path.
@@ -312,6 +313,30 @@ impl EmbedError {
     }
 }
 
+// ── EmbedOptions ──────────────────────────────────────────────────────────────
+
+/// Best-effort performance hints for batch embedding.
+///
+/// Both fields default to `None`, which preserves the implementation's
+/// built-in behavior. Implementations are free to ignore these hints; the
+/// trait-level default of
+/// [`embed_documents_batch_with_options`](Embed::embed_documents_batch_with_options)
+/// does exactly that.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EmbedOptions {
+    /// Token budget per forward pass, overriding the built-in
+    /// `TOKEN_BUDGET` used to size sub-batches. Smaller budgets shorten
+    /// each GPU forward, trading throughput for host responsiveness.
+    ///
+    /// Values above the built-in budget are not clamped here and raise
+    /// GPU out-of-memory risk; callers should clamp to the built-in
+    /// budget or below.
+    pub token_budget: Option<usize>,
+    /// Sleep inserted after each completed forward pass, yielding the GPU
+    /// to other processes (e.g. WindowServer) between forwards.
+    pub forward_pause: Option<Duration>,
+}
+
 // ── Embed trait ───────────────────────────────────────────────────────────────
 
 /// Embedding provider.
@@ -355,6 +380,25 @@ pub trait Embed: Send + Sync {
     /// Implementations should return the first operational failure they
     /// encounter and preserve input ordering for successful outputs.
     fn embed_documents_batch(&self, texts: &[&str]) -> Result<Vec<ChunkedEmbedding>, EmbedError>;
+
+    /// Batch-embed documents with best-effort performance hints.
+    ///
+    /// The default implementation ignores `options` and delegates to
+    /// [`embed_documents_batch`](Self::embed_documents_batch), so results are
+    /// identical either way; `options` only shapes *how* the work is
+    /// scheduled (sub-batch sizing, inter-forward pauses) on implementations
+    /// that honor it, such as [`Embedder`].
+    ///
+    /// # Errors
+    ///
+    /// Same contract as [`embed_documents_batch`](Self::embed_documents_batch).
+    fn embed_documents_batch_with_options(
+        &self,
+        texts: &[&str],
+        _options: &EmbedOptions,
+    ) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
+        self.embed_documents_batch(texts)
+    }
 
     /// Embed text using the specified prefix (prepended before tokenization).
     /// The text is truncated if it exceeds [`MAX_SEQ_LEN`] (no chunking).

--- a/src/embed/embedder.rs
+++ b/src/embed/embedder.rs
@@ -3,7 +3,9 @@ use std::sync::{Mutex, MutexGuard};
 
 use super::metrics::BatchMetrics;
 use super::mlx::EmbedderInner;
-use super::{Artifacts, ChunkedEmbedding, Embed, EmbedError, ModelInitError, QUERY_PREFIX};
+use super::{
+    Artifacts, ChunkedEmbedding, Embed, EmbedError, EmbedOptions, ModelInitError, QUERY_PREFIX,
+};
 use crate::model_probe::ProbeStatus;
 
 /// Thread-safe embedding model backed by MLX. Wraps the backend in a [`Mutex`].
@@ -73,7 +75,7 @@ impl Embedder {
         texts: &[&str],
     ) -> Result<(Vec<ChunkedEmbedding>, BatchMetrics), EmbedError> {
         self.lock_inner()?
-            .embed_documents_batch_chunked_with_metrics(texts)
+            .embed_documents_batch_chunked_with_metrics(texts, &EmbedOptions::default())
     }
 
     /// Test whether the model can load without aborting the caller.
@@ -116,6 +118,15 @@ impl Embed for Embedder {
 
     fn embed_documents_batch(&self, texts: &[&str]) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
         self.lock_inner()?.embed_documents_batch_chunked(texts)
+    }
+
+    fn embed_documents_batch_with_options(
+        &self,
+        texts: &[&str],
+        options: &EmbedOptions,
+    ) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
+        self.lock_inner()?
+            .embed_documents_batch_chunked_with_options(texts, options)
     }
 
     fn embed_text(&self, text: &str, prefix: &str) -> Result<Vec<f32>, EmbedError> {

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -1,3 +1,4 @@
+use std::thread;
 use std::time::Instant;
 
 use mlx_rs::Array;
@@ -5,7 +6,7 @@ use mlx_rs::Array;
 use super::Artifacts;
 use super::metrics::{BatchMetrics, EmbedKind, PhaseMetrics};
 use super::{
-    CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, MAX_SEQ_LEN,
+    CHUNK_OVERLAP_TOKENS, ChunkedEmbedding, DOCUMENT_PREFIX, EmbedError, EmbedOptions, MAX_SEQ_LEN,
     ModelInitError, extract_prefix_tokens, gpu_pool_and_normalize, max_content,
     tokenize_with_prefix, truncate_for_query,
 };
@@ -219,7 +220,18 @@ impl EmbedderInner {
         &mut self,
         texts: &[&str],
     ) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
-        self.embed_documents_batch_chunked_with_metrics(texts)
+        self.embed_documents_batch_chunked_with_options(texts, &EmbedOptions::default())
+    }
+
+    /// Same as [`embed_documents_batch_chunked`](Self::embed_documents_batch_chunked)
+    /// but honors [`EmbedOptions`]: `token_budget` overrides the sub-batch
+    /// sizing budget and `forward_pause` sleeps after each forward pass.
+    pub(super) fn embed_documents_batch_chunked_with_options(
+        &mut self,
+        texts: &[&str],
+        options: &EmbedOptions,
+    ) -> Result<Vec<ChunkedEmbedding>, EmbedError> {
+        self.embed_documents_batch_chunked_with_metrics(texts, options)
             .map(|(results, _metrics)| results)
     }
 
@@ -231,6 +243,7 @@ impl EmbedderInner {
     pub(super) fn embed_documents_batch_chunked_with_metrics(
         &mut self,
         texts: &[&str],
+        options: &EmbedOptions,
     ) -> Result<(Vec<ChunkedEmbedding>, BatchMetrics), EmbedError> {
         if texts.is_empty() {
             return Ok((Vec::new(), BatchMetrics::default()));
@@ -267,9 +280,15 @@ impl EmbedderInner {
             // sub_batch_size against the bucket ceiling keeps every possible
             // sub-batch under TOKEN_BUDGET even when every chunk is at the
             // bucket_max boundary, matching the pre-bucketing OOM guarantee.
-            let sub_batch_size = compute_sub_batch_size(BUCKET_BOUNDS[bucket_idx], None);
+            let sub_batch_size =
+                compute_sub_batch_size(BUCKET_BOUNDS[bucket_idx], options.token_budget);
             for sub_batch in bucket.chunks(sub_batch_size) {
                 self.forward_sub_batch(sub_batch, bucket_idx, &mut out, &mut metrics)?;
+                // Yield the GPU between forwards so interactive processes
+                // (WindowServer) regain responsiveness during long batches.
+                if let Some(pause) = options.forward_pause {
+                    thread::sleep(pause);
+                }
             }
         }
 

--- a/src/embed/mlx.rs
+++ b/src/embed/mlx.rs
@@ -267,7 +267,7 @@ impl EmbedderInner {
             // sub_batch_size against the bucket ceiling keeps every possible
             // sub-batch under TOKEN_BUDGET even when every chunk is at the
             // bucket_max boundary, matching the pre-bucketing OOM guarantee.
-            let sub_batch_size = compute_sub_batch_size(BUCKET_BOUNDS[bucket_idx]);
+            let sub_batch_size = compute_sub_batch_size(BUCKET_BOUNDS[bucket_idx], None);
             for sub_batch in bucket.chunks(sub_batch_size) {
                 self.forward_sub_batch(sub_batch, bucket_idx, &mut out, &mut metrics)?;
             }

--- a/src/embed/tests.rs
+++ b/src/embed/tests.rs
@@ -493,3 +493,30 @@ fn chunked_embedding_try_new_generates_matching_chunk_ids() {
     let ce = ChunkedEmbedding::try_new(vec![vec![0.0], vec![1.0]]).unwrap();
     assert_eq!(ce.chunk_ids(), ["c0", "c1"]);
 }
+
+// ── EmbedOptions tests ──────────────────────────────────────────────────────
+
+#[test]
+fn embed_options_default_has_no_budget_override_and_no_pause() {
+    let opts = EmbedOptions::default();
+    assert_eq!(opts.token_budget, None);
+    assert_eq!(opts.forward_pause, None);
+}
+
+#[test]
+fn embed_documents_batch_with_options_default_impl_ignores_options() {
+    let embedder = MockEmbedder::default();
+    let texts = ["alpha", "beta"];
+    let opts = EmbedOptions {
+        token_budget: Some(2048),
+        forward_pause: Some(Duration::from_millis(700)),
+    };
+    let with_opts = embedder
+        .embed_documents_batch_with_options(&texts, &opts)
+        .unwrap();
+    let without = embedder.embed_documents_batch(&texts).unwrap();
+    assert_eq!(with_opts.len(), without.len());
+    for (a, b) in with_opts.iter().zip(&without) {
+        assert_eq!(a.chunks(), b.chunks());
+    }
+}

--- a/src/model_io.rs
+++ b/src/model_io.rs
@@ -285,12 +285,18 @@ pub(crate) fn artifacts_from_cache<Id: ModelArtifact>(
 /// for the cross-module forward-pass invariant.
 pub(crate) const TOKEN_BUDGET: usize = 256_000;
 
-/// Sub-batch size that keeps each forward pass under [`TOKEN_BUDGET`] when
-/// every item sits at the bucket boundary. Callers iterate
-/// `items.chunks(sub_batch_size)`. Floors at 1 so the loop progresses for
-/// `bucket_len > TOKEN_BUDGET`.
-pub(crate) fn compute_sub_batch_size(bucket_len: usize) -> usize {
-    (TOKEN_BUDGET / bucket_len).max(1)
+/// Sub-batch size that keeps each forward pass under [`TOKEN_BUDGET`] (or
+/// `budget_override` when `Some`) when every item sits at the bucket
+/// boundary. Callers iterate `items.chunks(sub_batch_size)`. Floors at 1 so
+/// the loop progresses when the effective budget is smaller than
+/// `bucket_len`.
+///
+/// `budget_override`: `Some(n)` uses `n` in place of [`TOKEN_BUDGET`]; `None`
+/// falls through to the const. Reranker callers pass `None` to preserve the
+/// ADR-0009 cross-module forward-pass invariant.
+pub(crate) fn compute_sub_batch_size(bucket_len: usize, budget_override: Option<usize>) -> usize {
+    let budget = budget_override.unwrap_or(TOKEN_BUDGET);
+    (budget / bucket_len).max(1)
 }
 
 /// Pad variable-length token sequences into contiguous flat arrays for batched inference.

--- a/src/model_io/tests.rs
+++ b/src/model_io/tests.rs
@@ -128,10 +128,10 @@ fn pad_sequences_panics_when_masks_longer_than_ids() {
 // (2000, 500, 125, 31); embed and reranker callers share this function.
 #[test]
 fn compute_sub_batch_size_matches_formula_per_bucket() {
-    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[0]), 2000);
-    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[1]), 500);
-    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[2]), 125);
-    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[3]), 31);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[0], None), 2000);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[1], None), 500);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[2], None), 125);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[3], None), 31);
 }
 
 // `max(1)` floor: pathological bucket_len > TOKEN_BUDGET cannot happen in
@@ -139,8 +139,23 @@ fn compute_sub_batch_size_matches_formula_per_bucket() {
 // from looping over zero-sized chunks if BUCKET_BOUNDS is later widened.
 #[test]
 fn compute_sub_batch_size_returns_one_when_bucket_exceeds_token_budget() {
-    assert_eq!(compute_sub_batch_size(TOKEN_BUDGET + 1), 1);
-    assert_eq!(compute_sub_batch_size(usize::MAX), 1);
+    assert_eq!(compute_sub_batch_size(TOKEN_BUDGET + 1, None), 1);
+    assert_eq!(compute_sub_batch_size(usize::MAX, None), 1);
+}
+
+// T-001: compute_sub_batch_size は budget_override=None で現行 const 由来の値を返す
+#[test]
+fn compute_sub_batch_size_with_none_override_matches_const_token_budget() {
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[0], None), 2000);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[1], None), 500);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[2], None), 125);
+    assert_eq!(compute_sub_batch_size(BUCKET_BOUNDS[3], None), 31);
+}
+
+// T-002: compute_sub_batch_size は budget_override=Some で override し 1 で floor する
+#[test]
+fn compute_sub_batch_size_with_some_override_takes_priority_over_const_and_floors_at_one() {
+    assert_eq!(compute_sub_batch_size(8192, Some(2048)), 1);
 }
 
 // ── ModelArtifact::Kind associated type ─────────────────────────────────

--- a/src/reranker/mlx.rs
+++ b/src/reranker/mlx.rs
@@ -67,7 +67,7 @@ impl RerankerInner {
         let raw_max = all_ids.iter().map(Vec::len).max().unwrap_or(0);
         let bucket_idx = assign_bucket(raw_max);
         let bucket_len = BUCKET_BOUNDS[bucket_idx];
-        let sub_batch_size = compute_sub_batch_size(bucket_len);
+        let sub_batch_size = compute_sub_batch_size(bucket_len, None);
 
         let total_pairs = pairs.len();
         let sub_batch_count = total_pairs.div_ceil(sub_batch_size);


### PR DESCRIPTION
## 背景

recall thkt/recall#270: embed 中の GPU 飽和 (87% residency) が WindowServer を飢餓させホストがカクつく。実測動作点 budget=2048 + per-forward 700ms pause で応答性が回復する。consumer (recall) からこの 2 つを制御できる公開 API が必要。

## 変更内容

- `EmbedOptions { token_budget: Option<usize>, forward_pause: Option<Duration> }` (pub, Default = 現行挙動)
- `Embed::embed_documents_batch_with_options` — default impl は options を無視して `embed_documents_batch` へ委譲 (best-effort hint)
- `Embedder` が override: token_budget → `compute_sub_batch_size` の override 引数、forward_pause → forward_sub_batch 完了直後の sleep
- query 経路 (`embed_query_truncated`) と reranker は非影響 (budget override は None 維持、ADR-0009 OOM ガード不変)
- token_budget は rurico 側ではクランプしない (doc 明記、caller 責務 — recall 側で 256_000 上限クランプ)

## テスト

- `embed_options_default_has_no_budget_override_and_no_pause`
- `embed_documents_batch_with_options_default_impl_ignores_options` (MockEmbedder で default impl の委譲を検証)
- 既存 `compute_sub_batch_size` override テスト (b4f2330) — `cargo test --lib` 369 passed

## 利用側

recall PR thkt/recall#271 がこの branch rev を pin して使用 (merge 後に main rev へ re-pin)。

https://claude.ai/code/session_01Hwxnk4GBQkDKwJQCjmeF89