### PR TITLE
chore(deps): cargo update で darling を 0.23.0 に更新

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -542,6 +542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +580,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +610,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]


### PR DESCRIPTION
## 概要

`cargo update` による Cargo.lock のみの推移的依存更新。`bon-macros v3.9.3` が引く `darling` を `0.21.3` → `0.23.0` へ bump。

## 変更内容

- `Cargo.lock`: `darling` / `darling_core` / `darling_macro` に 0.23.0 系のエントリを追加、`bon-macros` の参照を 0.21.3 → 0.23.0 に更新
- `Cargo.toml` の変更なし（直接依存ではなくビルド時 proc-macro の推移的依存）

## 補足

- `generic-array` は `0.14.9` が利用可能と表示されるが、`crypto-common v0.1.7` が `generic-array = "=0.14.7"` と厳密ピンしているため上げられない（MSRV 1.96 は無関係）。上流の `hf-hub`/`hf-xet` 追従待ちのため本 PR のスコープ外。

## 検証

- pre-commit の `cargo check`（rurico）通過

https://claude.ai/code/session_01PV4oDaa6CB3ci77Gm48kNg