### PR TITLE
fix(ci): visibility override から terminate-after を除去し cold build の false-red を解消

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,12 +6,18 @@ fail-fast = false
 slow-timeout = { period = "120s", terminate-after = 2 }
 final-status-level = "flaky"
 
-# visibility::ui is a trybuild test: it compiles tests/ui/*.rs as a separate
-# target, cold-building the whole workspace dependency graph (including mlx-sys's
-# C++ FFI), so it takes 120-240s. The fleet-standard 240s ceiling leaves almost
-# no margin and CI load jitter terminates it (main passes at ~133s by a hair).
-# Widen the ceiling for this binary only; the default 240s still guards the
-# model_probe timeout-verification tests against real hangs.
+# visibility::ui is a trybuild test: it compiles tests/ui/*.rs in a separate
+# CARGO_TARGET_DIR (target/tests/trybuild/), cold-building the whole workspace
+# dependency graph (including mlx-sys's C++ FFI) a second time. On a lockfile-
+# change PR that misses rust-cache, that double cold build can exceed 600s and
+# terminate-after would kill it mid-compile — a false red cleared only by a
+# manual rerun. The kill timing is the symptom, not the cost, so drop
+# terminate-after here: visibility only emits a SLOW warning at 300s and is
+# never killed; the job's timeout-minutes: 60 is the real backstop. The default
+# profile.ci timeout (120s, terminate-after 2) still guards the model_probe
+# timeout-verification tests (binary rurico, outside this override) against real
+# hangs. Removing terminate-after is a stopgap; the underlying double cold build
+# is tracked separately.
 [[profile.ci.overrides]]
 filter = 'binary(visibility)'
-slow-timeout = { period = "300s", terminate-after = 2 }
+slow-timeout = { period = "300s" }


### PR DESCRIPTION
## 概要

`.config/nextest.toml` の `binary(visibility)` override から `terminate-after` を除去し、lockfile 変更 PR で発生する構造的な false-red（手動 rerun でしか green にならない問題）を解消する。Closes #267。

## 背景

lockfile を変更する PR では `Swatinem/rust-cache` が cache miss し、trybuild テスト `visibility::ui` が別 CARGO_TARGET_DIR（`target/tests/trybuild/`）で依存グラフ全体（mlx-sys の C++ FFI 含む）を二重にコールドビルドする。この初回コンパイルが `300s × 2 = 600s` を超え `terminate-after` で kill され、`TIMEOUT [600.019s]` で test ジョブが exit 100。rerun すると warm cache で PASS（PR #266 実測: 初回 25m31s TIMEOUT → rerun 6m9s PASS）。

## 変更内容

- `binary(visibility)` override を `slow-timeout = { period = "300s" }`（`terminate-after` なし）に変更。visibility は 300s で **SLOW 警告のみ・kill しない**。backstop は job の `timeout-minutes: 60`（`.github/workflows/ci.yml:16`）。
- default `profile.ci`（`120s`, `terminate-after 2`）は据え置き。model_probe（binary rurico）の timeout 検証テストは引き続きこのガードで守られる（override 対象外）。
- lines 9-14 のコメントを実態に更新（SLOW 警告のみ／job 60min が backstop／trybuild の二重 cold build が本質原因／除去は kill タイミングのみ直す stopgap）。

これは kill タイミングを直す stopgap（Make it Work）。二重コールドビルド自体の解消は backlog へ切り出す。

## 検証

`cargo nextest run --workspace --features test-support,test-mlx --profile ci -E 'binary(visibility)'` → PASS（warm 1.85s）。cold build（600s 超）での kill 回避は、次の lockfile 変更 PR の CI 実行で確認される（ローカル warm では再現不可）。

## build ワークフローの補足

`/build #267` で処理したが、Code(TDD) 段階が Red を確認できず実装がスキップされた。T-001 のテストは warm ローカルで <1s PASS する一方、`terminate-after` の kill は cold build で ~600s 後にしか発火せず、未修正でも落ちないため Red 不成立（anomaly として記録）。Ship 段階は空 diff を検知して誤コミットを回避。実装内容は U-001 contract で明確だったため手動適用した。config 変更の効果は cold build でしか観測できず、TDD の Red 前提と構造的に噛み合わない性質のタスク。

https://claude.ai/code/session_01PV4oDaa6CB3ci77Gm48kNg
