### PR TITLE
ci(spike): trybuild pre-warm step で cold build を計測区間外へ逃がす (#269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,22 @@ jobs:
         with:
           tool: cargo-nextest
 
+      # EXPERIMENTAL — spike #269 (priority:low, benefit cosmetic). Pre-warm the
+      # trybuild nested target dir so visibility::ui is measured warm in the Test
+      # step below. trybuild compiles tests/ui/*.rs at test-execution time in a
+      # separate dir (target/tests/trybuild/), so on a lockfile-change (cache
+      # miss) PR that whole graph — mlx-sys C++ FFI included — cold-builds inside
+      # the nextest run, inflating visibility::ui's per-test number and tripping
+      # the binary(visibility) SLOW override in .config/nextest.toml. Running it
+      # here with plain cargo test (no nextest, so the cold pre-warm emits no
+      # SLOW warning / slow-timeout kill) relocates that cold build out of the
+      # measured step; same features as Test so the warm artifacts are reused,
+      # not rebuilt. Total job wall-clock is ≈unchanged — the cold build is moved,
+      # not removed. Keep-or-revert decision pending a real cold-build measurement
+      # (issue #269 U-002).
+      - name: Pre-warm trybuild target (spike #269)
+        run: cargo test --test visibility --features test-support,test-mlx
+
       - name: Test
         run: cargo nextest run --workspace --features test-support,test-mlx --profile ci
 


### PR DESCRIPTION
## 概要

spike #269 の実装物。lockfile 変更 (cache miss) PR で trybuild が `tests/ui/*.rs` を別 target dir (`target/tests/trybuild/`) で external crate としてコンパイルし、mlx-sys C++ FFI 込みの依存グラフが nextest Test 内で cold 再ビルドされる問題に対し、Test の直前に plain `cargo test --test visibility` の pre-warm step を追加して cold build を計測区間外へ移す。

- nextest を使わないため cold pre-warm 中に SLOW 警告 / slow-timeout kill は出ない。
- 同一 feature (`test-support,test-mlx`) なので warm 化した artifact は再ビルドされず Test で再利用される。
- 総 job wall-clock は cold build 消失ではなく**移動**なので ≈不変。便益は per-test 計測の意味回復と `binary(visibility)` SLOW 警告抑制 (cosmetic)。

## この PR の性質: spike

#269 は実装 issue ではなく **pre-warm 機構の実効果を計測して採否を判断する spike**。本 PR は検証対象の機構を CI に載せた段階で、**採否判断 (U-002) は未完**。

## 残タスク (U-002 / 手動 trigger 必須)

cold-build 効果は実 cold-build PR でしか観測できない。以下を実測して採否を記録:

- [ ] lockfile 変更 (cache miss) を起こす PR で、Test 内の `visibility::ui` per-test が cold コンパイルを含まず warm 値・SLOW 警告なしで完走するか
- [ ] 総 Test-job wall-clock が ≈不変か（cold build は消えず前段へ移るだけの想定）
- [ ] cosmetic な便益 vs CI step 追加コストの採否判断。効果が確認できなければ本 step を revert

## 関連

- Refs #269 (spike, priority:low) — 採否判断が残るため close せず
- 親: #267 (stopgap) / #268 (`terminate-after` 除去済み)

https://claude.ai/code/session_01PV4oDaa6CB3ci77Gm48kNg