### PR TITLE
ci: revert trybuild pre-warm step (spike #269 の cosmetic 対処を撤回)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,22 +41,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      # EXPERIMENTAL — spike #269 (priority:low, benefit cosmetic). Pre-warm the
-      # trybuild nested target dir so visibility::ui is measured warm in the Test
-      # step below. trybuild compiles tests/ui/*.rs at test-execution time in a
-      # separate dir (target/tests/trybuild/), so on a lockfile-change (cache
-      # miss) PR that whole graph — mlx-sys C++ FFI included — cold-builds inside
-      # the nextest run, inflating visibility::ui's per-test number and tripping
-      # the binary(visibility) SLOW override in .config/nextest.toml. Running it
-      # here with plain cargo test (no nextest, so the cold pre-warm emits no
-      # SLOW warning / slow-timeout kill) relocates that cold build out of the
-      # measured step; same features as Test so the warm artifacts are reused,
-      # not rebuilt. Total job wall-clock is ≈unchanged — the cold build is moved,
-      # not removed. Keep-or-revert decision pending a real cold-build measurement
-      # (issue #269 U-002).
-      - name: Pre-warm trybuild target (spike #269)
-        run: cargo test --test visibility --features test-support,test-mlx
-
       - name: Test
         run: cargo nextest run --workspace --features test-support,test-mlx --profile ci
 


### PR DESCRIPTION
## 概要

a29e469 (#271) で導入した trybuild pre-warm step を撤回する。

## なぜ

`visibility::ui` の false-red kill という実バグは #268 で `binary(visibility)` override から `terminate-after` を除去して既に解消済み・durable。pre-warm step はその後続の cosmetic 対処だったが、以下の理由で撤回する。

| 項目 | 実態 |
|---|---|
| pre-warm の便益 | cold build を計測区間外へ移すのみ。二重 cold build 自体は消えず、SLOW 警告抑制と per-test 計測の意味回復という cosmetic な効果に留まる |
| pre-warm の副作用 | 通常の warm CI でも `visibility` test を pre-warm と Test で **毎回 2 回実行** する per-run 税 |
| keep/revert を決める実測 (#269 U-002) | 未実施 (13m の PR run は lockfile 変更なしで cache-miss cold-build に非該当) |

priority:low の cosmetic 便益に対し、毎 CI の二重実行コストは見合わない。#268 を最終形とし、残る無害な SLOW 警告は許容する。

## 根治が infeasible な理由

真の根治 (二重 cold build から mlx-sys C++ FFI を実体除去) は、`mlx-rs` (→ mlx-sys) が `rurico` の `[dependencies]` 直下・非 optional の無条件依存で、trybuild fixture が `rurico::embed::*` / `rurico::artifacts::*` を参照し rurico lib 全体を要するため、feature では外せない。visibility 対象 API を mlx 非依存の `rurico-core` crate へ分離する workspace split でしか達成できず、priority:low に対して過剰と判断した。

## 差分

`.github/workflows/ci.yml` から pre-warm step (16 行) を除去。blob は a29e469 以前の状態に一致する精密 revert。

## 関連

- #269 (spike、cold build 根治): pre-warm の keep/revert 判断を revert で確定
- #268: false-red kill の durable fix (terminate-after 除去)

https://claude.ai/code/session_01694CHW9kxUsukVxUXpMF2D